### PR TITLE
Add tests for the WebDebugger wire protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ sudo: false
 env:
   - TASK=tests
   - TASK=checkstyle
+  - TASK=webdebugger
 script:
   - if [ "$TASK" = "tests" ];      then ant tests; fi
   - if [ "$TASK" = "checkstyle" ]; then ant checkstyle; fi
+  - if [ "$TASK" = "webdebugger" ]; then nvm install 6 && ant && cd tools/webdebugger && npm install && npm test; fi

--- a/tools/webdebugger/.gitignore
+++ b/tools/webdebugger/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+out
+typings

--- a/tools/webdebugger/package.json
+++ b/tools/webdebugger/package.json
@@ -1,0 +1,35 @@
+{
+  "name"       : "webdebugger",
+  "displayName": "Web Debugger",
+  "version"    : "0.0.1",
+  "publisher"  : "smarr",
+  "description": "Front-end for the SOMns Web Debugger Tool",
+  "author": {
+    "name": "Stefan Marr",
+    "email": "git@stefan-marr.de"
+  },
+  "license": "MIT",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/smarr/SOMns.git"
+  },
+  "engines": {
+    "node" : "^6.3.1"
+  },
+  "dependencies": {
+    "ws" : "^1.1.1"
+  },
+  "devDependencies": {
+    "chai"      : "^3.5.0",
+    "mocha"     : "^3.0.2",
+    "typescript": "^1.8.10",
+    "typings"   : "^1.3.2"
+  },
+  "scripts": {
+    "postinstall": "typings install && npm run compile",
+    "compile": "node ./node_modules/typescript/bin/tsc",
+    "watch"  : "node ./node_modules/typescript/bin/tsc -w",
+    "test"   : "node ./node_modules/mocha/bin/mocha -t 5000 -u tdd ./out/tests/"
+  }
+}

--- a/tools/webdebugger/src/foobar.ts
+++ b/tools/webdebugger/src/foobar.ts
@@ -1,0 +1,1 @@
+// just make sure that folder structure is preserved

--- a/tools/webdebugger/tests/basic-protocol.ts
+++ b/tools/webdebugger/tests/basic-protocol.ts
@@ -26,8 +26,10 @@ interface OnMessageHandler {
   (event: OnMessageEvent): void
 }
 
