### PR TITLE
Handle Eager Primitive Specialization without huge switch/case

### DIFF
--- a/src/som/VM.java
+++ b/src/som/VM.java
@@ -32,6 +32,7 @@ import som.interpreter.actors.SFarReference;
 import som.interpreter.actors.SPromise;
 import som.interpreter.actors.SPromise.SResolver;
 import som.vm.ObjectSystem;
+import som.vm.Primitives;
 import som.vmobjects.SObjectWithClass.SObjectWithoutFields;
 import tools.actors.ActorExecutionTrace;
 import tools.debugger.WebDebugger;
@@ -90,6 +91,10 @@ public final class VM {
 
   public SObjectWithoutFields getVmMirror() {
     return vmMirror;
+  }
+
+  public Primitives getPrimitives() {
+    return objectSystem.getPrimitives();
   }
 
   public static void thisMethodNeedsToBeOptimized(final String msg) {

--- a/src/som/interpreter/actors/ReceivedRootNode.java
+++ b/src/som/interpreter/actors/ReceivedRootNode.java
@@ -24,7 +24,7 @@ public abstract class ReceivedRootNode extends RootNode {
       if (resolver == null) {
         this.resolve = insert(new NullResolver(getSourceSection()));
       } else {
-        this.resolve = insert(ResolvePromiseNodeFactory.create(getSourceSection(), null, null));
+        this.resolve = insert(ResolvePromiseNodeFactory.create(false, getSourceSection(), null, null));
       }
     }
 
@@ -34,7 +34,7 @@ public abstract class ReceivedRootNode extends RootNode {
   public final class NullResolver extends ResolvePromiseNode {
 
     public NullResolver(final SourceSection source) {
-      super(source);
+      super(false, source);
     }
 
     @Override

--- a/src/som/interpreter/actors/ResolvePromiseNode.java
+++ b/src/som/interpreter/actors/ResolvePromiseNode.java
@@ -15,7 +15,8 @@ import som.primitives.Primitive;
 @Primitive(primitive = "actorsResolve:with:")
 @Instrumentable(factory = ResolvePromiseNodeWrapper.class)
 public abstract class ResolvePromiseNode extends BinaryComplexOperation {
-  protected ResolvePromiseNode(final SourceSection source) { super(false, source); }
+  protected ResolvePromiseNode(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
+  protected ResolvePromiseNode(final ResolvePromiseNode node) { super(node); }
 
   public abstract Object executeEvaluated(VirtualFrame frame, final SResolver receiver, Object argument);
 

--- a/src/som/interpreter/actors/ResolvePromiseNode.java
+++ b/src/som/interpreter/actors/ResolvePromiseNode.java
@@ -12,7 +12,7 @@ import som.primitives.Primitive;
 
 
 @GenerateNodeFactory
-@Primitive("actorsResolve:with:")
+@Primitive(primitive = "actorsResolve:with:")
 @Instrumentable(factory = ResolvePromiseNodeWrapper.class)
 public abstract class ResolvePromiseNode extends BinaryComplexOperation {
   protected ResolvePromiseNode(final SourceSection source) { super(false, source); }

--- a/src/som/interpreter/actors/WrapReferenceNode.java
+++ b/src/som/interpreter/actors/WrapReferenceNode.java
@@ -1,12 +1,12 @@
 package som.interpreter.actors;
 
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+
 import som.primitives.ObjectPrims.IsValue;
 import som.primitives.ObjectPrimsFactory.IsValueFactory;
 import som.vmobjects.SArray.STransferArray;
 import som.vmobjects.SObject;
-
-import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.nodes.Node;
 
 
 public abstract class WrapReferenceNode extends Node {
@@ -42,7 +42,7 @@ public abstract class WrapReferenceNode extends Node {
     return !(obj instanceof SFarReference) && !(obj instanceof SPromise);
   }
 
-  @Child protected IsValue isValue = IsValueFactory.create(null, null);
+  @Child protected IsValue isValue = IsValueFactory.create(false, null, null);
 
   protected final boolean isValue(final Object obj) {
     return isValue.executeEvaluated(obj);

--- a/src/som/interpreter/nodes/MessageSendNode.java
+++ b/src/som/interpreter/nodes/MessageSendNode.java
@@ -22,11 +22,9 @@ import som.interpreter.nodes.dispatch.GenericDispatchNode;
 import som.interpreter.nodes.dispatch.UninitializedDispatchNode;
 import som.interpreter.nodes.nary.EagerlySpecializableNode;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
-import som.interpreter.nodes.specialized.whileloops.WhileWithDynamicBlocksNode;
 import som.vm.NotYetImplementedException;
 import som.vm.Primitives;
 import som.vm.Primitives.Specializer;
-import som.vmobjects.SBlock;
 import som.vmobjects.SSymbol;
 import tools.dym.Tags.VirtualInvoke;
 
@@ -161,13 +159,6 @@ public final class MessageSendNode {
           return makeEagerPrim(newNode);
         }
       }
-
-      // let's organize the specializations by number of arguments
-      // perhaps not the best, but simple
-      switch (argumentNodes.length) {
-        case  2: return specializeBinary(arguments);
-        case  3: return specializeTernary(arguments);
-      }
       return makeSend();
     }
 
@@ -206,18 +197,6 @@ public final class MessageSendNode {
       }
 
       return result;
-    }
-
-    protected PreevaluatedExpression specializeBinary(final Object[] arguments) {
-      switch (selector.getString()) {
-      }
-      return makeSend();
-    }
-
-    protected PreevaluatedExpression specializeTernary(final Object[] arguments) {
-      switch (selector.getString()) {
-      }
-      return makeSend();
     }
   }
 
@@ -307,29 +286,6 @@ public final class MessageSendNode {
     protected PreevaluatedExpression makeSpecialSend() {
       // should never be reached with isSuperSend() returning always false
       throw new RuntimeException("A symbol send should never be a special send.");
-    }
-
-    @Override
-    protected PreevaluatedExpression specializeBinary(final Object[] arguments) {
-      switch (selector.getString()) {
-        case "whileTrue:": {
-          if (arguments[1] instanceof SBlock && arguments[0] instanceof SBlock) {
-            SBlock argBlock = (SBlock) arguments[1];
-            return replace(new WhileWithDynamicBlocksNode((SBlock) arguments[0],
-                argBlock, true, getSourceSection()));
-          }
-          break;
-        }
-        case "whileFalse:":
-          if (arguments[1] instanceof SBlock && arguments[0] instanceof SBlock) {
-            SBlock    argBlock     = (SBlock)    arguments[1];
-            return replace(new WhileWithDynamicBlocksNode(
-                (SBlock) arguments[0], argBlock, false, getSourceSection()));
-          }
-          break; // use normal send
-      }
-
-      return super.specializeBinary(arguments);
     }
   }
 

--- a/src/som/interpreter/nodes/nary/BinaryComplexOperation.java
+++ b/src/som/interpreter/nodes/nary/BinaryComplexOperation.java
@@ -13,6 +13,7 @@ import tools.dym.Tags.ComplexPrimitiveOperation;
  */
 public abstract class BinaryComplexOperation extends BinaryExpressionNode {
   protected BinaryComplexOperation(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
+  protected BinaryComplexOperation(final BinaryComplexOperation node) { super(node); }
 
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {

--- a/src/som/interpreter/nodes/nary/EagerBinaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerBinaryPrimitiveNode.java
@@ -23,11 +23,11 @@ public final class EagerBinaryPrimitiveNode extends EagerPrimitive {
 
   private final SSymbol selector;
 
-  public EagerBinaryPrimitiveNode(final SSymbol selector,
+  public EagerBinaryPrimitiveNode(final SourceSection source,
+      final SSymbol selector,
       final ExpressionNode receiver,
       final ExpressionNode argument,
-      final BinaryExpressionNode primitive,
-      final SourceSection source) {
+      final BinaryExpressionNode primitive) {
     super(source);
     assert source == primitive.getSourceSection();
     this.receiver  = receiver;

--- a/src/som/interpreter/nodes/nary/EagerlySpecializableNode.java
+++ b/src/som/interpreter/nodes/nary/EagerlySpecializableNode.java
@@ -1,0 +1,62 @@
+package som.interpreter.nodes.nary;
+
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.SourceSection;
+
+import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.PreevaluatedExpression;
+import som.vmobjects.SSymbol;
+
+public abstract class EagerlySpecializableNode extends ExprWithTagsNode
+  implements PreevaluatedExpression {
+
+  @CompilationFinal private boolean eagerlyWrapped;
+
+  protected EagerlySpecializableNode(final EagerlySpecializableNode wrappedNode) {
+    super(wrappedNode);
+    assert !wrappedNode.eagerlyWrapped : "I think this should be true.";
+    this.eagerlyWrapped = false;
+  }
+
+  public EagerlySpecializableNode(final boolean eagerlyWrapped,
+      final SourceSection source) {
+    super(source);
+    this.eagerlyWrapped = eagerlyWrapped;
+  }
+
+  /**
+   * This method is used by eager wrapper or if this node is not eagerly
+   * wrapped.
+   */
+  protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
+    return super.isTaggedWith(tag);
+  }
+
+  @Override
+  protected final boolean isTaggedWith(final Class<?> tag) {
+    if (eagerlyWrapped) {
+      return false;
+    } else {
+      return isTaggedWithIgnoringEagerness(tag);
+    }
+  }
+
+  @Override
+  protected void onReplace(final Node newNode, final CharSequence reason) {
+    if (newNode instanceof WrapperNode ||
+        !(newNode instanceof EagerlySpecializableNode)) { return; }
+
+    EagerlySpecializableNode n = (EagerlySpecializableNode) newNode;
+    n.eagerlyWrapped = eagerlyWrapped;
+    super.onReplace(newNode, reason);
+  }
+
+  /**
+   * Create an eager primitive wrapper, which wraps this node.
+   */
+  public abstract EagerPrimitive wrapInEagerWrapper(
+      final EagerlySpecializableNode prim, final SSymbol selector,
+      final ExpressionNode[] arguments);
+}

--- a/src/som/interpreter/nodes/nary/QuaternaryExpressionNode.java
+++ b/src/som/interpreter/nodes/nary/QuaternaryExpressionNode.java
@@ -1,11 +1,13 @@
 package som.interpreter.nodes.nary;
 
-import som.interpreter.nodes.ExpressionNode;
-
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
+
+import som.interpreter.nodes.ExpressionNode;
+import som.vm.NotYetImplementedException;
+import som.vmobjects.SSymbol;
 
 
 @NodeChildren({
@@ -13,13 +15,35 @@ import com.oracle.truffle.api.source.SourceSection;
   @NodeChild(value = "firstArg",  type = ExpressionNode.class),
   @NodeChild(value = "secondArg", type = ExpressionNode.class),
   @NodeChild(value = "thirdArg",  type = ExpressionNode.class)})
-public abstract class QuaternaryExpressionNode extends ExprWithTagsNode {
+public abstract class QuaternaryExpressionNode extends EagerlySpecializableNode {
 
-  public QuaternaryExpressionNode(final SourceSection sourceSection) {
-    super(sourceSection);
+  public QuaternaryExpressionNode(final boolean eagerlyWrapped,
+      final SourceSection source) {
+    super(eagerlyWrapped, source);
+  }
+
+  /**
+   * For wrapped nodes only.
+   */
+  protected QuaternaryExpressionNode(final QuaternaryExpressionNode wrappedNode) {
+    super(wrappedNode);
   }
 
   public abstract Object executeEvaluated(final VirtualFrame frame,
       final Object receiver, final Object firstArg, final Object secondArg,
       final Object thirdArg);
+
+  @Override
+  public final Object doPreEvaluated(final VirtualFrame frame,
+      final Object[] arguments) {
+    return executeEvaluated(frame, arguments[0], arguments[1], arguments[2],
+        arguments[3]);
+  }
+
+  @Override
+  public EagerPrimitive wrapInEagerWrapper(
+      final EagerlySpecializableNode prim, final SSymbol selector,
+      final ExpressionNode[] arguments) {
+    throw new NotYetImplementedException(); // wasn't needed so far
+  }
 }

--- a/src/som/interpreter/nodes/nary/TernaryExpressionNode.java
+++ b/src/som/interpreter/nodes/nary/TernaryExpressionNode.java
@@ -1,16 +1,13 @@
 package som.interpreter.nodes.nary;
 
-import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
-import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
-import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
-import som.interpreter.nodes.PreevaluatedExpression;
+import som.vmobjects.SSymbol;
 
 
 @NodeChildren({
@@ -18,15 +15,11 @@ import som.interpreter.nodes.PreevaluatedExpression;
   @NodeChild(value = "firstArg",  type = ExpressionNode.class),
   @NodeChild(value = "secondArg", type = ExpressionNode.class)})
 @Instrumentable(factory = TernaryExpressionNodeWrapper.class)
-public abstract class TernaryExpressionNode extends ExprWithTagsNode
-    implements PreevaluatedExpression {
-
-  @CompilationFinal private boolean eagerlyWrapped;
+public abstract class TernaryExpressionNode extends EagerlySpecializableNode {
 
   public TernaryExpressionNode(final boolean eagerlyWrapped,
       final SourceSection sourceSection) {
-    super(sourceSection);
-    this.eagerlyWrapped = eagerlyWrapped;
+    super(eagerlyWrapped, sourceSection);
   }
 
   /**
@@ -34,35 +27,6 @@ public abstract class TernaryExpressionNode extends ExprWithTagsNode
    */
   protected TernaryExpressionNode(final TernaryExpressionNode wrappedNode) {
     super(wrappedNode);
-    assert !wrappedNode.eagerlyWrapped : "I think this should be true.";
-    this.eagerlyWrapped = false;
-  }
-
-  /**
-   * This method is used by eager wrapper or if this node is not eagerly
-   * wrapped.
-   */
-  protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
-    return super.isTaggedWith(tag);
-  }
-
-  @Override
-  protected final boolean isTaggedWith(final Class<?> tag) {
-    if (eagerlyWrapped) {
-      return false;
-    } else {
-      return isTaggedWithIgnoringEagerness(tag);
-    }
-  }
-
-  @Override
-  protected void onReplace(final Node newNode, final CharSequence reason) {
-    if (newNode instanceof WrapperNode ||
-        !(newNode instanceof TernaryExpressionNode)) { return; }
-
-    TernaryExpressionNode n = (TernaryExpressionNode) newNode;
-    n.eagerlyWrapped = eagerlyWrapped;
-    super.onReplace(newNode, reason);
   }
 
   public abstract Object executeEvaluated(final VirtualFrame frame,
@@ -72,5 +36,13 @@ public abstract class TernaryExpressionNode extends ExprWithTagsNode
   public final Object doPreEvaluated(final VirtualFrame frame,
       final Object[] arguments) {
     return executeEvaluated(frame, arguments[0], arguments[1], arguments[2]);
+  }
+
+  @Override
+  public EagerPrimitive wrapInEagerWrapper(
+      final EagerlySpecializableNode prim, final SSymbol selector,
+      final ExpressionNode[] arguments) {
+    return new EagerTernaryPrimitiveNode(getSourceSection(), selector,
+        arguments[0], arguments[1], arguments[2], this);
   }
 }

--- a/src/som/interpreter/nodes/specialized/AndMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/AndMessageNode.java
@@ -2,13 +2,21 @@ package som.interpreter.nodes.specialized;
 
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.source.SourceSection;
 
+import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.literals.BlockNode;
 import som.interpreter.nodes.nary.BinaryBasicOperation;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
+import som.interpreter.nodes.nary.BinaryExpressionNode;
+import som.interpreter.nodes.specialized.AndMessageNode.AndOrSplzr;
+import som.interpreter.nodes.specialized.AndMessageNodeFactory.AndBoolMessageNodeFactory;
+import som.primitives.Primitive;
+import som.vm.Primitives.Specializer;
 import som.vmobjects.SBlock;
 import som.vmobjects.SInvokable;
 import tools.dym.Tags.ControlFlowCondition;
@@ -16,7 +24,43 @@ import tools.dym.Tags.OpComparison;
 
 
 @GenerateNodeFactory
+@Primitive(selector = "and:", noWrapper = true, specializer = AndOrSplzr.class)
+@Primitive(selector = "&&",   noWrapper = true, specializer = AndOrSplzr.class)
 public abstract class AndMessageNode extends BinaryComplexOperation {
+  public static class AndOrSplzr extends Specializer<BinaryExpressionNode> {
+    protected final NodeFactory<BinaryExpressionNode> boolFact;
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public AndOrSplzr(final Primitive prim, final NodeFactory<BinaryExpressionNode> fact) {
+      this(prim, fact, (NodeFactory) AndBoolMessageNodeFactory.getInstance());
+    }
+
+    protected AndOrSplzr(final Primitive prim, final NodeFactory<BinaryExpressionNode> msgFact,
+        final NodeFactory<BinaryExpressionNode> boolFact) {
+      super(prim, msgFact);
+      this.boolFact = boolFact;
+    }
+
+    @Override
+    public final boolean matches(final Object[] args, final ExpressionNode[] argNodes) {
+      return args[0] instanceof Boolean &&
+          (args[1] instanceof Boolean ||
+              unwrapIfNecessary(argNodes[1]) instanceof BlockNode);
+    }
+
+    @Override
+    public final BinaryExpressionNode create(final Object[] arguments,
+        final ExpressionNode[] argNodes, final SourceSection section,
+        final boolean eagerWrapper) {
+      if (unwrapIfNecessary(argNodes[1]) instanceof BlockNode) {
+        return fact.createNode(arguments[1], section, argNodes[0], argNodes[1]);
+      } else {
+        assert arguments[1] instanceof Boolean;
+        return boolFact.createNode(section, argNodes[0], argNodes[1]);
+      }
+    }
+  }
+
 
   private final SInvokable blockMethod;
   @Child private DirectCallNode blockValueSend;

--- a/src/som/interpreter/nodes/specialized/IfMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/IfMessageNode.java
@@ -2,6 +2,8 @@ package som.interpreter.nodes.specialized;
 
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
@@ -9,13 +11,38 @@ import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.profiles.ConditionProfile;
 import com.oracle.truffle.api.source.SourceSection;
 
+import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
+import som.interpreter.nodes.specialized.IfMessageNode.IfFalseSpecialier;
+import som.interpreter.nodes.specialized.IfMessageNode.IfTrueSpecialier;
+import som.primitives.Primitive;
+import som.vm.Primitives.Specializer;
 import som.vm.constants.Nil;
 import som.vmobjects.SBlock;
 import som.vmobjects.SInvokable;
 
 
+@GenerateNodeFactory
+@Primitive(selector = "ifTrue:",  noWrapper = true, specializer = IfTrueSpecialier.class)
+@Primitive(selector = "ifFalse:", noWrapper = true, specializer = IfFalseSpecialier.class)
 public abstract class IfMessageNode extends BinaryComplexOperation {
+  public static class IfTrueSpecialier extends Specializer {
+    @Override
+    public <T> T create(final NodeFactory<T> factory, final Object[] arguments,
+        final ExpressionNode[] argNodes, final SourceSection section,
+        final boolean eagerWrapper) {
+      return factory.createNode(true, section, argNodes[0], argNodes[1]);
+    }
+  }
+
+  public static class IfFalseSpecialier extends Specializer {
+    @Override
+    public <T> T create(final NodeFactory<T> factory, final Object[] arguments,
+        final ExpressionNode[] argNodes, final SourceSection section,
+        final boolean eagerWrapper) {
+      return factory.createNode(false, section, argNodes[0], argNodes[1]);
+    }
+  }
 
   protected final ConditionProfile condProf = ConditionProfile.createCountingProfile();
   private final boolean expected;

--- a/src/som/interpreter/nodes/specialized/IfMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/IfMessageNode.java
@@ -3,7 +3,6 @@ package som.interpreter.nodes.specialized;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
-import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
@@ -11,37 +10,25 @@ import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.profiles.ConditionProfile;
 import com.oracle.truffle.api.source.SourceSection;
 
-import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
-import som.interpreter.nodes.specialized.IfMessageNode.IfFalseSpecialier;
-import som.interpreter.nodes.specialized.IfMessageNode.IfTrueSpecialier;
 import som.primitives.Primitive;
-import som.vm.Primitives.Specializer;
 import som.vm.constants.Nil;
 import som.vmobjects.SBlock;
 import som.vmobjects.SInvokable;
 
 
-@GenerateNodeFactory
-@Primitive(selector = "ifTrue:",  noWrapper = true, specializer = IfTrueSpecialier.class)
-@Primitive(selector = "ifFalse:", noWrapper = true, specializer = IfFalseSpecialier.class)
 public abstract class IfMessageNode extends BinaryComplexOperation {
-  public static class IfTrueSpecialier extends Specializer {
-    @Override
-    public <T> T create(final NodeFactory<T> factory, final Object[] arguments,
-        final ExpressionNode[] argNodes, final SourceSection section,
-        final boolean eagerWrapper) {
-      return factory.createNode(true, section, argNodes[0], argNodes[1]);
-    }
+
+  @GenerateNodeFactory
+  @Primitive(selector = "ifTrue:",  noWrapper = true)
+  public abstract static class IfTrueMessageNode extends IfMessageNode {
+    public IfTrueMessageNode(final boolean eagWrap, final SourceSection source) { super(true, source); assert !eagWrap; }
   }
 
-  public static class IfFalseSpecialier extends Specializer {
-    @Override
-    public <T> T create(final NodeFactory<T> factory, final Object[] arguments,
-        final ExpressionNode[] argNodes, final SourceSection section,
-        final boolean eagerWrapper) {
-      return factory.createNode(false, section, argNodes[0], argNodes[1]);
-    }
+  @GenerateNodeFactory
+  @Primitive(selector = "ifFalse:",  noWrapper = true)
+  public abstract static class IfFalseMessageNode extends IfMessageNode {
+    public IfFalseMessageNode(final boolean eagWrap, final SourceSection source) { super(false, source); assert !eagWrap; }
   }
 
   protected final ConditionProfile condProf = ConditionProfile.createCountingProfile();

--- a/src/som/interpreter/nodes/specialized/IntDownToDoMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/IntDownToDoMessageNode.java
@@ -2,17 +2,23 @@ package som.interpreter.nodes.specialized;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.TernaryExpressionNode;
+import som.interpreter.nodes.specialized.IntToDoMessageNode.ToDoSplzr;
+import som.primitives.Primitive;
 import som.vmobjects.SBlock;
 import som.vmobjects.SInvokable;
 import tools.dym.Tags.LoopNode;
 
 
+@GenerateNodeFactory
+@Primitive(selector = "downTo:do:", noWrapper = true, disabled = true,
+           specializer = ToDoSplzr.class)
 public abstract class IntDownToDoMessageNode extends TernaryExpressionNode {
 
   private final SInvokable blockMethod;

--- a/src/som/interpreter/nodes/specialized/IntToByDoMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/IntToByDoMessageNode.java
@@ -2,27 +2,43 @@ package som.interpreter.nodes.specialized;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.PreevaluatedExpression;
 import som.interpreter.nodes.nary.QuaternaryExpressionNode;
+import som.interpreter.nodes.specialized.IntToByDoMessageNode.Splzr;
+import som.primitives.Primitive;
+import som.vm.Primitives.Specializer;
 import som.vmobjects.SBlock;
 import som.vmobjects.SInvokable;
 import tools.dym.Tags.LoopNode;
 
 
+@GenerateNodeFactory
+@Primitive(selector = "to:by:do:", disabled = true, specializer = Splzr.class, noWrapper = true)
 public abstract class IntToByDoMessageNode extends QuaternaryExpressionNode
     implements PreevaluatedExpression {
+  public static class Splzr extends Specializer {
+    @Override
+    public <T> T create(final NodeFactory<T> factory, final Object[] arguments,
+        final ExpressionNode[] argNodes, final SourceSection section,
+        final boolean eagerWrapper) {
+      return factory.createNode(section, arguments[3], argNodes[0],
+          argNodes[1], argNodes[2], argNodes[3]);
+    }
+  }
 
   private final SInvokable blockMethod;
   @Child private DirectCallNode valueSend;
 
-  public IntToByDoMessageNode(final ExpressionNode orignialNode,
-      final SBlock block) {
-    super(orignialNode.getSourceSection());
+  public IntToByDoMessageNode(final SourceSection section, final SBlock block) {
+    super(section);
     blockMethod = block.getMethod();
     valueSend = Truffle.getRuntime().createDirectCallNode(
                     blockMethod.getCallTarget());

--- a/src/som/interpreter/nodes/specialized/IntToByDoMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/IntToByDoMessageNode.java
@@ -10,7 +10,6 @@ import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
-import som.interpreter.nodes.PreevaluatedExpression;
 import som.interpreter.nodes.nary.QuaternaryExpressionNode;
 import som.interpreter.nodes.specialized.IntToByDoMessageNode.Splzr;
 import som.primitives.Primitive;
@@ -22,8 +21,7 @@ import tools.dym.Tags.LoopNode;
 
 @GenerateNodeFactory
 @Primitive(selector = "to:by:do:", disabled = true, specializer = Splzr.class, noWrapper = true)
-public abstract class IntToByDoMessageNode extends QuaternaryExpressionNode
-    implements PreevaluatedExpression {
+public abstract class IntToByDoMessageNode extends QuaternaryExpressionNode {
   public static class Splzr extends Specializer {
     @Override
     public <T> T create(final NodeFactory<T> factory, final Object[] arguments,
@@ -38,32 +36,25 @@ public abstract class IntToByDoMessageNode extends QuaternaryExpressionNode
   @Child private DirectCallNode valueSend;
 
   public IntToByDoMessageNode(final SourceSection section, final SBlock block) {
-    super(section);
+    super(false, section);
     blockMethod = block.getMethod();
     valueSend = Truffle.getRuntime().createDirectCallNode(
                     blockMethod.getCallTarget());
   }
 
   public IntToByDoMessageNode(final IntToByDoMessageNode node) {
-    super(node.getSourceSection());
+    super(false, node.getSourceSection());
     this.blockMethod = node.blockMethod;
     this.valueSend   = node.valueSend;
   }
 
   @Override
-  protected boolean isTaggedWith(final Class<?> tag) {
+  protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
     if (tag == LoopNode.class) {
       return true;
     } else {
-      return super.isTaggedWith(tag);
+      return super.isTaggedWithIgnoringEagerness(tag);
     }
-  }
-
-  @Override
-  public final Object doPreEvaluated(final VirtualFrame frame,
-      final Object[] arguments) {
-    return executeEvaluated(frame, arguments[0], arguments[1],  arguments[2],
-        arguments[3]);
   }
 
   protected final boolean isSameBlockLong(final SBlock block) {

--- a/src/som/interpreter/nodes/specialized/IntToByDoMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/IntToByDoMessageNode.java
@@ -3,7 +3,6 @@ package som.interpreter.nodes.specialized;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
-import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
@@ -11,33 +10,22 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.QuaternaryExpressionNode;
-import som.interpreter.nodes.specialized.IntToByDoMessageNode.Splzr;
 import som.primitives.Primitive;
-import som.vm.Primitives.Specializer;
 import som.vmobjects.SBlock;
 import som.vmobjects.SInvokable;
 import tools.dym.Tags.LoopNode;
 
 
 @GenerateNodeFactory
-@Primitive(selector = "to:by:do:", disabled = true, specializer = Splzr.class, noWrapper = true)
+@Primitive(selector = "to:by:do:", disabled = true, noWrapper = true, requiresArguments = true)
 public abstract class IntToByDoMessageNode extends QuaternaryExpressionNode {
-  public static class Splzr extends Specializer {
-    @Override
-    public <T> T create(final NodeFactory<T> factory, final Object[] arguments,
-        final ExpressionNode[] argNodes, final SourceSection section,
-        final boolean eagerWrapper) {
-      return factory.createNode(section, arguments[3], argNodes[0],
-          argNodes[1], argNodes[2], argNodes[3]);
-    }
-  }
-
   private final SInvokable blockMethod;
   @Child private DirectCallNode valueSend;
 
-  public IntToByDoMessageNode(final SourceSection section, final SBlock block) {
-    super(false, section);
-    blockMethod = block.getMethod();
+  public IntToByDoMessageNode(final boolean eagWrap, final SourceSection section, final Object[] args) {
+    super(eagWrap, section);
+    assert !eagWrap;
+    blockMethod = ((SBlock) args[3]).getMethod();
     valueSend = Truffle.getRuntime().createDirectCallNode(
                     blockMethod.getCallTarget());
   }

--- a/src/som/interpreter/nodes/specialized/IntToDoMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/IntToDoMessageNode.java
@@ -3,25 +3,45 @@ package som.interpreter.nodes.specialized;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.source.SourceSection;
 
+import som.VmSettings;
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.TernaryExpressionNode;
+import som.interpreter.nodes.specialized.IntToDoMessageNode.ToDoSplzr;
+import som.primitives.Primitive;
+import som.vm.Primitives.Specializer;
 import som.vmobjects.SBlock;
 import som.vmobjects.SInvokable;
 import tools.dym.Tags.LoopNode;
 
 
+@GenerateNodeFactory
+@Primitive(selector = "to:do:", noWrapper = true, disabled = true,
+           specializer = ToDoSplzr.class)
 public abstract class IntToDoMessageNode extends TernaryExpressionNode {
+  public static class ToDoSplzr extends Specializer<IntToDoMessageNode> {
+    public ToDoSplzr(final Primitive prim, final NodeFactory<IntToDoMessageNode> fact) { super(prim, fact); }
+
+    @Override
+    public boolean matches(final Object[] args,
+        final ExpressionNode[] argNodes) {
+      return !VmSettings.DYNAMIC_METRICS && args[0] instanceof Long &&
+          (args[1] instanceof Long || args[1] instanceof Double) &&
+          args[2] instanceof SBlock;
+    }
+  }
 
   protected static final DirectCallNode create(final SInvokable blockMethod) {
     return Truffle.getRuntime().createDirectCallNode(blockMethod.getCallTarget());
   }
 
-  protected IntToDoMessageNode(final SourceSection source) { super(false, source); }
+  protected IntToDoMessageNode(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {

--- a/src/som/interpreter/nodes/specialized/NotMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/NotMessageNode.java
@@ -13,8 +13,7 @@ import tools.dym.Tags.OpArithmetic;
 @GenerateNodeFactory
 @Primitive(selector = "not", receiverType = Boolean.class)
 public abstract class NotMessageNode extends UnaryBasicOperation {
-  public NotMessageNode(final boolean eagerlyWrapped, final SourceSection source) { super(eagerlyWrapped, source); }
-  public NotMessageNode(final SourceSection source) { super(false, source); }
+  public NotMessageNode(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {

--- a/src/som/interpreter/nodes/specialized/NotMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/NotMessageNode.java
@@ -6,10 +6,12 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryBasicOperation;
+import som.primitives.Primitive;
 import tools.dym.Tags.OpArithmetic;
 
 
 @GenerateNodeFactory
+@Primitive(selector = "not", receiverType = Boolean.class)
 public abstract class NotMessageNode extends UnaryBasicOperation {
   public NotMessageNode(final boolean eagerlyWrapped, final SourceSection source) { super(eagerlyWrapped, source); }
   public NotMessageNode(final SourceSection source) { super(false, source); }

--- a/src/som/interpreter/nodes/specialized/OrMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/OrMessageNode.java
@@ -1,6 +1,8 @@
 package som.interpreter.nodes.specialized;
 
 import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
@@ -8,13 +10,28 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.BinaryBasicOperation;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
+import som.interpreter.nodes.nary.BinaryExpressionNode;
+import som.interpreter.nodes.specialized.AndMessageNode.AndOrSplzr;
+import som.interpreter.nodes.specialized.OrMessageNode.OrSplzr;
+import som.interpreter.nodes.specialized.OrMessageNodeFactory.OrBoolMessageNodeFactory;
+import som.primitives.Primitive;
 import som.vmobjects.SBlock;
 import som.vmobjects.SInvokable;
 import tools.dym.Tags.ControlFlowCondition;
 import tools.dym.Tags.OpComparison;
 
 
+@GenerateNodeFactory
+@Primitive(selector = "or:", noWrapper = true, specializer = OrSplzr.class)
+@Primitive(selector = "||",  noWrapper = true, specializer = OrSplzr.class)
 public abstract class OrMessageNode extends BinaryComplexOperation {
+  public static final class OrSplzr extends AndOrSplzr {
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public OrSplzr(final Primitive prim, final NodeFactory<BinaryExpressionNode> fact) {
+      super(prim, fact, (NodeFactory) OrBoolMessageNodeFactory.getInstance());
+    }
+  }
+
   private final SInvokable blockMethod;
   @Child private DirectCallNode blockValueSend;
 
@@ -56,6 +73,7 @@ public abstract class OrMessageNode extends BinaryComplexOperation {
     }
   }
 
+  @GenerateNodeFactory
   public abstract static class OrBoolMessageNode extends BinaryBasicOperation {
     public OrBoolMessageNode(final SourceSection source) { super(false, source); }
 

--- a/src/som/interpreter/nodes/specialized/whileloops/WhileWithStaticBlocksNode.java
+++ b/src/som/interpreter/nodes/specialized/whileloops/WhileWithStaticBlocksNode.java
@@ -20,39 +20,43 @@ import som.vmobjects.SBlock;
 @Primitive(selector = "whileTrue:",  noWrapper = true, specializer = WhileTrueSplzr.class)
 @Primitive(selector = "whileFalse:", noWrapper = true, specializer = WhileFalseSplzr.class)
 public final class WhileWithStaticBlocksNode extends AbstractWhileNode {
-  public abstract static class WhileSplzr extends Specializer {
+  public abstract static class WhileSplzr extends Specializer<WhileWithStaticBlocksNode> {
     private final boolean whileTrueOrFalse;
-    protected WhileSplzr(final boolean whileTrueOrFalse) {
+    protected WhileSplzr(final Primitive prim,
+        final NodeFactory<WhileWithStaticBlocksNode> fact,
+        final boolean whileTrueOrFalse) {
+      super(prim, fact);
       this.whileTrueOrFalse = whileTrueOrFalse;
     }
 
     @Override
-    public boolean matches(final Primitive prim, final Object receiver,
-        final ExpressionNode[] args) {
-      return unwrapIfNecessary(args[1]) instanceof BlockNode &&
-          unwrapIfNecessary(args[0]) instanceof BlockNode;
+    public boolean matches(final Object[] args,
+        final ExpressionNode[] argNodes) {
+      return unwrapIfNecessary(argNodes[1]) instanceof BlockNode &&
+          unwrapIfNecessary(argNodes[0]) instanceof BlockNode;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public <T> T create(final NodeFactory<T> factory, final Object[] arguments,
+    public WhileWithStaticBlocksNode create(final Object[] arguments,
         final ExpressionNode[] argNodes, final SourceSection section,
         final boolean eagerWrapper) {
       assert !eagerWrapper;
       BlockNode argBlockNode = (BlockNode) unwrapIfNecessary(argNodes[1]);
       SBlock    argBlock     = (SBlock)    arguments[1];
-      return (T) new WhileWithStaticBlocksNode(
+      return new WhileWithStaticBlocksNode(
           (BlockNode) unwrapIfNecessary(argNodes[0]), argBlockNode,
           (SBlock) arguments[0], argBlock, whileTrueOrFalse, section);
     }
   }
 
   public static final class WhileTrueSplzr extends WhileSplzr {
-    public WhileTrueSplzr() { super(true); }
+    public WhileTrueSplzr(final Primitive prim,
+        final NodeFactory<WhileWithStaticBlocksNode> fact) { super(prim, fact, true); }
   }
 
   public static final class WhileFalseSplzr extends WhileSplzr {
-    public WhileFalseSplzr() { super(false); }
+    public WhileFalseSplzr(final Primitive prim,
+        final NodeFactory<WhileWithStaticBlocksNode> fact) { super(prim, fact, false); }
   }
 
   @Child protected BlockNode receiver;

--- a/src/som/interpreter/nodes/specialized/whileloops/WhileWithStaticBlocksNode.java
+++ b/src/som/interpreter/nodes/specialized/whileloops/WhileWithStaticBlocksNode.java
@@ -1,13 +1,60 @@
 package som.interpreter.nodes.specialized.whileloops;
 
-import som.interpreter.nodes.literals.BlockNode;
-import som.vmobjects.SBlock;
+import java.util.List;
 
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
 
+import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.literals.BlockNode;
+import som.interpreter.nodes.specialized.whileloops.WhileWithStaticBlocksNode.WhileFalseSplzr;
+import som.interpreter.nodes.specialized.whileloops.WhileWithStaticBlocksNode.WhileTrueSplzr;
+import som.primitives.Primitive;
+import som.vm.NotYetImplementedException;
+import som.vm.Primitives.Specializer;
+import som.vmobjects.SBlock;
 
-public abstract class WhileWithStaticBlocksNode extends AbstractWhileNode {
+
+@Primitive(selector = "whileTrue:",  noWrapper = true, specializer = WhileTrueSplzr.class)
+@Primitive(selector = "whileFalse:", noWrapper = true, specializer = WhileFalseSplzr.class)
+public final class WhileWithStaticBlocksNode extends AbstractWhileNode {
+  public abstract static class WhileSplzr extends Specializer {
+    private final boolean whileTrueOrFalse;
+    protected WhileSplzr(final boolean whileTrueOrFalse) {
+      this.whileTrueOrFalse = whileTrueOrFalse;
+    }
+
+    @Override
+    public boolean matches(final Primitive prim, final Object receiver,
+        final ExpressionNode[] args) {
+      return unwrapIfNecessary(args[1]) instanceof BlockNode &&
+          unwrapIfNecessary(args[0]) instanceof BlockNode;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T create(final NodeFactory<T> factory, final Object[] arguments,
+        final ExpressionNode[] argNodes, final SourceSection section,
+        final boolean eagerWrapper) {
+      assert !eagerWrapper;
+      BlockNode argBlockNode = (BlockNode) unwrapIfNecessary(argNodes[1]);
+      SBlock    argBlock     = (SBlock)    arguments[1];
+      return (T) new WhileWithStaticBlocksNode(
+          (BlockNode) unwrapIfNecessary(argNodes[0]), argBlockNode,
+          (SBlock) arguments[0], argBlock, whileTrueOrFalse, section);
+    }
+  }
+
+  public static final class WhileTrueSplzr extends WhileSplzr {
+    public WhileTrueSplzr() { super(true); }
+  }
+
+  public static final class WhileFalseSplzr extends WhileSplzr {
+    public WhileFalseSplzr() { super(false); }
+  }
+
   @Child protected BlockNode receiver;
   @Child protected BlockNode argument;
 
@@ -20,32 +67,41 @@ public abstract class WhileWithStaticBlocksNode extends AbstractWhileNode {
   }
 
   @Override
-  public final Object executeGeneric(final VirtualFrame frame) {
+  public Object executeGeneric(final VirtualFrame frame) {
     SBlock rcvr = receiver.executeSBlock(frame);
     SBlock arg  = argument.executeSBlock(frame);
     return executeEvaluated(frame, rcvr, arg);
   }
 
   @Override
-  protected final Object doWhileConditionally(final VirtualFrame frame,
+  protected Object doWhileConditionally(final VirtualFrame frame,
       final SBlock loopCondition,
       final SBlock loopBody) {
     return doWhileUnconditionally(frame, loopCondition, loopBody);
   }
 
-  public static final class WhileTrueStaticBlocksNode extends WhileWithStaticBlocksNode {
-    public WhileTrueStaticBlocksNode(final BlockNode receiver,
-        final BlockNode argument, final SBlock rcvr, final SBlock arg,
-        final SourceSection source) {
-      super(receiver, argument, rcvr, arg, true, source);
-    }
-  }
+  public static final class WhileWithStaticBlocksNodeFactory implements NodeFactory<WhileWithStaticBlocksNode> {
 
-  public static final class WhileFalseStaticBlocksNode extends WhileWithStaticBlocksNode {
-    public WhileFalseStaticBlocksNode(final BlockNode receiver,
-        final BlockNode argument, final SBlock rcvr, final SBlock arg,
-        final SourceSection source) {
-      super(receiver, argument, rcvr, arg, false, source);
+    @Override
+    public WhileWithStaticBlocksNode createNode(final Object... args) {
+      return new WhileWithStaticBlocksNode((BlockNode) args[0],
+          (BlockNode) args[1], (SBlock) args[2], (SBlock) args[3],
+          (Boolean) args[4], (SourceSection) args[5]);
+    }
+
+    @Override
+    public Class<WhileWithStaticBlocksNode> getNodeClass() {
+      return WhileWithStaticBlocksNode.class;
+    }
+
+    @Override
+    public List<List<Class<?>>> getNodeSignatures() {
+      throw new NotYetImplementedException();
+    }
+
+    @Override
+    public List<Class<? extends Node>> getExecutionSignature() {
+      throw new NotYetImplementedException();
     }
   }
 }

--- a/src/som/primitives/AsStringPrim.java
+++ b/src/som/primitives/AsStringPrim.java
@@ -12,7 +12,9 @@ import som.vmobjects.SSymbol;
 
 
 @GenerateNodeFactory
-@Primitive({"symbolAsString:", "intAsString:", "doubleAsString:"})
+@Primitive(primitive = "symbolAsString:")
+@Primitive(primitive = "intAsString:")
+@Primitive(primitive = "doubleAsString:")
 public abstract class AsStringPrim extends UnaryBasicOperation {
   public AsStringPrim(final SourceSection source) { super(false, source); }
 

--- a/src/som/primitives/AsStringPrim.java
+++ b/src/som/primitives/AsStringPrim.java
@@ -16,7 +16,7 @@ import som.vmobjects.SSymbol;
 @Primitive(primitive = "intAsString:")
 @Primitive(primitive = "doubleAsString:")
 public abstract class AsStringPrim extends UnaryBasicOperation {
-  public AsStringPrim(final SourceSection source) { super(false, source); }
+  public AsStringPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
   // TODO: assign a tag
 

--- a/src/som/primitives/BlockPrims.java
+++ b/src/som/primitives/BlockPrims.java
@@ -59,7 +59,7 @@ public abstract class BlockPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "blockRestart:")
   public abstract static class RestartPrim extends UnaryExpressionNode {
-    public RestartPrim(final SourceSection source) { super(false, source); }
+    public RestartPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public SAbstractObject doSBlock(final SBlock receiver) {
@@ -77,7 +77,6 @@ public abstract class BlockPrims {
              receiverType = {SBlock.class, Boolean.class})
   public abstract static class ValueNonePrim extends UnaryExpressionNode {
     public ValueNonePrim(final boolean eagerlyWrapped, final SourceSection source) { super(eagerlyWrapped, source); }
-    public ValueNonePrim(final SourceSection source) { super(false, source); }
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
@@ -114,7 +113,6 @@ public abstract class BlockPrims {
              receiverType = SBlock.class)
   public abstract static class ValueOnePrim extends BinaryExpressionNode {
     protected ValueOnePrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-    protected ValueOnePrim(final SourceSection source) { super(false, source); }
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
@@ -147,7 +145,6 @@ public abstract class BlockPrims {
              receiverType = SBlock.class)
   public abstract static class ValueTwoPrim extends TernaryExpressionNode {
     public ValueTwoPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-    public ValueTwoPrim(final SourceSection source) { super(false, source); }
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {

--- a/src/som/primitives/BlockPrims.java
+++ b/src/som/primitives/BlockPrims.java
@@ -57,7 +57,7 @@ public abstract class BlockPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("blockRestart:")
+  @Primitive(primitive = "blockRestart:")
   public abstract static class RestartPrim extends UnaryExpressionNode {
     public RestartPrim(final SourceSection source) { super(false, source); }
 
@@ -73,7 +73,8 @@ public abstract class BlockPrims {
 
   @GenerateNodeFactory
   @ImportStatic(BlockPrims.class)
-  @Primitive("blockValue:")
+  @Primitive(primitive = "blockValue:", selector = "value",
+             receiverType = {SBlock.class, Boolean.class})
   public abstract static class ValueNonePrim extends UnaryExpressionNode {
     public ValueNonePrim(final boolean eagerlyWrapped, final SourceSection source) { super(eagerlyWrapped, source); }
     public ValueNonePrim(final SourceSection source) { super(false, source); }
@@ -109,7 +110,8 @@ public abstract class BlockPrims {
 
   @GenerateNodeFactory
   @ImportStatic(BlockPrims.class)
-  @Primitive("blockValue:with:")
+  @Primitive(primitive = "blockValue:with:", selector = "value:",
+             receiverType = SBlock.class)
   public abstract static class ValueOnePrim extends BinaryExpressionNode {
     protected ValueOnePrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
     protected ValueOnePrim(final SourceSection source) { super(false, source); }
@@ -141,7 +143,8 @@ public abstract class BlockPrims {
 
   @GenerateNodeFactory
   @ImportStatic(BlockPrims.class)
-  @Primitive("blockValue:with:with:")
+  @Primitive(primitive = "blockValue:with:with:", selector = "value:with:",
+             receiverType = SBlock.class)
   public abstract static class ValueTwoPrim extends TernaryExpressionNode {
     public ValueTwoPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
     public ValueTwoPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/ClassPrims.java
+++ b/src/som/primitives/ClassPrims.java
@@ -17,7 +17,7 @@ public class ClassPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "mirrorAClassesName:")
   public abstract static class NamePrim extends UnaryExpressionNode {
-    public NamePrim(final SourceSection source) { super(false, source); }
+    public NamePrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SAbstractObject doSClass(final SClass receiver) {
@@ -28,7 +28,7 @@ public class ClassPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "mirrorClassName:")
   public abstract static class ClassNamePrim extends UnaryExpressionNode {
-    public ClassNamePrim(final SourceSection source) { super(false, source); }
+    public ClassNamePrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SAbstractObject doSClass(final Object receiver) {
@@ -39,7 +39,7 @@ public class ClassPrims {
 
   @GenerateNodeFactory
   public abstract static class SuperClassPrim extends UnaryExpressionNode {
-    public SuperClassPrim(final SourceSection source) { super(false, source); }
+    public SuperClassPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SAbstractObject doSClass(final SClass receiver) {

--- a/src/som/primitives/ClassPrims.java
+++ b/src/som/primitives/ClassPrims.java
@@ -15,7 +15,7 @@ public class ClassPrims {
 
   // TODO: move to new mirror class
   @GenerateNodeFactory
-  @Primitive("mirrorAClassesName:")
+  @Primitive(primitive = "mirrorAClassesName:")
   public abstract static class NamePrim extends UnaryExpressionNode {
     public NamePrim(final SourceSection source) { super(false, source); }
 
@@ -26,7 +26,7 @@ public class ClassPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("mirrorClassName:")
+  @Primitive(primitive = "mirrorClassName:")
   public abstract static class ClassNamePrim extends UnaryExpressionNode {
     public ClassNamePrim(final SourceSection source) { super(false, source); }
 

--- a/src/som/primitives/CosPrim.java
+++ b/src/som/primitives/CosPrim.java
@@ -8,7 +8,7 @@ import som.interpreter.nodes.nary.UnaryBasicOperation;
 import tools.dym.Tags.OpArithmetic;
 
 @GenerateNodeFactory
-@Primitive("doubleCos:")
+@Primitive(primitive = "doubleCos:", selector = "cos", receiverType = Double.class)
 public abstract class CosPrim extends UnaryBasicOperation {
   public CosPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   public CosPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/CosPrim.java
+++ b/src/som/primitives/CosPrim.java
@@ -11,7 +11,6 @@ import tools.dym.Tags.OpArithmetic;
 @Primitive(primitive = "doubleCos:", selector = "cos", receiverType = Double.class)
 public abstract class CosPrim extends UnaryBasicOperation {
   public CosPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  public CosPrim(final SourceSection source) { super(false, source); }
 
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {

--- a/src/som/primitives/DoublePrims.java
+++ b/src/som/primitives/DoublePrims.java
@@ -4,8 +4,11 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
 
+import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.UnaryBasicOperation;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
+import som.vm.Primitives.Specializer;
+import som.vm.constants.Classes;
 import tools.dym.Tags.OpArithmetic;
 import tools.highlight.Tags.LiteralTag;
 
@@ -13,7 +16,8 @@ import tools.highlight.Tags.LiteralTag;
 public abstract class DoublePrims  {
 
   @GenerateNodeFactory
-  @Primitive("doubleRound:")
+  @Primitive(primitive = "doubleRound:", selector = "round",
+             receiverType = Double.class)
   public abstract static class RoundPrim extends UnaryBasicOperation {
     public RoundPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
     public RoundPrim(final SourceSection source) { super(false, source); }
@@ -34,7 +38,8 @@ public abstract class DoublePrims  {
   }
 
   @GenerateNodeFactory
-  @Primitive("doubleAsInteger:")
+  @Primitive(primitive = "doubleAsInteger:", selector = "asInteger",
+             receiverType = Double.class)
   public abstract static class AsIntPrim extends UnaryBasicOperation {
     public AsIntPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
     public AsIntPrim(final SourceSection source) { super(false, source); }
@@ -54,9 +59,19 @@ public abstract class DoublePrims  {
     }
   }
 
+  public static class IsDoubleClass extends Specializer {
+    @Override
+    public boolean matches(final Primitive prim, final Object receiver, ExpressionNode[] args) {
+      return receiver == Classes.doubleClass;
+    }
+  }
+
   @GenerateNodeFactory
-  @Primitive("doublePositiveInfinity:")
+  @Primitive(primitive = "doublePositiveInfinity:",
+             selector = "PositiveInfinity", noWrapper = true,
+             specializer = IsDoubleClass.class)
   public abstract static class PositiveInfinityPrim extends UnaryExpressionNode {
+    public PositiveInfinityPrim(final boolean eagerWrapper, final SourceSection source) { super(eagerWrapper, source); }
     public PositiveInfinityPrim(final SourceSection source) { super(false, source); }
 
     @Override

--- a/src/som/primitives/DoublePrims.java
+++ b/src/som/primitives/DoublePrims.java
@@ -1,6 +1,7 @@
 package som.primitives;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -20,7 +21,6 @@ public abstract class DoublePrims  {
              receiverType = Double.class)
   public abstract static class RoundPrim extends UnaryBasicOperation {
     public RoundPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-    public RoundPrim(final SourceSection source) { super(false, source); }
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
@@ -42,7 +42,6 @@ public abstract class DoublePrims  {
              receiverType = Double.class)
   public abstract static class AsIntPrim extends UnaryBasicOperation {
     public AsIntPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-    public AsIntPrim(final SourceSection source) { super(false, source); }
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
@@ -59,10 +58,12 @@ public abstract class DoublePrims  {
     }
   }
 
-  public static class IsDoubleClass extends Specializer {
+  public static class IsDoubleClass extends Specializer<ExpressionNode> {
+    public IsDoubleClass(final Primitive prim, final NodeFactory<ExpressionNode> fact) { super(prim, fact); }
+
     @Override
-    public boolean matches(final Primitive prim, final Object receiver, ExpressionNode[] args) {
-      return receiver == Classes.doubleClass;
+    public boolean matches(final Object[] args, final ExpressionNode[] argNodess) {
+      return args[0] == Classes.doubleClass;
     }
   }
 
@@ -72,7 +73,6 @@ public abstract class DoublePrims  {
              specializer = IsDoubleClass.class)
   public abstract static class PositiveInfinityPrim extends UnaryExpressionNode {
     public PositiveInfinityPrim(final boolean eagerWrapper, final SourceSection source) { super(eagerWrapper, source); }
-    public PositiveInfinityPrim(final SourceSection source) { super(false, source); }
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {

--- a/src/som/primitives/EqualsEqualsPrim.java
+++ b/src/som/primitives/EqualsEqualsPrim.java
@@ -15,7 +15,6 @@ import som.vmobjects.SObjectWithClass;
 @Primitive(primitive = "object:identicalTo:", selector = "==")
 public abstract class EqualsEqualsPrim extends ComparisonPrim {
   protected EqualsEqualsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected EqualsEqualsPrim(final SourceSection source) { super(false, source); }
 
   @Specialization
   public final boolean doSBlock(final SBlock left, final Object right) {

--- a/src/som/primitives/EqualsEqualsPrim.java
+++ b/src/som/primitives/EqualsEqualsPrim.java
@@ -12,7 +12,7 @@ import som.vmobjects.SObjectWithClass;
 
 
 @GenerateNodeFactory
-@Primitive("object:identicalTo:")
+@Primitive(primitive = "object:identicalTo:", selector = "==")
 public abstract class EqualsEqualsPrim extends ComparisonPrim {
   protected EqualsEqualsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected EqualsEqualsPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/EqualsPrim.java
+++ b/src/som/primitives/EqualsPrim.java
@@ -16,7 +16,11 @@ import som.vmobjects.SSymbol;
 
 @GenerateNodeFactory
 @ImportStatic(Nil.class)
-@Primitive({"value:sameAs:", "int:equals:", "double:equals:", "string:equals:"})
+@Primitive(primitive = "value:sameAs:")
+@Primitive(primitive = "int:equals:")
+@Primitive(primitive = "double:equals:")
+@Primitive(primitive = "string:equals:")
+@Primitive(selector = "=")
 public abstract class EqualsPrim extends ComparisonPrim {
   protected EqualsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected EqualsPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/EqualsPrim.java
+++ b/src/som/primitives/EqualsPrim.java
@@ -23,7 +23,6 @@ import som.vmobjects.SSymbol;
 @Primitive(selector = "=")
 public abstract class EqualsPrim extends ComparisonPrim {
   protected EqualsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected EqualsPrim(final SourceSection source) { super(false, source); }
 
   @Specialization
   public final boolean doBoolean(final boolean left, final boolean right) {

--- a/src/som/primitives/ExceptionsPrims.java
+++ b/src/som/primitives/ExceptionsPrims.java
@@ -36,7 +36,7 @@ public abstract class ExceptionsPrims {
           block.getMethod().getCallTarget());
     }
 
-    public ExceptionDoOnPrim(final SourceSection source) { super(false, source); }
+    public ExceptionDoOnPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     public static final boolean sameBlock(final SBlock block, final SInvokable method) {
       return block.getMethod() == method;
@@ -82,7 +82,7 @@ public abstract class ExceptionsPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "signalException:")
   public abstract static class SignalPrim extends UnaryExpressionNode {
-    public SignalPrim(final SourceSection source) { super(false, source); }
+    public SignalPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final Object doSignal(final SAbstractObject exceptionObject) {
@@ -97,7 +97,7 @@ public abstract class ExceptionsPrims {
     @Child protected BlockDispatchNode dispatchBody    = BlockDispatchNodeGen.create();
     @Child protected BlockDispatchNode dispatchHandler = BlockDispatchNodeGen.create();
 
-    protected EnsurePrim(final SourceSection source) { super(false, source); }
+    protected EnsurePrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final Object doException(final VirtualFrame frame, final SBlock body,

--- a/src/som/primitives/ExceptionsPrims.java
+++ b/src/som/primitives/ExceptionsPrims.java
@@ -25,7 +25,7 @@ import som.vmobjects.SInvokable;
 public abstract class ExceptionsPrims {
 
   @GenerateNodeFactory
-  @Primitive("exceptionDo:catch:onException:")
+  @Primitive(primitive = "exceptionDo:catch:onException:")
   public abstract static class ExceptionDoOnPrim extends TernaryExpressionNode {
 
     protected static final int INLINE_CACHE_SIZE = VmSettings.DYNAMIC_METRICS ? 100 : 6;
@@ -80,7 +80,7 @@ public abstract class ExceptionsPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("signalException:")
+  @Primitive(primitive = "signalException:")
   public abstract static class SignalPrim extends UnaryExpressionNode {
     public SignalPrim(final SourceSection source) { super(false, source); }
 
@@ -91,7 +91,7 @@ public abstract class ExceptionsPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("exceptionDo:ensure:")
+  @Primitive(primitive = "exceptionDo:ensure:")
   public abstract static class EnsurePrim extends BinaryComplexOperation {
 
     @Child protected BlockDispatchNode dispatchBody    = BlockDispatchNodeGen.create();

--- a/src/som/primitives/HashPrim.java
+++ b/src/som/primitives/HashPrim.java
@@ -11,7 +11,8 @@ import som.vmobjects.SSymbol;
 
 
 @GenerateNodeFactory
-@Primitive({"objHashcode:", "stringHashcode:"})
+@Primitive(primitive = "objHashcode:")
+@Primitive(primitive = "stringHashcode:")
 public abstract class HashPrim extends UnaryExpressionNode {
   public HashPrim(final SourceSection source) { super(false, source); }
 

--- a/src/som/primitives/HashPrim.java
+++ b/src/som/primitives/HashPrim.java
@@ -14,7 +14,7 @@ import som.vmobjects.SSymbol;
 @Primitive(primitive = "objHashcode:")
 @Primitive(primitive = "stringHashcode:")
 public abstract class HashPrim extends UnaryExpressionNode {
-  public HashPrim(final SourceSection source) { super(false, source); }
+  public HashPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
   @Specialization
   @TruffleBoundary

--- a/src/som/primitives/IntegerPrims.java
+++ b/src/som/primitives/IntegerPrims.java
@@ -26,7 +26,6 @@ public abstract class IntegerPrims {
              selector = "as32BitSignedValue", receiverType = Long.class)
   public abstract static class As32BitSignedValue extends UnaryBasicOperation {
     public As32BitSignedValue(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-    public As32BitSignedValue(final SourceSection source) { super(false, source); }
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
@@ -48,7 +47,6 @@ public abstract class IntegerPrims {
              selector = "as32BitUnsignedValue", receiverType = Long.class)
   public abstract static class As32BitUnsignedValue extends UnaryBasicOperation {
     public As32BitUnsignedValue(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-    public As32BitUnsignedValue(final SourceSection source) { super(false, source); }
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
@@ -68,7 +66,7 @@ public abstract class IntegerPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "intFromString:")
   public abstract static class FromStringPrim extends UnaryExpressionNode {
-    public FromStringPrim(final SourceSection source) { super(false, source); }
+    public FromStringPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
@@ -96,7 +94,6 @@ public abstract class IntegerPrims {
   @Primitive(primitive = "int:leftShift:", selector = "<<", receiverType = Long.class)
   public abstract static class LeftShiftPrim extends ArithmeticPrim {
     protected LeftShiftPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-    protected LeftShiftPrim(final SourceSection source) { super(false, source); }
 
     private final BranchProfile overflow = BranchProfile.create();
 
@@ -126,7 +123,6 @@ public abstract class IntegerPrims {
              receiverType = Long.class)
   public abstract static class UnsignedRightShiftPrim extends ArithmeticPrim {
     protected UnsignedRightShiftPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-    protected UnsignedRightShiftPrim(final SourceSection source) { super(false, source); }
 
     @Specialization
     public final long doLong(final long receiver, final long right) {
@@ -138,7 +134,6 @@ public abstract class IntegerPrims {
   @Primitive(selector = "max:", receiverType = Long.class, disabled = true)
   public abstract static class MaxIntPrim extends ArithmeticPrim {
     protected MaxIntPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-    protected MaxIntPrim(final SourceSection source) { super(false, source); }
 
     @Specialization
     public final long doLong(final long receiver, final long right) {
@@ -150,7 +145,6 @@ public abstract class IntegerPrims {
   @Primitive(selector = "to:", receiverType = Long.class, disabled = true)
   public abstract static class ToPrim extends BinaryComplexOperation {
     protected ToPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-    protected ToPrim(final SourceSection source) { super(false, source); }
 
     @Specialization
     public final SMutableArray doLong(final long receiver, final long right) {
@@ -167,7 +161,6 @@ public abstract class IntegerPrims {
   @Primitive(selector = "abs", receiverType = Long.class)
   public abstract static class AbsPrim extends UnaryBasicOperation {
     public AbsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-    public AbsPrim(final SourceSection source) { super(false, source); }
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {

--- a/src/som/primitives/IntegerPrims.java
+++ b/src/som/primitives/IntegerPrims.java
@@ -22,7 +22,8 @@ import tools.dym.Tags.StringAccess;
 public abstract class IntegerPrims {
 
   @GenerateNodeFactory
-  @Primitive("intAs32BitSignedValue:")
+  @Primitive(primitive = "intAs32BitSignedValue:",
+             selector = "as32BitSignedValue", receiverType = Long.class)
   public abstract static class As32BitSignedValue extends UnaryBasicOperation {
     public As32BitSignedValue(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
     public As32BitSignedValue(final SourceSection source) { super(false, source); }
@@ -43,7 +44,8 @@ public abstract class IntegerPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("intAs32BitUnsignedValue:")
+  @Primitive(primitive = "intAs32BitUnsignedValue:",
+             selector = "as32BitUnsignedValue", receiverType = Long.class)
   public abstract static class As32BitUnsignedValue extends UnaryBasicOperation {
     public As32BitUnsignedValue(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
     public As32BitUnsignedValue(final SourceSection source) { super(false, source); }
@@ -64,7 +66,7 @@ public abstract class IntegerPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("intFromString:")
+  @Primitive(primitive = "intFromString:")
   public abstract static class FromStringPrim extends UnaryExpressionNode {
     public FromStringPrim(final SourceSection source) { super(false, source); }
 
@@ -91,7 +93,7 @@ public abstract class IntegerPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("int:leftShift:")
+  @Primitive(primitive = "int:leftShift:", selector = "<<", receiverType = Long.class)
   public abstract static class LeftShiftPrim extends ArithmeticPrim {
     protected LeftShiftPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
     protected LeftShiftPrim(final SourceSection source) { super(false, source); }
@@ -120,7 +122,8 @@ public abstract class IntegerPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("int:unsignedRightShift:")
+  @Primitive(primitive = "int:unsignedRightShift:", selector = ">>>",
+             receiverType = Long.class)
   public abstract static class UnsignedRightShiftPrim extends ArithmeticPrim {
     protected UnsignedRightShiftPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
     protected UnsignedRightShiftPrim(final SourceSection source) { super(false, source); }
@@ -131,6 +134,8 @@ public abstract class IntegerPrims {
     }
   }
 
+  @GenerateNodeFactory
+  @Primitive(selector = "max:", receiverType = Long.class, disabled = true)
   public abstract static class MaxIntPrim extends ArithmeticPrim {
     protected MaxIntPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
     protected MaxIntPrim(final SourceSection source) { super(false, source); }
@@ -141,6 +146,8 @@ public abstract class IntegerPrims {
     }
   }
 
+  @GenerateNodeFactory
+  @Primitive(selector = "to:", receiverType = Long.class, disabled = true)
   public abstract static class ToPrim extends BinaryComplexOperation {
     protected ToPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
     protected ToPrim(final SourceSection source) { super(false, source); }
@@ -156,6 +163,8 @@ public abstract class IntegerPrims {
     }
   }
 
+  @GenerateNodeFactory
+  @Primitive(selector = "abs", receiverType = Long.class)
   public abstract static class AbsPrim extends UnaryBasicOperation {
     public AbsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
     public AbsPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/MethodPrims.java
+++ b/src/som/primitives/MethodPrims.java
@@ -21,7 +21,7 @@ import som.vmobjects.SInvokable;
 public final class MethodPrims {
 
   @GenerateNodeFactory
-  @Primitive("methodName:")
+  @Primitive(primitive = "methodName:")
   public abstract static class SignaturePrim extends UnaryExpressionNode {
     public SignaturePrim(final SourceSection source) { super(false, source); }
 

--- a/src/som/primitives/MethodPrims.java
+++ b/src/som/primitives/MethodPrims.java
@@ -13,6 +13,7 @@ import som.interpreter.nodes.dispatch.InvokeOnCache;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
 import som.primitives.arrays.ToArgumentsArrayNode;
+import som.primitives.arrays.ToArgumentsArrayNodeFactory;
 import som.vmobjects.SAbstractObject;
 import som.vmobjects.SArray;
 import som.vmobjects.SInvokable;
@@ -23,7 +24,7 @@ public final class MethodPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "methodName:")
   public abstract static class SignaturePrim extends UnaryExpressionNode {
-    public SignaturePrim(final SourceSection source) { super(false, source); }
+    public SignaturePrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SAbstractObject doSMethod(final SInvokable receiver) {
@@ -38,8 +39,10 @@ public final class MethodPrims {
     @NodeChild(value = "somArr", type = ExpressionNode.class),
     @NodeChild(value = "argArr", type = ToArgumentsArrayNode.class,
                executeWith = {"somArr", "target"})})
+  @Primitive(selector = "invokeOn:with:", noWrapper = true,
+             extraChild = ToArgumentsArrayNodeFactory.class)
   public abstract static class InvokeOnPrim extends ExprWithTagsNode
-    implements PreevaluatedExpression {
+      implements PreevaluatedExpression {
     @Child private InvokeOnCache callNode;
 
     public InvokeOnPrim(final SourceSection source) {

--- a/src/som/primitives/MirrorPrims.java
+++ b/src/som/primitives/MirrorPrims.java
@@ -29,7 +29,7 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "objNestedClasses:")
   public abstract static class NestedClassesPrim extends UnaryExpressionNode {
-    public NestedClassesPrim(final SourceSection source) { super(false, source); }
+    public NestedClassesPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SMutableArray getNestedClasses(final SObjectWithClass rcvr) {
@@ -41,7 +41,7 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "obj:respondsTo:")
   public abstract static class RespondsToPrim extends BinaryComplexOperation {
-    protected RespondsToPrim(final SourceSection source) { super(false, source); }
+    protected RespondsToPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final boolean objectResondsTo(final Object rcvr, final SSymbol selector) {
@@ -53,7 +53,7 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "objMethods:")
   public abstract static class MethodsPrim extends UnaryExpressionNode {
-    public MethodsPrim(final SourceSection source) { super(false, source); }
+    public MethodsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SImmutableArray getMethod(final Object rcvr) {
@@ -67,8 +67,8 @@ public abstract class MirrorPrims {
   @Primitive(primitive = "obj:perform:")
   public abstract static class PerformPrim extends BinaryComplexOperation {
     @Child protected AbstractSymbolDispatch dispatch;
-    public PerformPrim(final SourceSection source) {
-      super(false, source);
+    public PerformPrim(final boolean eagWrap, final SourceSection source) {
+      super(eagWrap, source);
       dispatch = AbstractSymbolDispatchNodeGen.create(source);
     }
 
@@ -82,7 +82,7 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "classDefinition:")
   public abstract static class ClassDefinitionPrim extends UnaryExpressionNode {
-    public ClassDefinitionPrim(final SourceSection source) { super(false, source); }
+    public ClassDefinitionPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final Object getClassDefinition(final SClass rcvr) {
@@ -93,7 +93,7 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "classDefNestedClassDefinitions:")
   public abstract static class NestedClassDefinitionsPrim extends UnaryExpressionNode {
-    public NestedClassDefinitionsPrim(final SourceSection source) { super(false, source); }
+    public NestedClassDefinitionsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final Object getClassDefinition(final Object mixinHandle) {
@@ -107,7 +107,7 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "classDefName:")
   public abstract static class ClassDefNamePrim extends UnaryExpressionNode {
-    public ClassDefNamePrim(final SourceSection source) { super(false, source); }
+    public ClassDefNamePrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SSymbol getName(final Object mixinHandle) {
@@ -120,7 +120,7 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "classDefMethods:")
   public abstract static class ClassDefMethodsPrim extends UnaryExpressionNode {
-    public ClassDefMethodsPrim(final SourceSection source) { super(false, source); }
+    public ClassDefMethodsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SImmutableArray getName(final Object mixinHandle) {
@@ -141,7 +141,7 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "classDef:hasFactoryMethod:")
   public abstract static class ClassDefHasFactoryMethodPrim extends BinaryComplexOperation {
-    protected ClassDefHasFactoryMethodPrim(final SourceSection source) { super(false, source); }
+    protected ClassDefHasFactoryMethodPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final boolean hasFactoryMethod(final Object mixinHandle,

--- a/src/som/primitives/MirrorPrims.java
+++ b/src/som/primitives/MirrorPrims.java
@@ -27,7 +27,7 @@ import som.vmobjects.SSymbol;
 public abstract class MirrorPrims {
 
   @GenerateNodeFactory
-  @Primitive("objNestedClasses:")
+  @Primitive(primitive = "objNestedClasses:")
   public abstract static class NestedClassesPrim extends UnaryExpressionNode {
     public NestedClassesPrim(final SourceSection source) { super(false, source); }
 
@@ -39,7 +39,7 @@ public abstract class MirrorPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("obj:respondsTo:")
+  @Primitive(primitive = "obj:respondsTo:")
   public abstract static class RespondsToPrim extends BinaryComplexOperation {
     protected RespondsToPrim(final SourceSection source) { super(false, source); }
 
@@ -51,7 +51,7 @@ public abstract class MirrorPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("objMethods:")
+  @Primitive(primitive = "objMethods:")
   public abstract static class MethodsPrim extends UnaryExpressionNode {
     public MethodsPrim(final SourceSection source) { super(false, source); }
 
@@ -64,7 +64,7 @@ public abstract class MirrorPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("obj:perform:")
+  @Primitive(primitive = "obj:perform:")
   public abstract static class PerformPrim extends BinaryComplexOperation {
     @Child protected AbstractSymbolDispatch dispatch;
     public PerformPrim(final SourceSection source) {
@@ -80,7 +80,7 @@ public abstract class MirrorPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("classDefinition:")
+  @Primitive(primitive = "classDefinition:")
   public abstract static class ClassDefinitionPrim extends UnaryExpressionNode {
     public ClassDefinitionPrim(final SourceSection source) { super(false, source); }
 
@@ -91,7 +91,7 @@ public abstract class MirrorPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("classDefNestedClassDefinitions:")
+  @Primitive(primitive = "classDefNestedClassDefinitions:")
   public abstract static class NestedClassDefinitionsPrim extends UnaryExpressionNode {
     public NestedClassDefinitionsPrim(final SourceSection source) { super(false, source); }
 
@@ -105,7 +105,7 @@ public abstract class MirrorPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("classDefName:")
+  @Primitive(primitive = "classDefName:")
   public abstract static class ClassDefNamePrim extends UnaryExpressionNode {
     public ClassDefNamePrim(final SourceSection source) { super(false, source); }
 
@@ -118,7 +118,7 @@ public abstract class MirrorPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("classDefMethods:")
+  @Primitive(primitive = "classDefMethods:")
   public abstract static class ClassDefMethodsPrim extends UnaryExpressionNode {
     public ClassDefMethodsPrim(final SourceSection source) { super(false, source); }
 
@@ -139,7 +139,7 @@ public abstract class MirrorPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("classDef:hasFactoryMethod:")
+  @Primitive(primitive = "classDef:hasFactoryMethod:")
   public abstract static class ClassDefHasFactoryMethodPrim extends BinaryComplexOperation {
     protected ClassDefHasFactoryMethodPrim(final SourceSection source) { super(false, source); }
 

--- a/src/som/primitives/ObjectPrims.java
+++ b/src/som/primitives/ObjectPrims.java
@@ -41,7 +41,7 @@ public final class ObjectPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "objClassName:")
   public abstract static class ObjectClassNamePrim extends UnaryExpressionNode {
-    public ObjectClassNamePrim(final SourceSection source) { super(false, source); }
+    public ObjectClassNamePrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SSymbol getName(final Object obj) {
@@ -53,7 +53,7 @@ public final class ObjectPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "halt:")
   public abstract static class HaltPrim extends UnaryExpressionNode {
-    public HaltPrim(final SourceSection source) { super(false, source); }
+    public HaltPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final Object doSAbstractObject(final Object receiver) {
@@ -90,7 +90,7 @@ public final class ObjectPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "objClass:")
   public abstract static class ClassPrim extends UnaryExpressionNode {
-    public ClassPrim(final SourceSection source) { super(false, source); }
+    public ClassPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SClass doSAbstractObject(final SAbstractObject receiver) {
@@ -107,8 +107,7 @@ public final class ObjectPrims {
   @GenerateNodeFactory
   @Primitive(selector = "isNil", noWrapper = true)
   public abstract static class IsNilNode extends UnaryBasicOperation {
-    public IsNilNode(final boolean eagerWrapper, final SourceSection source) { super(eagerWrapper, source); }
-    public IsNilNode(final SourceSection source) { super(false, source); }
+    public IsNilNode(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
@@ -128,8 +127,7 @@ public final class ObjectPrims {
   @GenerateNodeFactory
   @Primitive(selector = "notNil", noWrapper = true)
   public abstract static class NotNilNode extends UnaryBasicOperation {
-    public NotNilNode(final boolean eagerWrapper, final SourceSection source) { super(eagerWrapper, source); }
-    public NotNilNode(final SourceSection source) { super(false, source); }
+    public NotNilNode(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
@@ -154,12 +152,13 @@ public final class ObjectPrims {
   @ImportStatic(Nil.class)
   @Instrumentable(factory = IsValueWrapper.class)
   public abstract static class IsValue extends UnaryExpressionNode {
-    public IsValue(final SourceSection source) { super(false, source); }
+    public IsValue(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
+    public IsValue(final IsValue node) { super(node); }
 
     public abstract boolean executeEvaluated(Object rcvr);
 
     public static IsValue createSubNode() {
-      return IsValueFactory.create(null, null);
+      return IsValueFactory.create(false, null, null);
     }
 
     @Specialization

--- a/src/som/primitives/ObjectPrims.java
+++ b/src/som/primitives/ObjectPrims.java
@@ -39,7 +39,7 @@ import tools.dym.Tags.OpComparison;
 public final class ObjectPrims {
 
   @GenerateNodeFactory
-  @Primitive("objClassName:")
+  @Primitive(primitive = "objClassName:")
   public abstract static class ObjectClassNamePrim extends UnaryExpressionNode {
     public ObjectClassNamePrim(final SourceSection source) { super(false, source); }
 
@@ -51,7 +51,7 @@ public final class ObjectPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("halt:")
+  @Primitive(primitive = "halt:")
   public abstract static class HaltPrim extends UnaryExpressionNode {
     public HaltPrim(final SourceSection source) { super(false, source); }
 
@@ -88,7 +88,7 @@ public final class ObjectPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("objClass:")
+  @Primitive(primitive = "objClass:")
   public abstract static class ClassPrim extends UnaryExpressionNode {
     public ClassPrim(final SourceSection source) { super(false, source); }
 
@@ -104,7 +104,10 @@ public final class ObjectPrims {
     }
   }
 
+  @GenerateNodeFactory
+  @Primitive(selector = "isNil", noWrapper = true)
   public abstract static class IsNilNode extends UnaryBasicOperation {
+    public IsNilNode(final boolean eagerWrapper, final SourceSection source) { super(eagerWrapper, source); }
     public IsNilNode(final SourceSection source) { super(false, source); }
 
     @Override
@@ -122,7 +125,10 @@ public final class ObjectPrims {
     }
   }
 
+  @GenerateNodeFactory
+  @Primitive(selector = "notNil", noWrapper = true)
   public abstract static class NotNilNode extends UnaryBasicOperation {
+    public NotNilNode(final boolean eagerWrapper, final SourceSection source) { super(eagerWrapper, source); }
     public NotNilNode(final SourceSection source) { super(false, source); }
 
     @Override
@@ -144,7 +150,7 @@ public final class ObjectPrims {
    * A node that checks whether a given object is a Value.
    */
   @GenerateNodeFactory
-  @Primitive("objIsValue:")
+  @Primitive(primitive = "objIsValue:")
   @ImportStatic(Nil.class)
   @Instrumentable(factory = IsValueWrapper.class)
   public abstract static class IsValue extends UnaryExpressionNode {

--- a/src/som/primitives/ObjectSystemPrims.java
+++ b/src/som/primitives/ObjectSystemPrims.java
@@ -12,7 +12,7 @@ import som.vmobjects.SObject;
 public abstract class ObjectSystemPrims {
 
   @GenerateNodeFactory
-  @Primitive("kernelObject:")
+  @Primitive(primitive = "kernelObject:")
   public abstract static class KernelObjectPrim extends UnaryExpressionNode {
     public KernelObjectPrim(final SourceSection source) { super(false, source); }
 

--- a/src/som/primitives/ObjectSystemPrims.java
+++ b/src/som/primitives/ObjectSystemPrims.java
@@ -14,7 +14,7 @@ public abstract class ObjectSystemPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "kernelObject:")
   public abstract static class KernelObjectPrim extends UnaryExpressionNode {
-    public KernelObjectPrim(final SourceSection source) { super(false, source); }
+    public KernelObjectPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SObject getKernel(final Object self) {

--- a/src/som/primitives/Primitive.java
+++ b/src/som/primitives/Primitive.java
@@ -1,17 +1,48 @@
 package som.primitives;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import som.vm.Primitives.Specializer;
+
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
+@Repeatable(Primitive.Container.class)
 public @interface Primitive {
 
   /** Name of the selector, for which the primitive is to be installed. */
-  String[] value();
+  String primitive() default "";
   // TODO: additional hints for instantiation
 
+  /** Selector for eager replacement. */
+  String selector() default "";
+
+  /** Expected type of receiver for eager replacement. */
+  Class<?>[] receiverType() default {};
+
+  /**
+   * The specializer is used to check when eager specialization is to be
+   * applied and to construct the node. */
+  Class<? extends Specializer> specializer() default Specializer.class;
+
+  /** Disabled for Dynamic Metrics. */
+  boolean disabled() default false;
+
+  /**
+   * Disable the eager primitive wrapper.
+   *
+   * This should only be used for nodes that are specifically designed
+   * to handle all possible cases themselves.
+   */
+  boolean noWrapper() default false;
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE})
+  public @interface Container {
+    Primitive[] value();
+  }
 }

--- a/src/som/primitives/Primitive.java
+++ b/src/som/primitives/Primitive.java
@@ -6,6 +6,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.oracle.truffle.api.dsl.NodeFactory;
+import com.oracle.truffle.api.dsl.internal.NodeFactoryBase;
+
 import som.vm.Primitives.Specializer;
 
 
@@ -16,18 +19,29 @@ public @interface Primitive {
 
   /** Name of the selector, for which the primitive is to be installed. */
   String primitive() default "";
-  // TODO: additional hints for instantiation
 
   /** Selector for eager replacement. */
   String selector() default "";
 
-  /** Expected type of receiver for eager replacement. */
+  /**
+   * Expected type of receiver for eager replacement,
+   * if given one of the types needs to match.
+   */
   Class<?>[] receiverType() default {};
 
   /**
    * The specializer is used to check when eager specialization is to be
-   * applied and to construct the node. */
+   * applied and to construct the node.
+   */
+  @SuppressWarnings("rawtypes")
   Class<? extends Specializer> specializer() default Specializer.class;
+
+  /** A factory for an extra child node that is passed as last argument. */
+  @SuppressWarnings("rawtypes")
+  Class<? extends NodeFactory> extraChild() default NodeFactoryBase.class;
+
+  /** Pass array of evaluated arguments to node constructor. */
+  boolean requiresArguments() default false;
 
   /** Disabled for Dynamic Metrics. */
   boolean disabled() default false;

--- a/src/som/primitives/SizeAndLengthPrim.java
+++ b/src/som/primitives/SizeAndLengthPrim.java
@@ -12,7 +12,8 @@ import tools.dym.Tags.OpLength;
 
 
 @GenerateNodeFactory
-@Primitive({"arraySize:", "stringLength:"})
+@Primitive(primitive = "arraySize:",    selector = "size",   receiverType = SArray.class)
+@Primitive(primitive = "stringLength:", selector = "length", receiverType = String.class)
 public abstract class SizeAndLengthPrim extends UnaryBasicOperation {
   private final ValueProfile storageType = ValueProfile.createClassProfile();
 

--- a/src/som/primitives/SizeAndLengthPrim.java
+++ b/src/som/primitives/SizeAndLengthPrim.java
@@ -18,7 +18,6 @@ public abstract class SizeAndLengthPrim extends UnaryBasicOperation {
   private final ValueProfile storageType = ValueProfile.createClassProfile();
 
   public SizeAndLengthPrim(final boolean eagerlyWrapped, final SourceSection source) { super(eagerlyWrapped, source); }
-  public SizeAndLengthPrim(final SourceSection source) { super(false, source); }
 
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {

--- a/src/som/primitives/StringPrims.java
+++ b/src/som/primitives/StringPrims.java
@@ -19,7 +19,7 @@ import tools.dym.Tags.StringAccess;
 public class StringPrims {
 
   @GenerateNodeFactory
-  @Primitive("string:concat:")
+  @Primitive(primitive = "string:concat:")
   public abstract static class ConcatPrim extends BinaryComplexOperation {
     protected ConcatPrim(final SourceSection source) { super(false, source); }
 
@@ -54,7 +54,7 @@ public class StringPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("stringAsSymbol:")
+  @Primitive(primitive = "stringAsSymbol:")
   public abstract static class AsSymbolPrim extends UnaryBasicOperation {
     public AsSymbolPrim(final SourceSection source) { super(false, source); }
 
@@ -79,7 +79,8 @@ public class StringPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("string:substringFrom:to:")
+  @Primitive(primitive = "string:substringFrom:to:",
+             selector = "substringFrom:to:", receiverType = String.class)
   public abstract static class SubstringPrim extends TernaryExpressionNode {
     public SubstringPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
     public SubstringPrim(final SourceSection source) { super(false, source); }
@@ -129,7 +130,7 @@ public class StringPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("string:charAt:")
+  @Primitive(primitive = "string:charAt:", selector = "charAt:", receiverType = String.class)
   public abstract static class CharAtPrim extends BinaryExpressionNode {
     public CharAtPrim(final boolean eagerWrap, final SourceSection source) { super(eagerWrap, source); }
     public CharAtPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/StringPrims.java
+++ b/src/som/primitives/StringPrims.java
@@ -21,7 +21,7 @@ public class StringPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "string:concat:")
   public abstract static class ConcatPrim extends BinaryComplexOperation {
-    protected ConcatPrim(final SourceSection source) { super(false, source); }
+    protected ConcatPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
@@ -56,7 +56,7 @@ public class StringPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "stringAsSymbol:")
   public abstract static class AsSymbolPrim extends UnaryBasicOperation {
-    public AsSymbolPrim(final SourceSection source) { super(false, source); }
+    public AsSymbolPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
@@ -83,7 +83,6 @@ public class StringPrims {
              selector = "substringFrom:to:", receiverType = String.class)
   public abstract static class SubstringPrim extends TernaryExpressionNode {
     public SubstringPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-    public SubstringPrim(final SourceSection source) { super(false, source); }
 
     private final BranchProfile invalidArgs = BranchProfile.create();
 
@@ -133,7 +132,6 @@ public class StringPrims {
   @Primitive(primitive = "string:charAt:", selector = "charAt:", receiverType = String.class)
   public abstract static class CharAtPrim extends BinaryExpressionNode {
     public CharAtPrim(final boolean eagerWrap, final SourceSection source) { super(eagerWrap, source); }
-    public CharAtPrim(final SourceSection source) { super(false, source); }
 
     private final BranchProfile invalidArgs = BranchProfile.create();
 

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -30,10 +30,12 @@ import som.interop.ValueConversion.ToSomConversion;
 import som.interop.ValueConversionFactory.ToSomConversionNodeGen;
 import som.interpreter.Invokable;
 import som.interpreter.SomLanguage;
+import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
 import som.interpreter.nodes.nary.UnaryBasicOperation;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
 import som.vm.NotYetImplementedException;
+import som.vm.Primitives.Specializer;
 import som.vm.constants.Classes;
 import som.vm.constants.Nil;
 import som.vmobjects.SArray;
@@ -47,7 +49,7 @@ public final class SystemPrims {
   @CompilationFinal public static SObjectWithClass SystemModule;
 
   @GenerateNodeFactory
-  @Primitive("systemModuleObject:")
+  @Primitive(primitive = "systemModuleObject:")
   public abstract static class SystemModuleObjectPrim extends UnaryExpressionNode {
     public SystemModuleObjectPrim(final SourceSection source) { super(false, source); }
 
@@ -70,7 +72,7 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("load:")
+  @Primitive(primitive = "load:")
   public abstract static class LoadPrim extends UnaryExpressionNode {
     @Child protected FindContextNode<VM> findContext = SomLanguage.INSTANCE.createNewFindContextNode();
 
@@ -83,7 +85,7 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("load:nextTo:")
+  @Primitive(primitive = "load:nextTo:")
   public abstract static class LoadNextToPrim extends BinaryComplexOperation {
     @Child protected FindContextNode<VM> findContext = SomLanguage.INSTANCE.createNewFindContextNode();
 
@@ -99,7 +101,7 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("exit:")
+  @Primitive(primitive = "exit:")
   public abstract static class ExitPrim extends UnaryExpressionNode {
     public ExitPrim(final SourceSection source) { super(false, source); }
 
@@ -111,7 +113,7 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("printString:")
+  @Primitive(primitive = "printString:")
   public abstract static class PrintStringPrim extends UnaryExpressionNode {
     public PrintStringPrim(final SourceSection source) { super(false, source); }
 
@@ -128,7 +130,7 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("printNewline:")
+  @Primitive(primitive = "printNewline:")
   public abstract static class PrintInclNewlinePrim extends UnaryExpressionNode {
     public PrintInclNewlinePrim(final SourceSection source) { super(false, source); }
 
@@ -140,7 +142,7 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("printStackTrace:")
+  @Primitive(primitive = "printStackTrace:")
   public abstract static class PrintStackTracePrim extends UnaryExpressionNode {
     public PrintStackTracePrim(final SourceSection source) { super(false, source); }
 
@@ -196,7 +198,7 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("vmArguments:")
+  @Primitive(primitive = "vmArguments:")
   public abstract static class VMArgumentsPrim extends UnaryExpressionNode {
     public VMArgumentsPrim(final SourceSection source) { super(false, source); }
 
@@ -207,7 +209,7 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("systemGC:")
+  @Primitive(primitive = "systemGC:")
   public abstract static class FullGCPrim extends UnaryExpressionNode {
     public FullGCPrim(final SourceSection source) { super(false, source); }
 
@@ -219,7 +221,7 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("systemTime:")
+  @Primitive(primitive = "systemTime:")
   public abstract static class TimePrim extends UnaryBasicOperation {
     public TimePrim(final SourceSection source) { super(false, source); }
 
@@ -229,9 +231,18 @@ public final class SystemPrims {
     }
   }
 
+  public static class IsSystemModule extends Specializer {
+    @Override
+    public boolean matches(final Primitive prim, final Object receiver, ExpressionNode[] args) {
+      return receiver == SystemPrims.SystemModule;
+    }
+  }
+
   @GenerateNodeFactory
-  @Primitive("systemTicks:")
+  @Primitive(primitive = "systemTicks:", selector = "ticks",
+             specializer = IsSystemModule.class, noWrapper = true)
   public abstract static class TicksPrim extends UnaryBasicOperation {
+    public TicksPrim(final boolean eagerWrapper, final SourceSection source) { super(eagerWrapper, source); }
     public TicksPrim(final SourceSection source) { super(false, source); }
 
     @Specialization
@@ -241,7 +252,7 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("systemExport:as:")
+  @Primitive(primitive = "systemExport:as:")
   public abstract static class ExportAsPrim extends BinaryComplexOperation {
     @Child protected FindContextNode<VM> findContext;
 
@@ -264,7 +275,7 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive("systemApply:with:")
+  @Primitive(primitive = "systemApply:with:")
   public abstract static class ApplyWithPrim extends BinaryComplexOperation {
     protected ApplyWithPrim(final SourceSection source) { super(false, source); }
 

--- a/src/som/primitives/UnequalsPrim.java
+++ b/src/som/primitives/UnequalsPrim.java
@@ -14,12 +14,11 @@ import som.vmobjects.SSymbol;
 
 @GenerateNodeFactory
 @ImportStatic(Nil.class)
-@Primitive(selector = "<>")
+//@Primitive(selector = "<>")
 // TODO: this primitive is somehow not correct, needs debugging. Not sure it is fixable
 // perhaps, i is ok to remove certain specializations
 public abstract class UnequalsPrim extends ComparisonPrim {
   protected UnequalsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected UnequalsPrim(final SourceSection source) { super(false, source); }
 
   @Specialization
   public final boolean doBoolean(final boolean left, final boolean right) {

--- a/src/som/primitives/UnequalsPrim.java
+++ b/src/som/primitives/UnequalsPrim.java
@@ -14,6 +14,7 @@ import som.vmobjects.SSymbol;
 
 @GenerateNodeFactory
 @ImportStatic(Nil.class)
+@Primitive(selector = "<>")
 public abstract class UnequalsPrim extends ComparisonPrim {
   protected UnequalsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected UnequalsPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/UnequalsPrim.java
+++ b/src/som/primitives/UnequalsPrim.java
@@ -15,6 +15,8 @@ import som.vmobjects.SSymbol;
 @GenerateNodeFactory
 @ImportStatic(Nil.class)
 @Primitive(selector = "<>")
+// TODO: this primitive is somehow not correct, needs debugging. Not sure it is fixable
+// perhaps, i is ok to remove certain specializations
 public abstract class UnequalsPrim extends ComparisonPrim {
   protected UnequalsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected UnequalsPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/actors/ActorClasses.java
+++ b/src/som/primitives/actors/ActorClasses.java
@@ -16,7 +16,7 @@ import som.vmobjects.SObject.SImmutableObject;
 
 public final class ActorClasses {
   @GenerateNodeFactory
-  @Primitive("actorsFarReferenceClass:")
+  @Primitive(primitive = "actorsFarReferenceClass:")
   public abstract static class SetFarReferenceClassPrim extends UnaryExpressionNode {
     public SetFarReferenceClassPrim(final SourceSection source) { super(false, source); }
 
@@ -28,7 +28,7 @@ public final class ActorClasses {
   }
 
   @GenerateNodeFactory
-  @Primitive("actorsPromiseClass:")
+  @Primitive(primitive = "actorsPromiseClass:")
   public abstract static class SetPromiseClassPrim extends UnaryExpressionNode {
     public SetPromiseClassPrim(final SourceSection source) { super(false, source); }
 
@@ -40,7 +40,7 @@ public final class ActorClasses {
   }
 
   @GenerateNodeFactory
-  @Primitive("actorsPairClass:")
+  @Primitive(primitive = "actorsPairClass:")
   public abstract static class SetPairClassPrim extends UnaryExpressionNode {
     public SetPairClassPrim(final SourceSection source) { super(false, source); }
 
@@ -52,7 +52,7 @@ public final class ActorClasses {
   }
 
   @GenerateNodeFactory
-  @Primitive("actorsResolverClass:")
+  @Primitive(primitive = "actorsResolverClass:")
   public abstract static class SetResolverClassPrim extends UnaryExpressionNode {
     public SetResolverClassPrim(final SourceSection source) { super(false, source); }
 
@@ -66,7 +66,7 @@ public final class ActorClasses {
   @CompilationFinal public static SImmutableObject ActorModule;
 
   @GenerateNodeFactory
-  @Primitive("actorsModule:")
+  @Primitive(primitive = "actorsModule:")
   public abstract static class SetModulePrim extends UnaryExpressionNode {
     public SetModulePrim(final SourceSection source) { super(false, source); }
 

--- a/src/som/primitives/actors/ActorClasses.java
+++ b/src/som/primitives/actors/ActorClasses.java
@@ -18,7 +18,7 @@ public final class ActorClasses {
   @GenerateNodeFactory
   @Primitive(primitive = "actorsFarReferenceClass:")
   public abstract static class SetFarReferenceClassPrim extends UnaryExpressionNode {
-    public SetFarReferenceClassPrim(final SourceSection source) { super(false, source); }
+    public SetFarReferenceClassPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SClass setClass(final SClass value) {
@@ -30,7 +30,7 @@ public final class ActorClasses {
   @GenerateNodeFactory
   @Primitive(primitive = "actorsPromiseClass:")
   public abstract static class SetPromiseClassPrim extends UnaryExpressionNode {
-    public SetPromiseClassPrim(final SourceSection source) { super(false, source); }
+    public SetPromiseClassPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SClass setClass(final SClass value) {
@@ -42,7 +42,7 @@ public final class ActorClasses {
   @GenerateNodeFactory
   @Primitive(primitive = "actorsPairClass:")
   public abstract static class SetPairClassPrim extends UnaryExpressionNode {
-    public SetPairClassPrim(final SourceSection source) { super(false, source); }
+    public SetPairClassPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SClass setClass(final SClass value) {
@@ -54,7 +54,7 @@ public final class ActorClasses {
   @GenerateNodeFactory
   @Primitive(primitive = "actorsResolverClass:")
   public abstract static class SetResolverClassPrim extends UnaryExpressionNode {
-    public SetResolverClassPrim(final SourceSection source) { super(false, source); }
+    public SetResolverClassPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SClass setClass(final SClass value) {
@@ -68,7 +68,7 @@ public final class ActorClasses {
   @GenerateNodeFactory
   @Primitive(primitive = "actorsModule:")
   public abstract static class SetModulePrim extends UnaryExpressionNode {
-    public SetModulePrim(final SourceSection source) { super(false, source); }
+    public SetModulePrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final SImmutableObject setClass(final SImmutableObject value) {

--- a/src/som/primitives/actors/CreateActorPrim.java
+++ b/src/som/primitives/actors/CreateActorPrim.java
@@ -2,44 +2,25 @@ package som.primitives.actors;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeChild;
-import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.VmSettings;
 import som.interpreter.actors.Actor;
 import som.interpreter.actors.SFarReference;
-import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
 import som.primitives.ObjectPrims.IsValue;
 import som.primitives.ObjectPrimsFactory.IsValueFactory;
 import som.primitives.Primitive;
-import som.primitives.actors.CreateActorPrim.Splzr;
-import som.vm.Primitives.Specializer;
+import som.primitives.actors.PromisePrims.IsActorModule;
 
 
 @GenerateNodeFactory
-@Primitive(primitive = "actors:createFromValue:",
-           selector = "createActorFromValue:",
-           specializer   = Splzr.class)
+@Primitive(primitive = "actors:createFromValue:", selector  = "createActorFromValue:",
+           specializer = IsActorModule.class, extraChild = IsValueFactory.class)
 @NodeChild(value = "isValue", type = IsValue.class, executeWith = "receiver")
 public abstract class CreateActorPrim extends BinaryComplexOperation {
-  public static class Splzr extends Specializer {
-    @Override
-    public boolean matches(final Primitive prim, final Object receiver, ExpressionNode[] args) {
-      return receiver == ActorClasses.ActorModule;
-    }
-
-    @Override
-    public <T> T create(final NodeFactory<T> factory, final Object[] arguments,
-        final ExpressionNode[] argNodes, final SourceSection section,
-        final boolean eagerWrapper) {
-      return factory.createNode(section, argNodes[0], argNodes[1],
-          IsValueFactory.create(section, null));
-    }
-  }
-
-  protected CreateActorPrim(final SourceSection source) { super(false, source); }
+  protected CreateActorPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
   @Specialization(guards = "isValue")
   public final SFarReference createActor(final Object nil, final Object value, final boolean isValue) {

--- a/src/som/primitives/actors/CreateActorPrim.java
+++ b/src/som/primitives/actors/CreateActorPrim.java
@@ -2,21 +2,43 @@ package som.primitives.actors;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.VmSettings;
 import som.interpreter.actors.Actor;
 import som.interpreter.actors.SFarReference;
+import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
 import som.primitives.ObjectPrims.IsValue;
+import som.primitives.ObjectPrimsFactory.IsValueFactory;
 import som.primitives.Primitive;
+import som.primitives.actors.CreateActorPrim.Splzr;
+import som.vm.Primitives.Specializer;
 
 
 @GenerateNodeFactory
-@Primitive("actors:createFromValue:")
+@Primitive(primitive = "actors:createFromValue:",
+           selector = "createActorFromValue:",
+           specializer   = Splzr.class)
 @NodeChild(value = "isValue", type = IsValue.class, executeWith = "receiver")
 public abstract class CreateActorPrim extends BinaryComplexOperation {
+  public static class Splzr extends Specializer {
+    @Override
+    public boolean matches(final Primitive prim, final Object receiver, ExpressionNode[] args) {
+      return receiver == ActorClasses.ActorModule;
+    }
+
+    @Override
+    public <T> T create(final NodeFactory<T> factory, final Object[] arguments,
+        final ExpressionNode[] argNodes, final SourceSection section,
+        final boolean eagerWrapper) {
+      return factory.createNode(section, argNodes[0], argNodes[1],
+          IsValueFactory.create(section, null));
+    }
+  }
+
   protected CreateActorPrim(final SourceSection source) { super(false, source); }
 
   @Specialization(guards = "isValue")

--- a/src/som/primitives/actors/PromisePrims.java
+++ b/src/som/primitives/actors/PromisePrims.java
@@ -5,6 +5,7 @@ import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.ImportStatic;
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
@@ -36,17 +37,18 @@ import som.vmobjects.SSymbol;
 
 public final class PromisePrims {
 
-  public static class IsActorModule extends Specializer {
+  public static class IsActorModule extends Specializer<ExpressionNode> {
+    public IsActorModule(final Primitive prim, final NodeFactory<ExpressionNode> fact) { super(prim, fact); }
+
     @Override
-    public boolean matches(final Primitive prim, final Object receiver, ExpressionNode[] args) {
-      return receiver == ActorClasses.ActorModule;
+    public boolean matches(final Object[] args, final ExpressionNode[] argNodes) {
+      return args[0] == ActorClasses.ActorModule;
     }
   }
 
   @GenerateNodeFactory
-  @Primitive(primitive = "actorsCreatePromisePair:",
-             selector = "createPromisePair", specializer = IsActorModule.class,
-             noWrapper = true)
+  @Primitive(primitive = "actorsCreatePromisePair:", selector = "createPromisePair",
+             specializer = IsActorModule.class, noWrapper = true)
   public abstract static class CreatePromisePairPrim extends UnaryExpressionNode {
 
     protected static final DirectCallNode create() {
@@ -56,7 +58,6 @@ public final class PromisePrims {
     }
 
     public CreatePromisePairPrim(final boolean eagerWrapper, final SourceSection source) { super(eagerWrapper, source); }
-    public CreatePromisePairPrim(final SourceSection source) { super(false, source); }
 
     @Specialization
     public final SImmutableObject createPromisePair(final VirtualFrame frame,
@@ -83,7 +84,6 @@ public final class PromisePrims {
     @Child protected RegisterWhenResolved registerNode = new RegisterWhenResolved();
 
     protected WhenResolvedPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-    protected WhenResolvedPrim(final SourceSection source) { super(false, source); }
 
     @Specialization(guards = "blockMethod == callback.getMethod()", limit = "10")
     public final SPromise whenResolved(final SPromise promise,
@@ -129,7 +129,7 @@ public final class PromisePrims {
   @ImportStatic(PromisePrims.class)
   @Primitive(primitive = "actorsFor:onError:")
   public abstract static class OnErrorPrim extends BinaryComplexOperation {
-    protected OnErrorPrim(final SourceSection source) { super(false, source); }
+    protected OnErrorPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization(guards = "blockMethod == callback.getMethod()")
     public final SPromise onError(final SPromise promise,
@@ -145,7 +145,7 @@ public final class PromisePrims {
   @ImportStatic(PromisePrims.class)
   @Primitive(primitive = "actorsFor:on:do:")
   public abstract static class OnExceptionDoPrim extends TernaryExpressionNode {
-    public OnExceptionDoPrim(final SourceSection source) { super(false, source); }
+    public OnExceptionDoPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization(guards = "blockMethod == callback.getMethod()")
     public final SPromise onExceptionDo(final SPromise promise,
@@ -163,7 +163,7 @@ public final class PromisePrims {
   public abstract static class WhenResolvedOnErrorPrim extends TernaryExpressionNode {
     @Child protected RegisterWhenResolved registerNode = new RegisterWhenResolved();
 
-    public WhenResolvedOnErrorPrim(final SourceSection source) { super(false, source); }
+    public WhenResolvedOnErrorPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization(guards = {"resolvedMethod == resolved.getMethod()", "errorMethod == error.getMethod()"})
     public final SPromise whenResolvedOnError(final SPromise promise,

--- a/src/som/primitives/arithmetic/AdditionPrim.java
+++ b/src/som/primitives/arithmetic/AdditionPrim.java
@@ -14,7 +14,9 @@ import som.vmobjects.SSymbol;
 
 
 @GenerateNodeFactory
-@Primitive({"int:add:", "double:add:"})
+@Primitive(primitive = "int:add:")
+@Primitive(primitive = "double:add:")
+@Primitive(selector = "+")
 public abstract class AdditionPrim extends ArithmeticPrim {
   protected AdditionPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected AdditionPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arithmetic/AdditionPrim.java
+++ b/src/som/primitives/arithmetic/AdditionPrim.java
@@ -19,7 +19,6 @@ import som.vmobjects.SSymbol;
 @Primitive(selector = "+")
 public abstract class AdditionPrim extends ArithmeticPrim {
   protected AdditionPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected AdditionPrim(final SourceSection source) { super(false, source); }
 
   @Specialization(rewriteOn = ArithmeticException.class)
   public final long doLong(final long left, final long argument) {

--- a/src/som/primitives/arithmetic/DividePrim.java
+++ b/src/som/primitives/arithmetic/DividePrim.java
@@ -10,7 +10,7 @@ import som.primitives.Primitive;
 
 
 @GenerateNodeFactory
-@Primitive("int:divideBy:")
+@Primitive(primitive = "int:divideBy:", selector = "/")
 public abstract class DividePrim extends ArithmeticPrim {
   protected DividePrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected DividePrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arithmetic/DividePrim.java
+++ b/src/som/primitives/arithmetic/DividePrim.java
@@ -13,7 +13,6 @@ import som.primitives.Primitive;
 @Primitive(primitive = "int:divideBy:", selector = "/")
 public abstract class DividePrim extends ArithmeticPrim {
   protected DividePrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected DividePrim(final SourceSection source) { super(false, source); }
 
   @Specialization
   public final long doLong(final long left, final long right) {

--- a/src/som/primitives/arithmetic/DoubleDivPrim.java
+++ b/src/som/primitives/arithmetic/DoubleDivPrim.java
@@ -13,7 +13,9 @@ import som.vmobjects.SAbstractObject;
 
 
 @GenerateNodeFactory
-@Primitive({"int:divideDouble:", "double:divideDouble:"})
+@Primitive(primitive = "int:divideDouble:")
+@Primitive(primitive = "double:divideDouble:")
+@Primitive(selector = "//")
 public abstract class DoubleDivPrim extends ArithmeticPrim {
   protected DoubleDivPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected DoubleDivPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arithmetic/DoubleDivPrim.java
+++ b/src/som/primitives/arithmetic/DoubleDivPrim.java
@@ -18,7 +18,6 @@ import som.vmobjects.SAbstractObject;
 @Primitive(selector = "//")
 public abstract class DoubleDivPrim extends ArithmeticPrim {
   protected DoubleDivPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected DoubleDivPrim(final SourceSection source) { super(false, source); }
 
   @Specialization
   public final double doDouble(final double left, final double right) {

--- a/src/som/primitives/arithmetic/ExpPrim.java
+++ b/src/som/primitives/arithmetic/ExpPrim.java
@@ -9,7 +9,7 @@ import som.primitives.Primitive;
 
 
 @GenerateNodeFactory
-@Primitive("doubleExp:")
+@Primitive(primitive = "doubleExp:", selector = "exp", receiverType = Double.class)
 public abstract class ExpPrim extends UnaryExpressionNode {
   public ExpPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   public ExpPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arithmetic/ExpPrim.java
+++ b/src/som/primitives/arithmetic/ExpPrim.java
@@ -12,7 +12,6 @@ import som.primitives.Primitive;
 @Primitive(primitive = "doubleExp:", selector = "exp", receiverType = Double.class)
 public abstract class ExpPrim extends UnaryExpressionNode {
   public ExpPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  public ExpPrim(final SourceSection source) { super(false, source); }
 
   @Specialization
   public final double doExp(final double rcvr) {

--- a/src/som/primitives/arithmetic/GreaterThanOrEqualPrim.java
+++ b/src/som/primitives/arithmetic/GreaterThanOrEqualPrim.java
@@ -2,12 +2,16 @@ package som.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.ComparisonPrim;
+import som.primitives.Primitive;
 
 
+@GenerateNodeFactory
+@Primitive(selector = ">=")
 public abstract class GreaterThanOrEqualPrim extends ComparisonPrim {
   protected GreaterThanOrEqualPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected GreaterThanOrEqualPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arithmetic/GreaterThanOrEqualPrim.java
+++ b/src/som/primitives/arithmetic/GreaterThanOrEqualPrim.java
@@ -14,7 +14,6 @@ import som.primitives.Primitive;
 @Primitive(selector = ">=")
 public abstract class GreaterThanOrEqualPrim extends ComparisonPrim {
   protected GreaterThanOrEqualPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected GreaterThanOrEqualPrim(final SourceSection source) { super(false, source); }
 
   @Specialization
   public final boolean doLong(final long left, final long right) {

--- a/src/som/primitives/arithmetic/GreaterThanPrim.java
+++ b/src/som/primitives/arithmetic/GreaterThanPrim.java
@@ -14,7 +14,6 @@ import som.primitives.Primitive;
 @Primitive(selector = ">")
 public abstract class GreaterThanPrim extends ComparisonPrim {
   protected GreaterThanPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected GreaterThanPrim(final SourceSection source) { super(false, source); }
 
   @Specialization
   public final boolean doLong(final long left, final long right) {

--- a/src/som/primitives/arithmetic/GreaterThanPrim.java
+++ b/src/som/primitives/arithmetic/GreaterThanPrim.java
@@ -2,12 +2,16 @@ package som.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.ComparisonPrim;
+import som.primitives.Primitive;
 
 
+@GenerateNodeFactory
+@Primitive(selector = ">")
 public abstract class GreaterThanPrim extends ComparisonPrim {
   protected GreaterThanPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected GreaterThanPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arithmetic/LessThanOrEqualPrim.java
+++ b/src/som/primitives/arithmetic/LessThanOrEqualPrim.java
@@ -2,12 +2,16 @@ package som.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.ComparisonPrim;
+import som.primitives.Primitive;
 
 
+@GenerateNodeFactory
+@Primitive(selector = "<=")
 public abstract class LessThanOrEqualPrim extends ComparisonPrim {
   protected LessThanOrEqualPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected LessThanOrEqualPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arithmetic/LessThanOrEqualPrim.java
+++ b/src/som/primitives/arithmetic/LessThanOrEqualPrim.java
@@ -14,7 +14,6 @@ import som.primitives.Primitive;
 @Primitive(selector = "<=")
 public abstract class LessThanOrEqualPrim extends ComparisonPrim {
   protected LessThanOrEqualPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected LessThanOrEqualPrim(final SourceSection source) { super(false, source); }
 
   @Specialization
   public final boolean doLong(final long left, final long right) {

--- a/src/som/primitives/arithmetic/LessThanPrim.java
+++ b/src/som/primitives/arithmetic/LessThanPrim.java
@@ -11,7 +11,9 @@ import som.primitives.Primitive;
 
 
 @GenerateNodeFactory
-@Primitive({"int:lessThan:", "double:lessThan:"})
+@Primitive(primitive = "int:lessThan:")
+@Primitive(primitive = "double:lessThan:")
+@Primitive(selector = "<")
 public abstract class LessThanPrim extends ComparisonPrim {
   protected LessThanPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected LessThanPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arithmetic/LessThanPrim.java
+++ b/src/som/primitives/arithmetic/LessThanPrim.java
@@ -16,7 +16,6 @@ import som.primitives.Primitive;
 @Primitive(selector = "<")
 public abstract class LessThanPrim extends ComparisonPrim {
   protected LessThanPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected LessThanPrim(final SourceSection source) { super(false, source); }
 
   @Specialization
   public final boolean doLong(final long left, final long right) {

--- a/src/som/primitives/arithmetic/LogPrim.java
+++ b/src/som/primitives/arithmetic/LogPrim.java
@@ -12,7 +12,6 @@ import som.primitives.Primitive;
 @Primitive(primitive = "doubleLog:", selector = "log", receiverType = Double.class)
 public abstract class LogPrim extends UnaryBasicOperation {
   public LogPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  public LogPrim(final SourceSection source) { super(false, source); }
 
   // TODO: assign some specific tag
 

--- a/src/som/primitives/arithmetic/LogPrim.java
+++ b/src/som/primitives/arithmetic/LogPrim.java
@@ -9,7 +9,7 @@ import som.primitives.Primitive;
 
 
 @GenerateNodeFactory
-@Primitive("doubleLog:")
+@Primitive(primitive = "doubleLog:", selector = "log", receiverType = Double.class)
 public abstract class LogPrim extends UnaryBasicOperation {
   public LogPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   public LogPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arithmetic/ModuloPrim.java
+++ b/src/som/primitives/arithmetic/ModuloPrim.java
@@ -10,7 +10,9 @@ import som.primitives.Primitive;
 
 
 @GenerateNodeFactory
-@Primitive({"int:modulo:", "double:modulo:"})
+@Primitive(primitive = "int:modulo:")
+@Primitive(primitive = "double:modulo:")
+@Primitive(selector = "%")
 public abstract class ModuloPrim extends ArithmeticPrim {
   protected ModuloPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected ModuloPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arithmetic/ModuloPrim.java
+++ b/src/som/primitives/arithmetic/ModuloPrim.java
@@ -15,7 +15,6 @@ import som.primitives.Primitive;
 @Primitive(selector = "%")
 public abstract class ModuloPrim extends ArithmeticPrim {
   protected ModuloPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected ModuloPrim(final SourceSection source) { super(false, source); }
 
   @Specialization
   public final double doDouble(final double left, final double right) {

--- a/src/som/primitives/arithmetic/MultiplicationPrim.java
+++ b/src/som/primitives/arithmetic/MultiplicationPrim.java
@@ -16,7 +16,6 @@ import som.primitives.Primitive;
 @Primitive(selector = "*")
 public abstract class MultiplicationPrim extends ArithmeticPrim {
   protected MultiplicationPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected MultiplicationPrim(final SourceSection source) { super(false, source); }
 
   @Specialization(rewriteOn = ArithmeticException.class)
   public final long doLong(final long left, final long right) {

--- a/src/som/primitives/arithmetic/MultiplicationPrim.java
+++ b/src/som/primitives/arithmetic/MultiplicationPrim.java
@@ -11,7 +11,9 @@ import som.primitives.Primitive;
 
 
 @GenerateNodeFactory
-@Primitive({"int:multiply:", "double:multiply:"})
+@Primitive(primitive = "int:multiply:")
+@Primitive(primitive = "double:multiply:")
+@Primitive(selector = "*")
 public abstract class MultiplicationPrim extends ArithmeticPrim {
   protected MultiplicationPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected MultiplicationPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arithmetic/RemainderPrim.java
+++ b/src/som/primitives/arithmetic/RemainderPrim.java
@@ -13,7 +13,6 @@ import som.primitives.Primitive;
 @Primitive(primitive = "int:reminder:", selector = "rem:")
 public abstract class RemainderPrim extends ArithmeticPrim {
   protected RemainderPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected RemainderPrim(final SourceSection source) { super(false, source); }
 
   @Specialization
   public final double doDouble(final double left, final double right) {

--- a/src/som/primitives/arithmetic/RemainderPrim.java
+++ b/src/som/primitives/arithmetic/RemainderPrim.java
@@ -10,7 +10,7 @@ import som.primitives.Primitive;
 
 
 @GenerateNodeFactory
-@Primitive("int:reminder:")
+@Primitive(primitive = "int:reminder:", selector = "rem:")
 public abstract class RemainderPrim extends ArithmeticPrim {
   protected RemainderPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected RemainderPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arithmetic/SinPrim.java
+++ b/src/som/primitives/arithmetic/SinPrim.java
@@ -13,7 +13,6 @@ import tools.dym.Tags.OpArithmetic;
 @Primitive(primitive = "doubleSin:", selector = "sin", receiverType = Double.class)
 public abstract class SinPrim extends UnaryBasicOperation {
   public SinPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  public SinPrim(final SourceSection source) { super(false, source); }
 
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {

--- a/src/som/primitives/arithmetic/SinPrim.java
+++ b/src/som/primitives/arithmetic/SinPrim.java
@@ -10,7 +10,7 @@ import tools.dym.Tags.OpArithmetic;
 
 
 @GenerateNodeFactory
-@Primitive("doubleSin:")
+@Primitive(primitive = "doubleSin:", selector = "sin", receiverType = Double.class)
 public abstract class SinPrim extends UnaryBasicOperation {
   public SinPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   public SinPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arithmetic/SqrtPrim.java
+++ b/src/som/primitives/arithmetic/SqrtPrim.java
@@ -12,7 +12,9 @@ import tools.dym.Tags.OpArithmetic;
 
 
 @GenerateNodeFactory
-@Primitive({"intSqrt:", "doubleSqrt:"})
+@Primitive(primitive = "intSqrt:")
+@Primitive(primitive = "doubleSqrt:")
+@Primitive(selector = "sqrt", receiverType = {Long.class, BigInteger.class, Double.class})
 public abstract class SqrtPrim extends UnaryBasicOperation {
   public SqrtPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   public SqrtPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arithmetic/SqrtPrim.java
+++ b/src/som/primitives/arithmetic/SqrtPrim.java
@@ -17,7 +17,6 @@ import tools.dym.Tags.OpArithmetic;
 @Primitive(selector = "sqrt", receiverType = {Long.class, BigInteger.class, Double.class})
 public abstract class SqrtPrim extends UnaryBasicOperation {
   public SqrtPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  public SqrtPrim(final SourceSection source) { super(false, source); }
 
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {

--- a/src/som/primitives/arithmetic/SubtractionPrim.java
+++ b/src/som/primitives/arithmetic/SubtractionPrim.java
@@ -16,7 +16,6 @@ import som.primitives.Primitive;
 @Primitive(selector = "-")
 public abstract class SubtractionPrim extends ArithmeticPrim {
   protected SubtractionPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected SubtractionPrim(final SourceSection source) { super(false, source); }
 
   @Specialization(rewriteOn = ArithmeticException.class)
   public final long doLong(final long left, final long right) {

--- a/src/som/primitives/arithmetic/SubtractionPrim.java
+++ b/src/som/primitives/arithmetic/SubtractionPrim.java
@@ -11,7 +11,9 @@ import som.primitives.Primitive;
 
 
 @GenerateNodeFactory
-@Primitive({"int:subtract:", "double:subtract:"})
+@Primitive(primitive = "int:subtract:")
+@Primitive(primitive = "double:subtract:")
+@Primitive(selector = "-")
 public abstract class SubtractionPrim extends ArithmeticPrim {
   protected SubtractionPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected SubtractionPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arrays/AtPrim.java
+++ b/src/som/primitives/arrays/AtPrim.java
@@ -13,7 +13,7 @@ import tools.dym.Tags.ArrayRead;
 
 
 @GenerateNodeFactory
-@Primitive("array:at:")
+@Primitive(primitive = "array:at:", selector = "at:", receiverType = SArray.class)
 public abstract class AtPrim extends BinaryBasicOperation {
   private final ValueProfile storageType = ValueProfile.createClassProfile();
 

--- a/src/som/primitives/arrays/AtPrim.java
+++ b/src/som/primitives/arrays/AtPrim.java
@@ -18,7 +18,6 @@ public abstract class AtPrim extends BinaryBasicOperation {
   private final ValueProfile storageType = ValueProfile.createClassProfile();
 
   protected AtPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected AtPrim(final SourceSection source) { super(false, source); }
 
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {

--- a/src/som/primitives/arrays/AtPutPrim.java
+++ b/src/som/primitives/arrays/AtPutPrim.java
@@ -11,6 +11,7 @@ import com.oracle.truffle.api.source.SourceSection;
 import som.interpreter.nodes.nary.TernaryExpressionNode;
 import som.primitives.Primitive;
 import som.vm.constants.Nil;
+import som.vmobjects.SArray;
 import som.vmobjects.SArray.PartiallyEmptyArray;
 import som.vmobjects.SArray.SMutableArray;
 import tools.dym.Tags.ArrayWrite;
@@ -19,7 +20,8 @@ import tools.dym.Tags.BasicPrimitiveOperation;
 
 @GenerateNodeFactory
 @ImportStatic(Nil.class)
-@Primitive("array:at:put:")
+@Primitive(primitive = "array:at:put:", selector = "at:put:",
+           receiverType = SArray.class)
 public abstract class AtPutPrim extends TernaryExpressionNode {
   private final ValueProfile storageType = ValueProfile.createClassProfile();
 

--- a/src/som/primitives/arrays/AtPutPrim.java
+++ b/src/som/primitives/arrays/AtPutPrim.java
@@ -26,7 +26,6 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   private final ValueProfile storageType = ValueProfile.createClassProfile();
 
   protected AtPutPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected AtPutPrim(final SourceSection source) { super(false, source); }
 
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {

--- a/src/som/primitives/arrays/CopyPrim.java
+++ b/src/som/primitives/arrays/CopyPrim.java
@@ -15,7 +15,6 @@ import som.vmobjects.SArray.SMutableArray;
 @Primitive(selector = "copy", receiverType = SArray.class, disabled = true)
 public abstract class CopyPrim extends UnaryExpressionNode {
   public CopyPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  public CopyPrim(final SourceSection source) { super(false, source); }
 
   private final ValueProfile storageType = ValueProfile.createClassProfile();
 

--- a/src/som/primitives/arrays/CopyPrim.java
+++ b/src/som/primitives/arrays/CopyPrim.java
@@ -1,13 +1,18 @@
 package som.primitives.arrays;
 
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.profiles.ValueProfile;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryExpressionNode;
+import som.primitives.Primitive;
+import som.vmobjects.SArray;
 import som.vmobjects.SArray.SMutableArray;
 
 
+@GenerateNodeFactory
+@Primitive(selector = "copy", receiverType = SArray.class, disabled = true)
 public abstract class CopyPrim extends UnaryExpressionNode {
   public CopyPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   public CopyPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/arrays/DoIndexesPrim.java
+++ b/src/som/primitives/arrays/DoIndexesPrim.java
@@ -28,7 +28,7 @@ public abstract class DoIndexesPrim extends BinaryComplexOperation {
     super(eagWrap, source);
     // TODO: tag properly, this is a loop, but without array access
     block = BlockDispatchNodeGen.create();
-    length = SizeAndLengthPrimFactory.create(null, null);
+    length = SizeAndLengthPrimFactory.create(false, null, null);
   }
   public DoIndexesPrim(final SourceSection source) { this(false, source); }
 

--- a/src/som/primitives/arrays/DoIndexesPrim.java
+++ b/src/som/primitives/arrays/DoIndexesPrim.java
@@ -11,6 +11,7 @@ import som.interpreter.nodes.dispatch.BlockDispatchNode;
 import som.interpreter.nodes.dispatch.BlockDispatchNodeGen;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
 import som.interpreter.nodes.specialized.SomLoop;
+import som.primitives.Primitive;
 import som.primitives.SizeAndLengthPrim;
 import som.primitives.SizeAndLengthPrimFactory;
 import som.vmobjects.SArray;
@@ -18,6 +19,7 @@ import som.vmobjects.SBlock;
 
 
 @GenerateNodeFactory
+@Primitive(selector = "doIndexes:", receiverType = SArray.class, disabled = true)
 public abstract class DoIndexesPrim extends BinaryComplexOperation {
   @Child protected BlockDispatchNode block;
   @Child protected SizeAndLengthPrim length;

--- a/src/som/primitives/arrays/DoPrim.java
+++ b/src/som/primitives/arrays/DoPrim.java
@@ -12,6 +12,7 @@ import som.interpreter.nodes.dispatch.BlockDispatchNode;
 import som.interpreter.nodes.dispatch.BlockDispatchNodeGen;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
 import som.interpreter.nodes.specialized.SomLoop;
+import som.primitives.Primitive;
 import som.vm.constants.Nil;
 import som.vmobjects.SArray;
 import som.vmobjects.SArray.PartiallyEmptyArray;
@@ -19,6 +20,7 @@ import som.vmobjects.SBlock;
 
 
 @GenerateNodeFactory
+@Primitive(selector = "do:", receiverType = SArray.class, disabled = true)
 public abstract class DoPrim extends BinaryComplexOperation {
   private final ValueProfile storageType = ValueProfile.createClassProfile();
 

--- a/src/som/primitives/arrays/NewImmutableArrayNode.java
+++ b/src/som/primitives/arrays/NewImmutableArrayNode.java
@@ -1,23 +1,38 @@
 package som.primitives.arrays;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
 
+import som.VmSettings;
+import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.dispatch.BlockDispatchNode;
 import som.interpreter.nodes.dispatch.BlockDispatchNodeGen;
 import som.interpreter.nodes.nary.TernaryExpressionNode;
 import som.interpreter.nodes.specialized.SomLoop;
 import som.primitives.ObjectPrims.IsValue;
 import som.primitives.ObjectPrimsFactory.IsValueFactory;
+import som.primitives.Primitive;
+import som.vm.Primitives.Specializer;
 import som.vm.constants.Classes;
 import som.vmobjects.SArray.SImmutableArray;
 import som.vmobjects.SBlock;
 import som.vmobjects.SClass;
 
 
+@GenerateNodeFactory
+@Primitive(selector = "new:withAll:",
+           specializer = NewImmutableArrayNode.IsValueArrayClass.class)
 public abstract class NewImmutableArrayNode extends TernaryExpressionNode {
+  public static class IsValueArrayClass extends Specializer {
+    @Override
+    public boolean matches(final Primitive prim, final Object receiver, ExpressionNode[] args) {
+      return !VmSettings.DYNAMIC_METRICS && receiver == Classes.valueArrayClass;
+    }
+  }
+
   public NewImmutableArrayNode(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   public NewImmutableArrayNode(final SourceSection source) { super(false, source); }
 

--- a/src/som/primitives/arrays/NewImmutableArrayNode.java
+++ b/src/som/primitives/arrays/NewImmutableArrayNode.java
@@ -2,6 +2,7 @@ package som.primitives.arrays;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
@@ -26,18 +27,19 @@ import som.vmobjects.SClass;
 @Primitive(selector = "new:withAll:",
            specializer = NewImmutableArrayNode.IsValueArrayClass.class)
 public abstract class NewImmutableArrayNode extends TernaryExpressionNode {
-  public static class IsValueArrayClass extends Specializer {
+  public static class IsValueArrayClass extends Specializer<NewImmutableArrayNode> {
+    public IsValueArrayClass(final Primitive prim, final NodeFactory<NewImmutableArrayNode> fact) { super(prim, fact); }
+
     @Override
-    public boolean matches(final Primitive prim, final Object receiver, ExpressionNode[] args) {
-      return !VmSettings.DYNAMIC_METRICS && receiver == Classes.valueArrayClass;
+    public boolean matches(final Object[] args, final ExpressionNode[] argNodes) {
+      return !VmSettings.DYNAMIC_METRICS && args[0] == Classes.valueArrayClass;
     }
   }
 
   public NewImmutableArrayNode(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  public NewImmutableArrayNode(final SourceSection source) { super(false, source); }
 
   @Child protected BlockDispatchNode block = BlockDispatchNodeGen.create();
-  @Child protected IsValue isValue = IsValueFactory.create(null, null);
+  @Child protected IsValue isValue = IsValueFactory.create(false, null, null);
 
   public static boolean isValueArrayClass(final SClass valueArrayClass) {
     return Classes.valueArrayClass == valueArrayClass;

--- a/src/som/primitives/arrays/NewPrim.java
+++ b/src/som/primitives/arrays/NewPrim.java
@@ -1,6 +1,7 @@
 package som.primitives.arrays;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -20,15 +21,16 @@ import tools.dym.Tags.NewArray;
 @Primitive(primitive = "array:new:", selector = "new:",
            specializer = NewPrim.IsArrayClass.class)
 public abstract class NewPrim extends BinaryExpressionNode {
-  public static class IsArrayClass extends Specializer {
+  public static class IsArrayClass extends Specializer<NewPrim> {
+    public IsArrayClass(final Primitive prim, final NodeFactory<NewPrim> fact) { super(prim, fact); }
+
     @Override
-    public boolean matches(final Primitive prim, final Object rcvr, ExpressionNode[] args) {
-      return rcvr instanceof SClass && ((SClass) rcvr).isArray();
+    public boolean matches(final Object[] args, final ExpressionNode[] argNodes) {
+      return args[0] instanceof SClass && ((SClass) args[0]).isArray();
     }
   }
 
   public NewPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  public NewPrim(final SourceSection source) { super(false, source); }
 
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {

--- a/src/som/primitives/arrays/NewPrim.java
+++ b/src/som/primitives/arrays/NewPrim.java
@@ -4,8 +4,10 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
 
+import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.BinaryExpressionNode;
 import som.primitives.Primitive;
+import som.vm.Primitives.Specializer;
 import som.vm.constants.Classes;
 import som.vmobjects.SArray.SImmutableArray;
 import som.vmobjects.SArray.SMutableArray;
@@ -15,8 +17,16 @@ import tools.dym.Tags.NewArray;
 
 
 @GenerateNodeFactory
-@Primitive("array:new:")
+@Primitive(primitive = "array:new:", selector = "new:",
+           specializer = NewPrim.IsArrayClass.class)
 public abstract class NewPrim extends BinaryExpressionNode {
+  public static class IsArrayClass extends Specializer {
+    @Override
+    public boolean matches(final Primitive prim, final Object rcvr, ExpressionNode[] args) {
+      return rcvr instanceof SClass && ((SClass) rcvr).isArray();
+    }
+  }
+
   public NewPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   public NewPrim(final SourceSection source) { super(false, source); }
 

--- a/src/som/primitives/arrays/PutAllNode.java
+++ b/src/som/primitives/arrays/PutAllNode.java
@@ -4,15 +4,21 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
 
+import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.dispatch.BlockDispatchNode;
 import som.interpreter.nodes.dispatch.BlockDispatchNodeGen;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
 import som.interpreter.nodes.specialized.SomLoop;
+import som.primitives.Primitive;
 import som.primitives.SizeAndLengthPrim;
+import som.primitives.SizeAndLengthPrimFactory;
+import som.primitives.arrays.PutAllNode.Splzr;
+import som.vm.Primitives.Specializer;
 import som.vm.constants.Nil;
 import som.vmobjects.SArray.SMutableArray;
 import som.vmobjects.SBlock;
@@ -21,8 +27,19 @@ import som.vmobjects.SObjectWithClass;
 
 @GenerateNodeFactory
 @ImportStatic(Nil.class)
+@Primitive(selector = "putAll", disabled = true, specializer = Splzr.class)
 @NodeChild(value = "length", type = SizeAndLengthPrim.class, executeWith = "receiver")
 public abstract class PutAllNode extends BinaryComplexOperation {
+  public static class Splzr extends Specializer {
+    @Override
+    public <T> T create(final NodeFactory<T> factory, final Object[] arguments,
+        final ExpressionNode[] argNodes, final SourceSection section,
+        final boolean eagerWrapper) {
+      assert eagerWrapper;
+      return factory.createNode(true, section, null, null, SizeAndLengthPrimFactory.create(null, null));
+    }
+  }
+
   @Child protected BlockDispatchNode block;
 
   public PutAllNode(final boolean eagWrap, final SourceSection source) {

--- a/src/som/primitives/arrays/PutAllNode.java
+++ b/src/som/primitives/arrays/PutAllNode.java
@@ -4,12 +4,10 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NodeChild;
-import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
 
-import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.dispatch.BlockDispatchNode;
 import som.interpreter.nodes.dispatch.BlockDispatchNodeGen;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
@@ -17,8 +15,6 @@ import som.interpreter.nodes.specialized.SomLoop;
 import som.primitives.Primitive;
 import som.primitives.SizeAndLengthPrim;
 import som.primitives.SizeAndLengthPrimFactory;
-import som.primitives.arrays.PutAllNode.Splzr;
-import som.vm.Primitives.Specializer;
 import som.vm.constants.Nil;
 import som.vmobjects.SArray.SMutableArray;
 import som.vmobjects.SBlock;
@@ -27,19 +23,10 @@ import som.vmobjects.SObjectWithClass;
 
 @GenerateNodeFactory
 @ImportStatic(Nil.class)
-@Primitive(selector = "putAll", disabled = true, specializer = Splzr.class)
+@Primitive(selector = "putAll:", disabled = true,
+           extraChild = SizeAndLengthPrimFactory.class)
 @NodeChild(value = "length", type = SizeAndLengthPrim.class, executeWith = "receiver")
 public abstract class PutAllNode extends BinaryComplexOperation {
-  public static class Splzr extends Specializer {
-    @Override
-    public <T> T create(final NodeFactory<T> factory, final Object[] arguments,
-        final ExpressionNode[] argNodes, final SourceSection section,
-        final boolean eagerWrapper) {
-      assert eagerWrapper;
-      return factory.createNode(true, section, null, null, SizeAndLengthPrimFactory.create(null, null));
-    }
-  }
-
   @Child protected BlockDispatchNode block;
 
   public PutAllNode(final boolean eagWrap, final SourceSection source) {

--- a/src/som/primitives/arrays/ToArgumentsArrayNode.java
+++ b/src/som/primitives/arrays/ToArgumentsArrayNode.java
@@ -2,18 +2,20 @@ package som.primitives.arrays;
 
 import java.util.Arrays;
 
-import som.interpreter.SArguments;
-import som.interpreter.nodes.nary.ExprWithTagsNode;
-import som.vm.constants.Nil;
-import som.vmobjects.SArray;
-
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.profiles.ValueProfile;
 import com.oracle.truffle.api.source.SourceSection;
 
+import som.interpreter.SArguments;
+import som.interpreter.nodes.nary.ExprWithTagsNode;
+import som.vm.constants.Nil;
+import som.vmobjects.SArray;
 
+
+@GenerateNodeFactory
 @NodeChildren({
   @NodeChild("somArray"),
   @NodeChild("receiver")})
@@ -21,6 +23,7 @@ public abstract class ToArgumentsArrayNode extends ExprWithTagsNode {
   private final ValueProfile storageType = ValueProfile.createClassProfile();
 
   public ToArgumentsArrayNode() { super((SourceSection) null); }
+  public ToArgumentsArrayNode(final boolean eagWrap) { this(); } // to have uniform create() for @Primitive
 
   public static final boolean isNull(final Object somArray) {
     return somArray == null;

--- a/src/som/primitives/bitops/BitAndPrim.java
+++ b/src/som/primitives/bitops/BitAndPrim.java
@@ -14,7 +14,6 @@ import som.primitives.arithmetic.ArithmeticPrim;
 @Primitive(primitive = "int:bitAnd:", selector = "&")
 public abstract class BitAndPrim extends ArithmeticPrim {
   protected BitAndPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected BitAndPrim(final SourceSection source) { super(false, source); }
 
   @Specialization
   public final long doLong(final long left, final long right) {

--- a/src/som/primitives/bitops/BitAndPrim.java
+++ b/src/som/primitives/bitops/BitAndPrim.java
@@ -11,7 +11,7 @@ import som.primitives.arithmetic.ArithmeticPrim;
 
 
 @GenerateNodeFactory
-@Primitive("int:bitAnd:")
+@Primitive(primitive = "int:bitAnd:", selector = "&")
 public abstract class BitAndPrim extends ArithmeticPrim {
   protected BitAndPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected BitAndPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/bitops/BitXorPrim.java
+++ b/src/som/primitives/bitops/BitXorPrim.java
@@ -12,7 +12,6 @@ import som.primitives.arithmetic.ArithmeticPrim;
 @Primitive(primitive = "int:bitXor:", selector = "bitXor:")
 public abstract class BitXorPrim extends ArithmeticPrim {
   protected BitXorPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
-  protected BitXorPrim(final SourceSection source) { super(false, source); }
 
   @Specialization
   public final long doLong(final long receiver, final long right) {

--- a/src/som/primitives/bitops/BitXorPrim.java
+++ b/src/som/primitives/bitops/BitXorPrim.java
@@ -9,7 +9,7 @@ import som.primitives.arithmetic.ArithmeticPrim;
 
 
 @GenerateNodeFactory
-@Primitive("int:bitXor:")
+@Primitive(primitive = "int:bitXor:", selector = "bitXor:")
 public abstract class BitXorPrim extends ArithmeticPrim {
   protected BitXorPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
   protected BitXorPrim(final SourceSection source) { super(false, source); }

--- a/src/som/primitives/reflection/AbstractSymbolDispatch.java
+++ b/src/som/primitives/reflection/AbstractSymbolDispatch.java
@@ -15,7 +15,7 @@ import som.interpreter.nodes.MessageSendNode.AbstractMessageSendNode;
 import som.interpreter.nodes.PreevaluatedExpression;
 import som.interpreter.nodes.dispatch.Dispatchable;
 import som.primitives.arrays.ToArgumentsArrayNode;
-import som.primitives.arrays.ToArgumentsArrayNodeGen;
+import som.primitives.arrays.ToArgumentsArrayNodeFactory;
 import som.vmobjects.SArray;
 import som.vmobjects.SSymbol;
 
@@ -51,7 +51,7 @@ public abstract class AbstractSymbolDispatch extends Node {
   }
 
   public static final ToArgumentsArrayNode createArgArrayNode() {
-    return ToArgumentsArrayNodeGen.create(null, null);
+    return ToArgumentsArrayNodeFactory.create(null, null);
   }
 
   @Specialization(limit = "INLINE_CACHE_SIZE", guards = {"selector == cachedSelector", "argsArr == null"})

--- a/src/som/vm/ObjectSystem.java
+++ b/src/som/vm/ObjectSystem.java
@@ -5,25 +5,19 @@ import static som.vm.constants.Classes.metaclassClass;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
-import com.oracle.truffle.api.dsl.GeneratedBy;
-import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.VmSettings;
 import som.compiler.AccessModifier;
-import som.compiler.MethodBuilder;
 import som.compiler.MixinBuilder.MixinDefinitionError;
 import som.compiler.MixinBuilder.MixinDefinitionId;
 import som.compiler.MixinDefinition;
@@ -31,62 +25,12 @@ import som.compiler.MixinDefinition.SlotDefinition;
 import som.compiler.Parser.ParseError;
 import som.compiler.SourcecodeCompiler;
 import som.interpreter.LexicalScope.MixinScope;
-import som.interpreter.Primitive;
 import som.interpreter.SomLanguage;
 import som.interpreter.actors.Actor;
 import som.interpreter.actors.EventualMessage.DirectMessage;
 import som.interpreter.actors.EventualSendNode;
-import som.interpreter.actors.ResolvePromiseNodeFactory;
 import som.interpreter.actors.SPromise;
-import som.interpreter.nodes.ArgumentReadNode.LocalArgumentReadNode;
-import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.dispatch.Dispatchable;
-import som.interpreter.nodes.specialized.AndMessageNodeFactory;
-import som.interpreter.nodes.specialized.NotMessageNodeFactory;
-import som.interpreter.nodes.specialized.whileloops.WhilePrimitiveNodeFactory;
-import som.primitives.AsStringPrimFactory;
-import som.primitives.BlockPrimsFactory;
-import som.primitives.ClassPrimsFactory;
-import som.primitives.CosPrimFactory;
-import som.primitives.DoublePrimsFactory;
-import som.primitives.EqualsEqualsPrimFactory;
-import som.primitives.EqualsPrimFactory;
-import som.primitives.ExceptionsPrimsFactory;
-import som.primitives.HashPrimFactory;
-import som.primitives.IntegerPrimsFactory;
-import som.primitives.MethodPrimsFactory;
-import som.primitives.MethodPrimsFactory.InvokeOnPrimFactory;
-import som.primitives.MirrorPrimsFactory;
-import som.primitives.ObjectPrimsFactory;
-import som.primitives.ObjectPrimsFactory.IsValueFactory;
-import som.primitives.ObjectSystemPrimsFactory;
-import som.primitives.SizeAndLengthPrimFactory;
-import som.primitives.StringPrimsFactory;
-import som.primitives.SystemPrimsFactory;
-import som.primitives.UnequalsPrimFactory;
-import som.primitives.actors.ActorClassesFactory;
-import som.primitives.actors.CreateActorPrimFactory;
-import som.primitives.actors.PromisePrimsFactory;
-import som.primitives.arithmetic.AdditionPrimFactory;
-import som.primitives.arithmetic.DividePrimFactory;
-import som.primitives.arithmetic.DoubleDivPrimFactory;
-import som.primitives.arithmetic.ExpPrimFactory;
-import som.primitives.arithmetic.LessThanPrimFactory;
-import som.primitives.arithmetic.LogPrimFactory;
-import som.primitives.arithmetic.ModuloPrimFactory;
-import som.primitives.arithmetic.MultiplicationPrimFactory;
-import som.primitives.arithmetic.RemainderPrimFactory;
-import som.primitives.arithmetic.SinPrimFactory;
-import som.primitives.arithmetic.SqrtPrimFactory;
-import som.primitives.arithmetic.SubtractionPrimFactory;
-import som.primitives.arrays.AtPrimFactory;
-import som.primitives.arrays.AtPutPrimFactory;
-import som.primitives.arrays.DoIndexesPrimFactory;
-import som.primitives.arrays.NewPrimFactory;
-import som.primitives.arrays.PutAllNodeFactory;
-import som.primitives.arrays.ToArgumentsArrayNodeGen;
-import som.primitives.bitops.BitAndPrimFactory;
-import som.primitives.bitops.BitXorPrimFactory;
 import som.vm.constants.Classes;
 import som.vm.constants.KernelObj;
 import som.vm.constants.Nil;
@@ -160,166 +104,8 @@ public final class ObjectSystem {
     }
   }
 
-  private static SInvokable constructVmMirrorPrimitive(
-      final SSymbol signature,
-      final som.primitives.Primitive primitive,
-      final NodeFactory<? extends ExpressionNode> factory) {
-    CompilerAsserts.neverPartOfCompilation("This is only executed during bootstrapping.");
-    assert signature.getNumberOfSignatureArguments() > 1 :
-      "Primitives should have the vmMirror as receiver, " +
-      "and then at least one object they are applied to";
-
-    // ignore the implicit vmMirror argument
-    final int numArgs = signature.getNumberOfSignatureArguments() - 1;
-
-    Source s = SomLanguage.getSyntheticSource("primitive", factory.getClass().getSimpleName());
-    MethodBuilder prim = new MethodBuilder(true);
-    ExpressionNode[] args = new ExpressionNode[numArgs];
-
-    for (int i = 0; i < numArgs; i++) {
-      // we do not pass the vmMirror, makes it easier to use the same primitives
-      // as replacements on the node level
-      args[i] = new LocalArgumentReadNode(i + 1, s.createSection(1));
-    }
-
-    ExpressionNode primNode;
-    SourceSection source = s.createSection(1);
-    switch (numArgs) {
-      case 1:
-        primNode = factory.createNode(source, args[0]);
-        break;
-      case 2:
-        // HACK for node class where we use `executeWith`
-        if (factory == PutAllNodeFactory.getInstance()) {
-          primNode = factory.createNode(source, args[0], args[1],
-              SizeAndLengthPrimFactory.create(null, null));
-//        } else if (factory == SpawnWithArgsPrimFactory.getInstance()) {
-//          primNode = factory.createNode(args[0], args[1],
-//              ToArgumentsArrayNodeGen.create(null, null));
-        } else if (factory == CreateActorPrimFactory.getInstance()) {
-          primNode = factory.createNode(source, args[0], args[1],
-              IsValueFactory.create(null, null));
-        } else {
-          primNode = factory.createNode(source, args[0], args[1]);
-        }
-        break;
-      case 3:
-        // HACK for node class where we use `executeWith`
-        if (factory == InvokeOnPrimFactory.getInstance()) {
-          primNode = factory.createNode(source, args[0], args[1], args[2],
-              ToArgumentsArrayNodeGen.create(null, null));
-        } else {
-          primNode = factory.createNode(source, args[0], args[1], args[2]);
-        }
-        break;
-      case 4:
-        primNode = factory.createNode(args[0], args[1], args[2], args[3]);
-        break;
-      default:
-        throw new RuntimeException("Not supported by SOM.");
-    }
-
-    String name = "vmMirror>>" + signature.toString();
-
-    Primitive primMethodNode = new Primitive(name, primNode,
-        prim.getCurrentMethodScope().getFrameDescriptor(),
-        (ExpressionNode) primNode.deepCopy());
-    return new SInvokable(signature, AccessModifier.PUBLIC, null,
-        primMethodNode, null);
-  }
-
-  private static List<NodeFactory<? extends ExpressionNode>> getFactories() {
-    List<NodeFactory<? extends ExpressionNode>> allFactories = new ArrayList<>();
-    allFactories.addAll(AndMessageNodeFactory.getFactories());
-    allFactories.addAll(WhilePrimitiveNodeFactory.getFactories());
-    allFactories.addAll(BlockPrimsFactory.getFactories());
-    allFactories.addAll(ClassPrimsFactory.getFactories());
-    allFactories.addAll(DoublePrimsFactory.getFactories());
-    allFactories.addAll(IntegerPrimsFactory.getFactories());
-    allFactories.addAll(MethodPrimsFactory.getFactories());
-    allFactories.addAll(ObjectPrimsFactory.getFactories());
-    allFactories.addAll(StringPrimsFactory.getFactories());
-    allFactories.addAll(SystemPrimsFactory.getFactories());
-    allFactories.addAll(ObjectSystemPrimsFactory.getFactories());
-    allFactories.addAll(MirrorPrimsFactory.getFactories());
-    allFactories.addAll(ExceptionsPrimsFactory.getFactories());
-    allFactories.addAll(ActorClassesFactory.getFactories());
-    allFactories.addAll(PromisePrimsFactory.getFactories());
-
-    allFactories.add(EqualsEqualsPrimFactory.getInstance());
-    allFactories.add(EqualsPrimFactory.getInstance());
-    allFactories.add(NotMessageNodeFactory.getInstance());
-    allFactories.add(AsStringPrimFactory.getInstance());
-    allFactories.add(HashPrimFactory.getInstance());
-    allFactories.add(SizeAndLengthPrimFactory.getInstance());
-    allFactories.add(UnequalsPrimFactory.getInstance());
-    allFactories.add(AdditionPrimFactory.getInstance());
-    allFactories.add(BitXorPrimFactory.getInstance());
-    allFactories.add(BitAndPrimFactory.getInstance());
-    allFactories.add(DividePrimFactory.getInstance());
-    allFactories.add(DoubleDivPrimFactory.getInstance());
-    allFactories.add(LessThanPrimFactory.getInstance());
-    allFactories.add(ModuloPrimFactory.getInstance());
-    allFactories.add(MultiplicationPrimFactory.getInstance());
-    allFactories.add(RemainderPrimFactory.getInstance());
-    allFactories.add(ExpPrimFactory.getInstance());
-    allFactories.add(LogPrimFactory.getInstance());
-    allFactories.add(CosPrimFactory.getInstance());
-    allFactories.add(SinPrimFactory.getInstance());
-    allFactories.add(SqrtPrimFactory.getInstance());
-    allFactories.add(SubtractionPrimFactory.getInstance());
-    allFactories.add(AtPrimFactory.getInstance());
-    allFactories.add(AtPutPrimFactory.getInstance());
-    allFactories.add(DoIndexesPrimFactory.getInstance());
-    allFactories.add(NewPrimFactory.getInstance());
-    allFactories.add(PutAllNodeFactory.getInstance());
-
-    allFactories.add(CreateActorPrimFactory.getInstance());
-    allFactories.add(ResolvePromiseNodeFactory.getInstance());
-
-    return allFactories;
-  }
-
-  private static HashMap<SSymbol, Dispatchable> constructVmMirrorPrimitives() {
-    HashMap<SSymbol, Dispatchable> primitives = new HashMap<>();
-
-    List<NodeFactory<? extends ExpressionNode>> primFacts = getFactories();
-    for (NodeFactory<? extends ExpressionNode> primFact : primFacts) {
-      som.primitives.Primitive prim = getPrimitiveAnnotation(primFact);
-      if (prim != null) {
-        for (String sig : prim.value()) {
-          SSymbol signature = Symbols.symbolFor(sig);
-          primitives.put(signature,
-              constructVmMirrorPrimitive(signature, prim, primFact));
-        }
-      }
-    }
-
-    return primitives;
-  }
-
-  public static som.primitives.Primitive getPrimitiveAnnotation(
-      final NodeFactory<? extends ExpressionNode> primFact) {
-    GeneratedBy[] genAnnotation = primFact.getClass().getAnnotationsByType(
-        GeneratedBy.class);
-
-    assert genAnnotation.length == 1; // should always be exactly one
-
-    Class<?> nodeClass = genAnnotation[0].value();
-    som.primitives.Primitive[] ann = nodeClass.getAnnotationsByType(
-        som.primitives.Primitive.class);
-    som.primitives.Primitive prim;
-    if (ann.length == 1) {
-      prim = ann[0];
-    } else {
-      prim = null;
-      assert ann.length == 0;
-    }
-    return prim;
-  }
-
   private static SObjectWithoutFields constructVmMirror() {
-    HashMap<SSymbol, Dispatchable> vmMirrorMethods = constructVmMirrorPrimitives();
+    HashMap<SSymbol, Dispatchable> vmMirrorMethods = Primitives.constructVmMirrorPrimitives();
     MixinScope scope = new MixinScope(null);
 
     MixinDefinition vmMirrorDef = new MixinDefinition(

--- a/src/som/vm/ObjectSystem.java
+++ b/src/som/vm/ObjectSystem.java
@@ -61,10 +61,13 @@ public final class ObjectSystem {
   private final SourcecodeCompiler compiler;
   private final StructuralProbe structuralProbe;
 
+  private final Primitives primitives;
+
   public ObjectSystem(final SourcecodeCompiler compiler,
       final StructuralProbe probe, final String platformFilename,
       final String kernelFilename) throws IOException {
     last = this;
+    this.primitives = new Primitives();
     this.compiler  = compiler;
     structuralProbe = probe;
     loadedModules  = new LinkedHashMap<>();
@@ -74,6 +77,10 @@ public final class ObjectSystem {
 
   public static boolean isInitialized() {
     return last.initialized;
+  }
+
+  public Primitives getPrimitives() {
+    return primitives;
   }
 
   public SClass getPlatformClass() {
@@ -104,8 +111,8 @@ public final class ObjectSystem {
     }
   }
 
-  private static SObjectWithoutFields constructVmMirror() {
-    HashMap<SSymbol, Dispatchable> vmMirrorMethods = Primitives.constructVmMirrorPrimitives();
+  private SObjectWithoutFields constructVmMirror() {
+    HashMap<SSymbol, Dispatchable> vmMirrorMethods = primitives.takeVmMirrorPrimitives();
     MixinScope scope = new MixinScope(null);
 
     MixinDefinition vmMirrorDef = new MixinDefinition(

--- a/src/som/vm/Primitives.java
+++ b/src/som/vm/Primitives.java
@@ -1,0 +1,229 @@
+package som.vm;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.dsl.GeneratedBy;
+import com.oracle.truffle.api.dsl.NodeFactory;
+import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.api.source.SourceSection;
+
+import som.compiler.AccessModifier;
+import som.compiler.MethodBuilder;
+import som.interpreter.Primitive;
+import som.interpreter.SomLanguage;
+import som.interpreter.actors.ResolvePromiseNodeFactory;
+import som.interpreter.nodes.ArgumentReadNode.LocalArgumentReadNode;
+import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.dispatch.Dispatchable;
+import som.interpreter.nodes.specialized.AndMessageNodeFactory;
+import som.interpreter.nodes.specialized.NotMessageNodeFactory;
+import som.interpreter.nodes.specialized.whileloops.WhilePrimitiveNodeFactory;
+import som.primitives.AsStringPrimFactory;
+import som.primitives.BlockPrimsFactory;
+import som.primitives.ClassPrimsFactory;
+import som.primitives.CosPrimFactory;
+import som.primitives.DoublePrimsFactory;
+import som.primitives.EqualsEqualsPrimFactory;
+import som.primitives.EqualsPrimFactory;
+import som.primitives.ExceptionsPrimsFactory;
+import som.primitives.HashPrimFactory;
+import som.primitives.IntegerPrimsFactory;
+import som.primitives.MethodPrimsFactory;
+import som.primitives.MethodPrimsFactory.InvokeOnPrimFactory;
+import som.primitives.MirrorPrimsFactory;
+import som.primitives.ObjectPrimsFactory;
+import som.primitives.ObjectPrimsFactory.IsValueFactory;
+import som.primitives.ObjectSystemPrimsFactory;
+import som.primitives.SizeAndLengthPrimFactory;
+import som.primitives.StringPrimsFactory;
+import som.primitives.SystemPrimsFactory;
+import som.primitives.UnequalsPrimFactory;
+import som.primitives.actors.ActorClassesFactory;
+import som.primitives.actors.CreateActorPrimFactory;
+import som.primitives.actors.PromisePrimsFactory;
+import som.primitives.arithmetic.AdditionPrimFactory;
+import som.primitives.arithmetic.DividePrimFactory;
+import som.primitives.arithmetic.DoubleDivPrimFactory;
+import som.primitives.arithmetic.ExpPrimFactory;
+import som.primitives.arithmetic.LessThanPrimFactory;
+import som.primitives.arithmetic.LogPrimFactory;
+import som.primitives.arithmetic.ModuloPrimFactory;
+import som.primitives.arithmetic.MultiplicationPrimFactory;
+import som.primitives.arithmetic.RemainderPrimFactory;
+import som.primitives.arithmetic.SinPrimFactory;
+import som.primitives.arithmetic.SqrtPrimFactory;
+import som.primitives.arithmetic.SubtractionPrimFactory;
+import som.primitives.arrays.AtPrimFactory;
+import som.primitives.arrays.AtPutPrimFactory;
+import som.primitives.arrays.DoIndexesPrimFactory;
+import som.primitives.arrays.NewPrimFactory;
+import som.primitives.arrays.PutAllNodeFactory;
+import som.primitives.arrays.ToArgumentsArrayNodeGen;
+import som.primitives.bitops.BitAndPrimFactory;
+import som.primitives.bitops.BitXorPrimFactory;
+import som.vmobjects.SInvokable;
+import som.vmobjects.SSymbol;
+
+public class Primitives {
+  private static som.primitives.Primitive getPrimitiveAnnotation(
+      final NodeFactory<? extends ExpressionNode> primFact) {
+    GeneratedBy[] genAnnotation = primFact.getClass().getAnnotationsByType(
+        GeneratedBy.class);
+
+    assert genAnnotation.length == 1 :
+      "We don't support more than one @Primitive annotation";
+
+    Class<?> nodeClass = genAnnotation[0].value();
+    som.primitives.Primitive[] ann = nodeClass.getAnnotationsByType(
+        som.primitives.Primitive.class);
+    som.primitives.Primitive prim;
+    if (ann.length == 1) {
+      prim = ann[0];
+    } else {
+      prim = null;
+      assert ann.length == 0;
+    }
+    return prim;
+  }
+
+  private static SInvokable constructVmMirrorPrimitive(
+      final SSymbol signature,
+      final som.primitives.Primitive primitive,
+      final NodeFactory<? extends ExpressionNode> factory) {
+    CompilerAsserts.neverPartOfCompilation("This is only executed during bootstrapping.");
+    assert signature.getNumberOfSignatureArguments() > 1 :
+      "Primitives should have the vmMirror as receiver, " +
+      "and then at least one object they are applied to";
+
+    // ignore the implicit vmMirror argument
+    final int numArgs = signature.getNumberOfSignatureArguments() - 1;
+
+    Source s = SomLanguage.getSyntheticSource("primitive", factory.getClass().getSimpleName());
+    MethodBuilder prim = new MethodBuilder(true);
+    ExpressionNode[] args = new ExpressionNode[numArgs];
+
+    for (int i = 0; i < numArgs; i++) {
+      // we do not pass the vmMirror, makes it easier to use the same primitives
+      // as replacements on the node level
+      args[i] = new LocalArgumentReadNode(i + 1, s.createSection(null, 1));
+    }
+
+    ExpressionNode primNode;
+    SourceSection source = s.createSection(null, 1);
+    switch (numArgs) {
+      case 1:
+        primNode = factory.createNode(source, args[0]);
+        break;
+      case 2:
+        // HACK for node class where we use `executeWith`
+        if (factory == PutAllNodeFactory.getInstance()) {
+          primNode = factory.createNode(source, args[0], args[1],
+              SizeAndLengthPrimFactory.create(null, null));
+//        } else if (factory == SpawnWithArgsPrimFactory.getInstance()) {
+//          primNode = factory.createNode(args[0], args[1],
+//              ToArgumentsArrayNodeGen.create(null, null));
+        } else if (factory == CreateActorPrimFactory.getInstance()) {
+          primNode = factory.createNode(source, args[0], args[1],
+              IsValueFactory.create(null, null));
+        } else {
+          primNode = factory.createNode(source, args[0], args[1]);
+        }
+        break;
+      case 3:
+        // HACK for node class where we use `executeWith`
+        if (factory == InvokeOnPrimFactory.getInstance()) {
+          primNode = factory.createNode(source, args[0], args[1], args[2],
+              ToArgumentsArrayNodeGen.create(null, null));
+        } else {
+          primNode = factory.createNode(source, args[0], args[1], args[2]);
+        }
+        break;
+      case 4:
+        primNode = factory.createNode(args[0], args[1], args[2], args[3]);
+        break;
+      default:
+        throw new RuntimeException("Not supported by SOM.");
+    }
+
+    String name = "vmMirror>>" + signature.toString();
+
+    Primitive primMethodNode = new Primitive(name, primNode,
+        prim.getCurrentMethodScope().getFrameDescriptor(),
+        (ExpressionNode) primNode.deepCopy());
+    return new SInvokable(signature, AccessModifier.PUBLIC, null,
+        primMethodNode, null);
+  }
+
+  public static HashMap<SSymbol, Dispatchable> constructVmMirrorPrimitives() {
+    HashMap<SSymbol, Dispatchable> primitives = new HashMap<>();
+
+    List<NodeFactory<? extends ExpressionNode>> primFacts = getFactories();
+    for (NodeFactory<? extends ExpressionNode> primFact : primFacts) {
+      som.primitives.Primitive prim = getPrimitiveAnnotation(primFact);
+      if (prim != null) {
+        for (String sig : prim.value()) {
+          SSymbol signature = Symbols.symbolFor(sig);
+          primitives.put(signature,
+              constructVmMirrorPrimitive(signature, prim, primFact));
+        }
+      }
+    }
+
+    return primitives;
+  }
+
+  private static List<NodeFactory<? extends ExpressionNode>> getFactories() {
+    List<NodeFactory<? extends ExpressionNode>> allFactories = new ArrayList<>();
+    allFactories.addAll(AndMessageNodeFactory.getFactories());
+    allFactories.addAll(WhilePrimitiveNodeFactory.getFactories());
+    allFactories.addAll(BlockPrimsFactory.getFactories());
+    allFactories.addAll(ClassPrimsFactory.getFactories());
+    allFactories.addAll(DoublePrimsFactory.getFactories());
+    allFactories.addAll(IntegerPrimsFactory.getFactories());
+    allFactories.addAll(MethodPrimsFactory.getFactories());
+    allFactories.addAll(ObjectPrimsFactory.getFactories());
+    allFactories.addAll(StringPrimsFactory.getFactories());
+    allFactories.addAll(SystemPrimsFactory.getFactories());
+    allFactories.addAll(ObjectSystemPrimsFactory.getFactories());
+    allFactories.addAll(MirrorPrimsFactory.getFactories());
+    allFactories.addAll(ExceptionsPrimsFactory.getFactories());
+    allFactories.addAll(ActorClassesFactory.getFactories());
+    allFactories.addAll(PromisePrimsFactory.getFactories());
+
+    allFactories.add(EqualsEqualsPrimFactory.getInstance());
+    allFactories.add(EqualsPrimFactory.getInstance());
+    allFactories.add(NotMessageNodeFactory.getInstance());
+    allFactories.add(AsStringPrimFactory.getInstance());
+    allFactories.add(HashPrimFactory.getInstance());
+    allFactories.add(SizeAndLengthPrimFactory.getInstance());
+    allFactories.add(UnequalsPrimFactory.getInstance());
+    allFactories.add(AdditionPrimFactory.getInstance());
+    allFactories.add(BitXorPrimFactory.getInstance());
+    allFactories.add(BitAndPrimFactory.getInstance());
+    allFactories.add(DividePrimFactory.getInstance());
+    allFactories.add(DoubleDivPrimFactory.getInstance());
+    allFactories.add(LessThanPrimFactory.getInstance());
+    allFactories.add(ModuloPrimFactory.getInstance());
+    allFactories.add(MultiplicationPrimFactory.getInstance());
+    allFactories.add(RemainderPrimFactory.getInstance());
+    allFactories.add(ExpPrimFactory.getInstance());
+    allFactories.add(LogPrimFactory.getInstance());
+    allFactories.add(CosPrimFactory.getInstance());
+    allFactories.add(SinPrimFactory.getInstance());
+    allFactories.add(SqrtPrimFactory.getInstance());
+    allFactories.add(SubtractionPrimFactory.getInstance());
+    allFactories.add(AtPrimFactory.getInstance());
+    allFactories.add(AtPutPrimFactory.getInstance());
+    allFactories.add(DoIndexesPrimFactory.getInstance());
+    allFactories.add(NewPrimFactory.getInstance());
+    allFactories.add(PutAllNodeFactory.getInstance());
+
+    allFactories.add(CreateActorPrimFactory.getInstance());
+    allFactories.add(ResolvePromiseNodeFactory.getInstance());
+
+    return allFactories;
+  }
+}

--- a/src/tools/dym/nodes/ArrayAllocationProfilingNode.java
+++ b/src/tools/dym/nodes/ArrayAllocationProfilingNode.java
@@ -14,7 +14,7 @@ public class ArrayAllocationProfilingNode extends CountingNode<ArrayCreationProf
 
   public ArrayAllocationProfilingNode(final ArrayCreationProfile counter) {
     super(counter);
-    size = SizeAndLengthPrimFactory.create(null, null);
+    size = SizeAndLengthPrimFactory.create(false, null, null);
   }
 
   @Override


### PR DESCRIPTION
The goal of this PR is to solve eager primitive specialization properly without having hard-coded switch/case stuff in MessageSendNode.

Currently work in progress.

Open issues:
 - [x] proper naming of members of `@Primitive` annotation
 - general cleanup
 - might want a mechanism to verify that all specialization works, it is easy to forget adding a primitive factory to the list. Could use a annotation processor, but that's complexity, I'd rather like to avoid

/cc
@charig probably relevant for you.
@kjx might be interesting for you, since it would allow to more systematically disable optimizations. If you need something specific, I should add a proper option.