+type MessageType = "source" | "suspendEvent";
+
 interface Message {
-  type: string;
+  type: MessageType;
 }
 
 interface Source {
@@ -71,7 +73,12 @@ interface Respond {
   action: string;
 }
 
+type BreakpointType = "lineBreakpoint" |
+                      "sendBreakpoint" |
+                      "asyncMsgRcvBreakpoint";
+
 interface Breakpoint {
+  type:      BreakpointType;
 }
 
 interface InitialBreakpointsResponds extends Respond {

--- a/tools/webdebugger/tests/basic-protocol.ts
+++ b/tools/webdebugger/tests/basic-protocol.ts
@@ -251,7 +251,6 @@ describe('Basic Protocol', function() {
     let getSourceData: (event: OnMessageEvent) => void;
     let sourceP = new Promise<SourceMessage>((resolve, reject) => {
       getSourceData = (event: OnMessageEvent) => {
-        // console.log(event);
         if (firstSourceCaptured) { return; }    
         const data = JSON.parse(event.data);
         if (data.type == "source") {
@@ -330,10 +329,8 @@ describe('Basic Protocol', function() {
     let getSuspendEvent: (event: OnMessageEvent) => void;
     let suspendP = new Promise<SuspendEventMessage>((resolve, reject) => {
       getSuspendEvent = (event: OnMessageEvent) => {
-        // console.log('getSuspendEvent');
         if (firstSuspendCaptured) { return; }    
         const data = JSON.parse(event.data);
-        // console.log('getSuspendEvent data.type: ' + data.type);
         if (data.type == "suspendEvent") {
           firstSuspendCaptured = true;
           resolve(data);
@@ -495,10 +492,8 @@ describe('Basic Protocol', function() {
     let getSuspendEvent: (event: OnMessageEvent) => void;
     
     getSuspendEvent = (event: OnMessageEvent) => {
-      console.log('getSuspendEvent');
       if (capturedEvents > 2) { return; }    
       const data = JSON.parse(event.data);
-      console.log('getSuspendEvent data.type: ' + data.type);
       if (data.type == "suspendEvent") {
         resolves[capturedEvents](data);
         capturedEvents += 1;
@@ -537,11 +532,9 @@ describe('Basic Protocol', function() {
     }));
 
     it('should single stepping', onlyWithConection(done => {
-      this.timeout(20000);
       suspendPs[0].then(msg => {
         const step : StepMessage = {action: "stepInto", suspendEvent: msg.id};
         connectionP.then(con => {
-          console.log(step);
           con.socket.send(JSON.stringify(step))});
 
         suspendPs[1].then(msgAfterStep => {

--- a/tools/webdebugger/tests/basic-protocol.ts
+++ b/tools/webdebugger/tests/basic-protocol.ts
@@ -249,6 +249,10 @@ describe('Basic Project Setup', () => {
 
 describe('Basic Protocol', function() {
   let connectionP : Promise<SomConnection> = null;
+  const closeConnectionAfterSuite = (done) => {
+    connectionP.then(c => { closeConnection(c, done);});
+    connectionP.catch(reason => done(reason));
+  };
 
   describe('source message', () => {
     // Capture first source message for testing
@@ -269,10 +273,7 @@ describe('Basic Protocol', function() {
       connectionP = startSomAndConnect(getSourceData, []);
     });
 
-    after((done) => {
-      connectionP.then(c => { closeConnection(c, done);});
-      connectionP.catch(reason => done(reason));
-    });
+    after(closeConnectionAfterSuite);
 
     it('should have sources', onlyWithConection(done => {
       sourceP.then(sourceMsg => {
@@ -354,10 +355,7 @@ describe('Basic Protocol', function() {
       connectionP = startSomAndConnect(getSuspendEvent, [breakpoint]);
     });
 
-    after((done) => {
-      connectionP.then(c => { closeConnection(c, done);});
-      connectionP.catch(reason => done(reason));
-    });
+    after(closeConnectionAfterSuite);
 
     it('should accept line breakpoint, and halt on expected line', onlyWithConection(done => {
       suspendP.then(msg => {
@@ -418,10 +416,7 @@ describe('Basic Protocol', function() {
       connectionP = startSomAndConnect(getSuspendEvent, [breakpoint]);
     });
 
-    after((done) => {
-      connectionP.then(c => { closeConnection(c, done);});
-      connectionP.catch(reason => done(reason));
-    });
+    after(closeConnectionAfterSuite);
 
     it('should accept send breakpoint, and halt on expected source section', onlyWithConection(done => {
       suspendP.then(msg => {
@@ -466,10 +461,7 @@ describe('Basic Protocol', function() {
       connectionP = startSomAndConnect(getSuspendEvent, [breakpoint]);
     });
 
-    after((done) => {
-      connectionP.then(c => { closeConnection(c, done);});
-      connectionP.catch(reason => done(reason));
-    });
+    after(closeConnectionAfterSuite);
 
     it('should accept send breakpoint, and halt on expected source section', onlyWithConection(done => {
       suspendP.then(msg => {
@@ -522,10 +514,7 @@ describe('Basic Protocol', function() {
       connectionP = startSomAndConnect(getSuspendEvent, [breakpoint]);
     });
 
-    after((done) => {
-      connectionP.then(c => { closeConnection(c, done);});
-      connectionP.catch(reason => done(reason));
-    });
+    after(closeConnectionAfterSuite);
 
     it('should stop initially at breakpoint', onlyWithConection(done => {
       suspendPs[0].then(msg => {

--- a/tools/webdebugger/tests/basic-protocol.ts
+++ b/tools/webdebugger/tests/basic-protocol.ts
@@ -1,0 +1,129 @@
+'use strict';
+
+const debuggerPort = 7977;
+const somBasepath = '../../';
+const som = somBasepath + 'som';
+
+import * as WebSocket from 'ws';
+import { expect } from 'chai';
+import { spawn, ChildProcess } from 'child_process';
+import { resolve } from 'path';
+import * as fs from 'fs';
+
+
+interface SomConnection {
+  somProc: ChildProcess;
+  socket:  WebSocket;
+}
+
+function startSomAndConnect(): Promise<SomConnection> {
+  const somProc = spawn(som, ['-G', '-t1', '-wd',
+                              somBasepath + 'core-lib/Benchmarks/AsyncHarness.som',
+                             'Savina.PingPong', '10', '0', '800']);
+  const promise = new Promise((resolve, reject) => {
+    let connecting = false;
+    somProc.stdout.on('data', (data) => {
+      if (data.toString().includes("Started HTTP Server") && !connecting) {
+        connecting = true;
+        const socket = new WebSocket('ws://localhost:' + debuggerPort);
+        socket.on('open', () => {
+          resolve({somProc: somProc, socket: socket});
+        });
+      }
+      if (data.toString().includes("Failed starting WebSocket and/or HTTP Server")) {
+        reject(new Error('SOMns failed to starting WebSocket and/or HTTP Server'));
+      }
+    });
+  });
+  return promise;
+}
+
+let connectionPossible = false;
+function onlyWithConection(fn: ActionFunction) {
+  return function(done) {
+    if (connectionPossible) {
+      fn(done);
+    } else {
+      this.skip();
+    }
+  }
+}
+
+describe('Basic Project Setup', () => {
+  describe('SOMns is testable', () => {
+    it('SOMns executable should be in somBasepath', (done) => {
+      fs.access(som, fs.X_OK, (err) => {
+        expect(err).to.be.null;
+        done();
+      })
+    });
+
+    it('should show help', done => {
+      let sawOutput = false;
+      const somProc = spawn(som, ['-h']);
+      somProc.stdout.on('data', (data) => { sawOutput = true; });
+      somProc.on('exit', (code) => {
+        expect(sawOutput).to.be.true;
+        expect(code).to.equal(0);
+        done();
+      });
+    });
+
+    it('should be possible to connect', done => {
+      const connectionP = startSomAndConnect();
+      connectionP.then(connection => {
+        connection.somProc.kill();
+        connection.somProc.on('exit', code => {
+          // wait until process is shut down
+          done();
+        });
+        connectionPossible = true;
+      });
+      connectionP.catch(reason => {
+        done(reason);
+      })
+    })
+  });
+});
+
+describe('Basic Protocol', function() {
+  let connectionP : Promise<SomConnection> = null;
+
+  before('Start SOMns and Connect', () => {
+    connectionP = startSomAndConnect();
+  });
+
+  after(() => {
+    connectionP.then(c => c.somProc.kill());
+  });
+
+
+  describe('connection successful', () => {
+    it('should eventually connect', onlyWithConection(done => {
+
+      connectionP.then(c => {
+        done();
+      });
+      connectionP.catch(e => done(e));
+    }));
+  });
+
+  describe('source information format', () => {
+    it('should have the expected fields and data');
+  });
+
+  describe('setting breakpoints', () => {
+    it('should accept line breakpoint format, and halt on expected line');
+    it('should accept source section breakpoint format (sender), and halt on eventual send');
+    it('suspended event should have expected structure and data');
+    it('should accept source section breakpoint format (receiver), and halt at expected method');
+    it('should accept source section breakpoint format (promise), and halt at resolution');
+  });
+
+  describe('stepping', () => {
+    it('should be possible to do single stepping with line breakpoints');
+    it('should be possible to do single stepping with source section breakpoints');
+
+    it('should be possible to do continue execution');
+  });
+});

--- a/tools/webdebugger/tests/basic-protocol.ts
+++ b/tools/webdebugger/tests/basic-protocol.ts
@@ -200,14 +200,10 @@ function startSomAndConnect(onMessageHandler?: OnMessageHandler,
 }
 
 let connectionPossible = false;
-function onlyWithConection(fn: ActionFunction) {
-  return function(done) {
+function onlyWithConnection(fn) {
+  return function() {
     if (connectionPossible) {
-      try {
-        fn(done);
-      } catch (e) {
-        done(e);
-      }
+      return fn();
     } else {
       this.skip();
     }
@@ -275,55 +271,40 @@ describe('Basic Protocol', function() {
 
     after(closeConnectionAfterSuite);
 
-    it('should have sources', onlyWithConection(done => {
-      sourceP.then(sourceMsg => {
+    it('should have sources', onlyWithConnection(() => {
+      return sourceP.then(sourceMsg => {
         for (let sourceId in sourceMsg.sources) {
-          try {
-            expect(sourceId).to.equal("s-0");
-            const source = sourceMsg.sources[sourceId];
-            expect(source.id).to.equal(sourceId);
-            expect(source.mimeType).to.equal("application/x-newspeak-som-ns");
-            expect(source.name).to.equal("Platform.som");
-            expect(source).to.have.property('sourceText');
-            expect(source).to.have.property('uri');
-            done();
-          } catch (e) {
-            done(e);
-          }
+          expect(sourceId).to.equal("s-0");
+          const source = sourceMsg.sources[sourceId];
+          expect(source.id).to.equal(sourceId);
+          expect(source.mimeType).to.equal("application/x-newspeak-som-ns");
+          expect(source.name).to.equal("Platform.som");
+          expect(source).to.have.property('sourceText');
+          expect(source).to.have.property('uri');
           return;
         }
       });
     }));
 
-    it('should have source sections', onlyWithConection(done => {
-      sourceP.then(sourceMsg => {
+    it('should have source sections', onlyWithConnection(() => {
+      return sourceP.then(sourceMsg => {
         for (let ssId in sourceMsg.sections) {
-          try {
-            const section = sourceMsg.sections[ssId];
-            expectSourceSection(section);
-            done();
-          } catch (e) {
-            done(e);
-          }
+          const section = sourceMsg.sections[ssId];
+          expectSourceSection(section);
           return;
         }
       });
     }));
 
-    it('should have methods', onlyWithConection(done => {
-      sourceP.then(sourceMsg => {
+    it('should have methods', onlyWithConnection(() => {
+      return sourceP.then(sourceMsg => {
         for (let method of sourceMsg.methods) {
-          try {
-            expect(method).to.have.property('name');
-            expect(method).to.have.property('definition');
+          expect(method).to.have.property('name');
+          expect(method).to.have.property('definition');
 
-            const def = method.definition[0];
-            expectSimpleSourceSection(def);
-            expectSourceSection(method.sourceSection);
-            done();
-          } catch (e) {
-            done(e);
-          }
+          const def = method.definition[0];
+          expectSimpleSourceSection(def);
+          expectSourceSection(method.sourceSection);
           return;
         }
       });
@@ -357,32 +338,22 @@ describe('Basic Protocol', function() {
 
     after(closeConnectionAfterSuite);
 
-    it('should accept line breakpoint, and halt on expected line', onlyWithConection(done => {
-      suspendP.then(msg => {
-        try {
-          expect(msg.stack).lengthOf(7);
-          expect(msg.stack[0].methodName).to.equal("PingPong>>#benchmark");
-          expect(msg.stack[0].sourceSection.line).to.equal(52);
-          done();
-        } catch (e) {
-          done(e);
-        }
+    it('should accept line breakpoint, and halt on expected line', onlyWithConnection(() => {
+      return suspendP.then(msg => {
+        expect(msg.stack).lengthOf(7);
+        expect(msg.stack[0].methodName).to.equal("PingPong>>#benchmark");
+        expect(msg.stack[0].sourceSection.line).to.equal(52);
       });
     }));
 
-    it('should have a well structured suspended event', onlyWithConection(done => {
-      suspendP.then(msg => {
-        try {
-          expectSourceSection(msg.stack[0].sourceSection);
-          expectSourceSection(msg.sections[msg.stack[0].sourceSection.id]);
-          expect(msg.id).to.equal("se-0");
-          expect(msg.sourceId).to.equal("s-6");
-          expect(msg.topFrame.arguments[0]).to.equal("a PingPong");
-          expect(msg.topFrame.slots['ping']).to.equal('null');
-          done();          
-        } catch (e) {
-          done(e);
-        }
+    it('should have a well structured suspended event', onlyWithConnection(() => {
+      return suspendP.then(msg => {
+        expectSourceSection(msg.stack[0].sourceSection);
+        expectSourceSection(msg.sections[msg.stack[0].sourceSection.id]);
+        expect(msg.id).to.equal("se-0");
+        expect(msg.sourceId).to.equal("s-6");
+        expect(msg.topFrame.arguments[0]).to.equal("a PingPong");
+        expect(msg.topFrame.slots['ping']).to.equal('null');
       });
     }));    
   });
@@ -418,16 +389,11 @@ describe('Basic Protocol', function() {
 
     after(closeConnectionAfterSuite);
 
-    it('should accept send breakpoint, and halt on expected source section', onlyWithConection(done => {
-      suspendP.then(msg => {
-        try {
-          expect(msg.stack).lengthOf(2);
-          expect(msg.stack[0].methodName).to.equal("Ping>>#start");
-          expect(msg.stack[0].sourceSection.line).to.equal(15);
-          done();
-        } catch (e) {
-          done(e);
-        }
+    it('should accept send breakpoint, and halt on expected source section', onlyWithConnection(() => {
+      return suspendP.then(msg => {
+        expect(msg.stack).lengthOf(2);
+        expect(msg.stack[0].methodName).to.equal("Ping>>#start");
+        expect(msg.stack[0].sourceSection.line).to.equal(15);
       });
     }));    
   });
@@ -463,16 +429,11 @@ describe('Basic Protocol', function() {
 
     after(closeConnectionAfterSuite);
 
-    it('should accept send breakpoint, and halt on expected source section', onlyWithConection(done => {
-      suspendP.then(msg => {
-        try {
-          expect(msg.stack).lengthOf(2);
-          expect(msg.stack[0].methodName).to.equal("Pong>>#ping:");
-          expect(msg.stack[0].sourceSection.line).to.equal(39);
-          done();
-        } catch (e) {
-          done(e);
-        }
+    it('should accept send breakpoint, and halt on expected source section', onlyWithConnection(() => {
+      return suspendP.then(msg => {
+        expect(msg.stack).lengthOf(2);
+        expect(msg.stack[0].methodName).to.equal("Pong>>#ping:");
+        expect(msg.stack[0].sourceSection.line).to.equal(39);
       });
     }));
   });
@@ -516,106 +477,91 @@ describe('Basic Protocol', function() {
 
     after(closeConnectionAfterSuite);
 
-    it('should stop initially at breakpoint', onlyWithConection(done => {
-      suspendPs[0].then(msg => {
-        try {
-          expect(msg.stack).lengthOf(2);
-          expect(msg.stack[0].methodName).to.equal("Ping>>#start");
-          expect(msg.stack[0].sourceSection.line).to.equal(15);
-          done();
-        } catch (e) {
-          done(e);
-        }
+    it('should stop initially at breakpoint', onlyWithConnection(() => {
+      return suspendPs[0].then(msg => {
+        expect(msg.stack).lengthOf(2);
+        expect(msg.stack[0].methodName).to.equal("Ping>>#start");
+        expect(msg.stack[0].sourceSection.line).to.equal(15);
       });
     }));
 
-    it('should single stepping', onlyWithConection(done => {
-      suspendPs[0].then(msg => {
-        const step : StepMessage = {action: "stepInto", suspendEvent: msg.id};
-        connectionP.then(con => {
-          con.socket.send(JSON.stringify(step))});
+    it('should single stepping', onlyWithConnection(() => {
+      return new Promise((resolve, reject) => {
+        suspendPs[0].then(msg => {
+          const step : StepMessage = {action: "stepInto", suspendEvent: msg.id};
+          connectionP.then(con => {
+            con.socket.send(JSON.stringify(step))});
 
-        suspendPs[1].then(msgAfterStep => {
-          try {
+          const p = suspendPs[1].then(msgAfterStep => {
             expect(msgAfterStep.stack).lengthOf(2);
             expect(msgAfterStep.stack[0].methodName).to.equal("Ping>>#start");
             expect(msgAfterStep.stack[0].sourceSection.line).to.equal(16);
-            done();
-          } catch (e) {
-            done(e);
-          }
+          });
+          resolve(p);
         });
       });
     }));
 
-
     it('should be possible to dynamically activate line breakpoints',
-        onlyWithConection(done => {
-      suspendPs[1].then(msgAfterStep => {
-        connectionP.then(con => {
-          // set another breakpoint, after stepping, and with connection
-          const lbp: LineBreakpoint = {
-            type: "lineBreakpoint",
-            line: 21,
-            sourceUri: 'file:' + resolve('tests/pingpong.som'),
-            enabled: true
-          };
-          con.socket.send(JSON.stringify(
-            {action: "updateBreakpoint", breakpoint: lbp}));
-          con.socket.send(JSON.stringify(
-            {action: "resume", suspendEvent: msgAfterStep.id}
-          ));  
-        });
-      });
-
-      suspendPs[2].then(msgLineBP => {
-        try {
+        onlyWithConnection(() => {
+      return Promise.all([
+        suspendPs[1].then(msgAfterStep => {
+          connectionP.then(con => {
+            // set another breakpoint, after stepping, and with connection
+            const lbp: LineBreakpoint = {
+              type: "lineBreakpoint",
+              line: 21,
+              sourceUri: 'file:' + resolve('tests/pingpong.som'),
+              enabled: true
+            };
+            con.socket.send(JSON.stringify(
+              {action: "updateBreakpoint", breakpoint: lbp}));
+            con.socket.send(JSON.stringify(
+              {action: "resume", suspendEvent: msgAfterStep.id}
+            ));  
+          });
+        }),
+        suspendPs[2].then(msgLineBP => {
           expect(msgLineBP.stack).lengthOf(2);
           expect(msgLineBP.stack[0].methodName).to.equal("Ping>>#ping");
           expect(msgLineBP.stack[0].sourceSection.line).to.equal(21);
-          done();
-        } catch (e) {
-          done(e);
-        }
-      });
+        })]);
     }));
 
     it('should be possible to disable a line breakpoint',
-        onlyWithConection(done => {
-      suspendPs[2].then(msgAfterStep => {
-        connectionP.then(con => {
-          const lbp22: LineBreakpoint = {
-            type: "lineBreakpoint",
-            line: 22,
-            sourceUri: 'file:' + resolve('tests/pingpong.som'),
-            enabled: true
-          };
-          con.socket.send(JSON.stringify(
-            {action: "updateBreakpoint", breakpoint: lbp22}));
-          
-          const lbp21: LineBreakpoint = {
-            type: "lineBreakpoint",
-            line: 21,
-            sourceUri: 'file:' + resolve('tests/pingpong.som'),
-            enabled: false
-          };
-          con.socket.send(JSON.stringify(
-            {action: "updateBreakpoint", breakpoint: lbp21}));
-          con.socket.send(JSON.stringify(
-            {action: "resume", suspendEvent: msgAfterStep.id}));
+        onlyWithConnection(() => {
+      return new Promise((resolve, reject) => {
+        suspendPs[2].then(msgAfterStep => {
+          connectionP.then(con => {
+            const lbp22: LineBreakpoint = {
+              type: "lineBreakpoint",
+              line: 22,
+              sourceUri: 'file:' + resolve('tests/pingpong.som'),
+              enabled: true
+            };
+            con.socket.send(JSON.stringify(
+              {action: "updateBreakpoint", breakpoint: lbp22}));
+            
+            const lbp21: LineBreakpoint = {
+              type: "lineBreakpoint",
+              line: 21,
+              sourceUri: 'file:' + resolve('tests/pingpong.som'),
+              enabled: false
+            };
+            con.socket.send(JSON.stringify(
+              {action: "updateBreakpoint", breakpoint: lbp21}));
+            con.socket.send(JSON.stringify(
+              {action: "resume", suspendEvent: msgAfterStep.id}));
 
-          suspendPs[3].then(msgLineBP => {
-            try {
+            const p = suspendPs[3].then(msgLineBP => {
               expect(msgLineBP.stack).lengthOf(2);
               expect(msgLineBP.stack[0].methodName).to.equal("Ping>>#ping");
               expect(msgLineBP.stack[0].sourceSection.line).to.equal(22);
-              done();
-            } catch (e) {
-              done(e);
-            }
+            });
+            resolve(p);
           });
         });
-      })
+      });
     }));
   });
 });

--- a/tools/webdebugger/tests/basic-protocol.ts
+++ b/tools/webdebugger/tests/basic-protocol.ts
@@ -236,11 +236,6 @@ describe('Basic Project Setup', () => {
 describe('Basic Protocol', function() {
   let connectionP : Promise<SomConnection> = null;
 
-  afterEach((done) => {
-    connectionP.then(c => { closeConnection(c, done);});
-    connectionP.catch(reason => done(reason));
-  });
-
   describe('source message', () => {
     // Capture first source message for testing
     let firstSourceCaptured = false;
@@ -259,6 +254,11 @@ describe('Basic Protocol', function() {
 
     before('Start SOMns and Connect', () => {
       connectionP = startSomAndConnect(getSourceData, []);
+    });
+
+    after((done) => {
+      connectionP.then(c => { closeConnection(c, done);});
+      connectionP.catch(reason => done(reason));
     });
 
     it('should have sources', onlyWithConection(done => {
@@ -342,6 +342,11 @@ describe('Basic Protocol', function() {
       connectionP = startSomAndConnect(getSuspendEvent, [breakpoint]);
     });
 
+    after((done) => {
+      connectionP.then(c => { closeConnection(c, done);});
+      connectionP.catch(reason => done(reason));
+    });
+
     it('should accept line breakpoint, and halt on expected line', onlyWithConection(done => {
       suspendP.then(msg => {
         try {
@@ -401,6 +406,11 @@ describe('Basic Protocol', function() {
       connectionP = startSomAndConnect(getSuspendEvent, [breakpoint]);
     });
 
+    after((done) => {
+      connectionP.then(c => { closeConnection(c, done);});
+      connectionP.catch(reason => done(reason));
+    });
+
     it('should accept send breakpoint, and halt on expected source section', onlyWithConection(done => {
       suspendP.then(msg => {
         try {
@@ -442,6 +452,11 @@ describe('Basic Protocol', function() {
         role:        "receiver"
       };
       connectionP = startSomAndConnect(getSuspendEvent, [breakpoint]);
+    });
+
+    after((done) => {
+      connectionP.then(c => { closeConnection(c, done);});
+      connectionP.catch(reason => done(reason));
     });
 
     it('should accept send breakpoint, and halt on expected source section', onlyWithConection(done => {

--- a/tools/webdebugger/tests/basic-protocol.ts
+++ b/tools/webdebugger/tests/basic-protocol.ts
@@ -20,6 +20,49 @@ function startSomAndConnect(): Promise<SomConnection> {
   const somProc = spawn(som, ['-G', '-t1', '-wd',
                               somBasepath + 'core-lib/Benchmarks/AsyncHarness.som',
                              'Savina.PingPong', '10', '0', '800']);
+interface OnMessageEvent {
+  data:   any;
+  type:   string;
+  target: WebSocket
+}
+
+interface OnMessageHandler {
+  (event: OnMessageEvent): void
+}
+
+interface Message {
+  type: string;
+}
+
+interface Source {
+  id:         string;
+  sourceText: string;
+  mimeType:   string;
+  name:       string;
+  uri:        string;
+}
+
+interface SourceMap {
+  [key: string]: Source;
+}
+
+interface SourceMessage extends Message {
+  sources: SourceMap;
+  sections: any; // TODO
+  methods:  any; // TODO
+}
+
+interface Respond {
+  action: string;
+}
+
+interface Breakpoint {
+}
+
+interface InitialBreakpointsResponds extends Respond {
+  breakpoints: Breakpoint[];
+}
+
   const promise = new Promise((resolve, reject) => {
     let connecting = false;
     somProc.stdout.on('data', (data) => {

--- a/tools/webdebugger/tests/basic-protocol.ts
+++ b/tools/webdebugger/tests/basic-protocol.ts
@@ -119,6 +119,7 @@ interface SendBreakpoint extends Breakpoint {
   role:        SendBreakpointType;
 }
 
+// TODO: refactor protocol, and just include a simple source section here
 interface AsyncMethodRcvBreakpoint extends Breakpoint {
   sectionId:   string;
   startLine:   number;
@@ -329,6 +330,7 @@ describe('Basic Protocol', function() {
   });
 
   describe('setting a line breakpoint', () => {
+    // Capture first suspended event for testing
     let firstSuspendCaptured = false;
     let getSuspendEvent: (event: OnMessageEvent) => void;
     let suspendP = new Promise<SuspendEventMessage>((resolve, reject) => {
@@ -384,7 +386,7 @@ describe('Basic Protocol', function() {
           done(e);
         }
       });
-    }));
+    }));    
   });
 
   describe('setting a source section sender breakpoint', () => {
@@ -432,7 +434,7 @@ describe('Basic Protocol', function() {
           done(e);
         }
       });
-    }));
+    }));    
   });
 
   describe('setting a source section receiver breakpoint', () => {
@@ -519,6 +521,7 @@ describe('Basic Protocol', function() {
       };
       connectionP = startSomAndConnect(getSuspendEvent, [breakpoint]);
     });
+
     after((done) => {
       connectionP.then(c => { closeConnection(c, done);});
       connectionP.catch(reason => done(reason));

--- a/tools/webdebugger/tests/basic-protocol.ts
+++ b/tools/webdebugger/tests/basic-protocol.ts
@@ -16,10 +16,6 @@ interface SomConnection {
   socket:  WebSocket;
 }
 
-function startSomAndConnect(): Promise<SomConnection> {
-  const somProc = spawn(som, ['-G', '-t1', '-wd',
-                              somBasepath + 'core-lib/Benchmarks/AsyncHarness.som',
-                             'Savina.PingPong', '10', '0', '800']);
 interface OnMessageEvent {
   data:   any;
   type:   string;
@@ -67,6 +63,9 @@ function getInitialBreakpointsResponds(breakpoints: Breakpoint[]): string {
   return JSON.stringify({action: "initialBreakpoints", breakpoints});
 }
 
+function startSomAndConnect(onMessageHandler?: OnMessageHandler,
+    initialBreakpoints?: Breakpoint[]): Promise<SomConnection> {
+  const somProc = spawn(som, ['-G', '-t1', '-wd', 'tests/pingpong.som']);
   const promise = new Promise((resolve, reject) => {
     let connecting = false;
     somProc.stdout.on('data', (data) => {

--- a/tools/webdebugger/tests/basic-protocol.ts
+++ b/tools/webdebugger/tests/basic-protocol.ts
@@ -63,6 +63,10 @@ interface InitialBreakpointsResponds extends Respond {
   breakpoints: Breakpoint[];
 }
 
+function getInitialBreakpointsResponds(breakpoints: Breakpoint[]): string {
+  return JSON.stringify({action: "initialBreakpoints", breakpoints});
+}
+
   const promise = new Promise((resolve, reject) => {
     let connecting = false;
     somProc.stdout.on('data', (data) => {
@@ -70,6 +74,10 @@ interface InitialBreakpointsResponds extends Respond {
         connecting = true;
         const socket = new WebSocket('ws://localhost:' + debuggerPort);
         socket.on('open', () => {
+          if (initialBreakpoints) {
+            socket.send(getInitialBreakpointsResponds(initialBreakpoints));
+          }
+
           resolve({somProc: somProc, socket: socket});
         });
       }

--- a/tools/webdebugger/tests/basic-protocol.ts
+++ b/tools/webdebugger/tests/basic-protocol.ts
@@ -488,15 +488,17 @@ describe('Basic Protocol', function() {
   describe('stepping', () => {
     // Capture suspended events
     const suspendPs: Promise<SuspendEventMessage>[] = [];
+    const numSuspends = 4;
     const resolves = [];
-    suspendPs.push(new Promise<SuspendEventMessage>((res, rej) => resolves.push(res)));
-    suspendPs.push(new Promise<SuspendEventMessage>((res, rej) => resolves.push(res)));
+    for (let i = 0; i < numSuspends; i++) {
+      suspendPs.push(new Promise<SuspendEventMessage>((res, rej) => resolves.push(res)));
+    }
 
     let capturedEvents = 0;
     let getSuspendEvent: (event: OnMessageEvent) => void;
     
     getSuspendEvent = (event: OnMessageEvent) => {
-      if (capturedEvents > 2) { return; }    
+      if (capturedEvents > numSuspends) { return; }    
       const data = JSON.parse(event.data);
       if (data.type == "suspendEvent") {
         resolves[capturedEvents](data);

--- a/tools/webdebugger/tests/pingpong.som
+++ b/tools/webdebugger/tests/pingpong.som
@@ -1,0 +1,67 @@
+class PingPongApp usingPlatform: platform = Value (
+| private actors = platform actors.
+|)(
+  public class PingPong new: numPings = Value (
+  | private NumPings = numPings.
+  |
+  )(
+    class Ping new: cnt with: pong = (
+      | private pingsLeft ::= cnt.
+        private pong = pong.
+      |
+    ) (
+      public start = (
+        'Ping>>start' println.
+        pong <-: ping: self.
+        pingsLeft := pingsLeft - 1.
+      )
+    
+      public ping = (
+        'Ping>>ping' println.
+        pong <-: ping: self.
+        pingsLeft := pingsLeft - 1.
+      )
+    
+      public pong: sender = (
+        'Ping>>pong' println.
+        pingsLeft > 0
+          ifTrue:  [ self <-: ping ]
+          ifFalse: [ pong <-: stop ].
+      )
+    )
+  
+    class Pong new: completionRes = (
+    | private pongCount ::= 0.
+      private completionRes = completionRes.
+    |
+    ) (
+      public ping: sender = (
+        'Pong>>ping' println.
+        sender <-: pong: self.
+        pongCount := pongCount + 1.
+      )
+    
+      public stop = (
+        'Pong>>stop' println.
+        completionRes resolve: pongCount
+      )
+    )
+    
+    public benchmark = (
+      | ping pong completionPP |
+      completionPP := actors createPromisePair.
+      pong := (actors createActorFromValue: Pong) <-: new: completionPP resolver.
+      ping := (actors createActorFromValue: Ping) <-: new: NumPings with: pong.
+      ping <-: start.
+      ^ completionPP promise whenResolved: [:r |
+         ('Done with: ' + r asString) println. ]
+    )
+  ) : (
+    public newInstance: problemSize = ( ^ self new: problemSize asInteger )
+    public setupVerifiedRun: run = ( run problemSize: 1 )
+  )
+
+  public main: args = (
+    ^ (PingPong new: 3) benchmark
+  )
+)

--- a/tools/webdebugger/tsconfig.json
+++ b/tools/webdebugger/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "inlineSourceMap": true,
+    "outDir": "out"
+  },
+  "exclude": [
+    "node_modules",
+    "out"
+  ]
+}

--- a/tools/webdebugger/typings.json
+++ b/tools/webdebugger/typings.json
@@ -1,0 +1,8 @@
+{
+  "globalDependencies": {
+    "chai": "registry:dt/chai#3.4.0+20160601211834",
+    "mocha": "registry:dt/mocha#2.2.5+20160720003353",
+    "node": "registry:dt/node#6.0.0+20160826120425",
+    "ws": "registry:dt/ws#0.0.0+20160724122153"
+  }
+}


### PR DESCRIPTION
Add infrastructure for testing the WebDebugger wire protocol.
This is implemented with TypeScript in the hope that we might reuse the code for a VS Code extension (see https://github.com/smarr/SOMns-vscode).

Current features:

- tests whether SOMns can be executed and connected to
- adds corresponding Travis setup