### PR TITLE
Make Stepping in Debugger nicer

### DIFF
--- a/src/som/interpreter/Method.java
+++ b/src/som/interpreter/Method.java
@@ -29,6 +29,7 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.LexicalScope.MethodScope;
 import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.SOMNode;
 
 
 public final class Method extends Invokable {
@@ -118,6 +119,14 @@ public final class Method extends Invokable {
 
   public boolean isBlock() {
     return block;
+  }
+
+  public SourceSection getRootNodeSource() {
+    ExpressionNode root = SOMNode.unwrapIfNecessary(expressionOrSequence);
+    assert root.isMarkedAsRootExpression();
+    assert root.assertIsStatement();
+
+    return root.getSourceSection();
   }
 
   public MethodScope getLexicalScope() {

--- a/src/som/interpreter/Primitive.java
+++ b/src/som/interpreter/Primitive.java
@@ -10,6 +10,7 @@ import com.oracle.truffle.api.nodes.Node;
 
 import som.interpreter.LexicalScope.MethodScope;
 import som.interpreter.nodes.ExpressionNode;
+import som.primitives.ObjectPrims.HaltPrim;
 
 
 public final class Primitive extends Invokable {
@@ -52,7 +53,7 @@ public final class Primitive extends Invokable {
    */
   @Override
   protected boolean isInstrumentable() {
-    return false;
+    return expressionOrSequence instanceof HaltPrim;
   }
 
   private static Method getNextMethodOnStack() {

--- a/src/som/interpreter/actors/ReceivedRootNode.java
+++ b/src/som/interpreter/actors/ReceivedRootNode.java
@@ -3,6 +3,7 @@ package som.interpreter.actors;
 import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -52,6 +53,14 @@ public abstract class ReceivedRootNode extends RootNode {
     @Override
     public Object executeGeneric(final VirtualFrame frame) {
       return null;
+    }
+
+    @Override
+    protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
+      if (tag == StatementTag.class) {
+        return isMarkedAsRootExpression();
+      }
+      return super.isTaggedWith(tag);
     }
   }
 }

--- a/src/som/interpreter/nodes/ArgumentReadNode.java
+++ b/src/som/interpreter/nodes/ArgumentReadNode.java
@@ -2,6 +2,7 @@ package som.interpreter.nodes;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
+import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.profiles.ValueProfile;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -96,6 +97,8 @@ public abstract class ArgumentReadNode {
     protected boolean isTaggedWith(final Class<?> tag) {
       if (tag == KeywordTag.class) {
         return true;
+      } else if (tag == StatementTag.class) {
+        return isMarkedAsRootExpression();
       } else {
         return super.isTaggedWith(tag);
       }
@@ -206,6 +209,8 @@ public abstract class ArgumentReadNode {
     protected boolean isTaggedWith(final Class<?> tag) {
       if (tag == KeywordTag.class) {
         return true;
+      } else if (tag == StatementTag.class) {
+        return isMarkedAsRootExpression();
       } else {
         return super.isTaggedWith(tag);
       }
@@ -239,6 +244,8 @@ public abstract class ArgumentReadNode {
     protected boolean isTaggedWith(final Class<?> tag) {
       if (tag == KeywordTag.class) {
         return true;
+      } else if (tag == StatementTag.class) {
+        return isMarkedAsRootExpression();
       } else {
         return super.isTaggedWith(tag);
       }
@@ -284,6 +291,8 @@ public abstract class ArgumentReadNode {
     protected boolean isTaggedWith(final Class<?> tag) {
       if (tag == KeywordTag.class) {
         return true;
+      } else if (tag == StatementTag.class) {
+        return isMarkedAsRootExpression();
       } else {
         return super.isTaggedWith(tag);
       }

--- a/src/som/interpreter/nodes/ExpressionNode.java
+++ b/src/som/interpreter/nodes/ExpressionNode.java
@@ -26,6 +26,7 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
 import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
+import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
 import com.oracle.truffle.api.source.SourceSection;
@@ -54,6 +55,10 @@ public abstract class ExpressionNode extends SOMNode {
    */
   protected ExpressionNode(final ExpressionNode wrappedNode) {
     super(null);
+  }
+
+  public boolean assertIsStatement() {
+    return isTaggedWith(StatementTag.class);
   }
 
   public void markAsRootExpression() { throw new UnsupportedOperationException(); }

--- a/src/som/interpreter/nodes/OuterObjectRead.java
+++ b/src/som/interpreter/nodes/OuterObjectRead.java
@@ -3,6 +3,7 @@ package som.interpreter.nodes;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.profiles.ValueProfile;
 import com.oracle.truffle.api.source.SourceSection;
@@ -143,5 +144,13 @@ public abstract class OuterObjectRead
       enclosing = enclosing.getSOMClass().getEnclosingObject();
     }
     return enclosingObj.profile(enclosing);
+  }
+
+  @Override
+  protected boolean isTaggedWith(final Class<?> tag) {
+    if (tag == StatementTag.class) {
+      return isMarkedAsRootExpression();
+    }
+    return super.isTaggedWith(tag);
   }
 }

--- a/src/som/interpreter/nodes/ResolvingImplicitReceiverSend.java
+++ b/src/som/interpreter/nodes/ResolvingImplicitReceiverSend.java
@@ -1,16 +1,17 @@
 package som.interpreter.nodes;
 
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.Instrumentable;
+import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
+import com.oracle.truffle.api.source.SourceSection;
+
 import som.compiler.MixinBuilder.MixinDefinitionId;
 import som.instrumentation.MessageSendNodeWrapper;
 import som.interpreter.LexicalScope.MethodScope;
 import som.interpreter.LexicalScope.MixinScope.MixinIdAndContextLevel;
 import som.interpreter.nodes.MessageSendNode.AbstractMessageSendNode;
 import som.vmobjects.SSymbol;
-
-import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.instrumentation.Instrumentable;
-import com.oracle.truffle.api.source.SourceSection;
 
 
 @Instrumentable(factory = MessageSendNodeWrapper.class)
@@ -87,6 +88,14 @@ public final class ResolvingImplicitReceiverSend extends AbstractMessageSendNode
       }
     }
     return replacedBy;
+  }
+
+  @Override
+  protected boolean isTaggedWith(final Class<?> tag) {
+    if (tag == StatementTag.class) {
+      return isMarkedAsRootExpression();
+    }
+    return super.isTaggedWith(tag);
   }
 
   @Override

--- a/src/som/interpreter/nodes/SequenceNode.java
+++ b/src/som/interpreter/nodes/SequenceNode.java
@@ -22,6 +22,7 @@
 package som.interpreter.nodes;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeCost;
@@ -64,6 +65,14 @@ public final class SequenceNode extends ExprWithTagsNode {
       return true;
     }
     return false;
+  }
+
+  @Override
+  protected boolean isTaggedWith(final Class<?> tag) {
+    if (tag == StatementTag.class) {
+      return isMarkedAsRootExpression();
+    }
+    return super.isTaggedWith(tag);
   }
 
   @Override

--- a/src/som/interpreter/nodes/nary/EagerBinaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerBinaryPrimitiveNode.java
@@ -3,6 +3,7 @@ package som.interpreter.nodes.nary;
 import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
+import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -38,6 +39,9 @@ public final class EagerBinaryPrimitiveNode extends EagerPrimitive {
 
   @Override
   protected boolean isTaggedWith(final Class<?> tag) {
+    if (tag == StatementTag.class) {
+      return isMarkedAsRootExpression();
+    }
     assert !(primitive instanceof WrapperNode);
     return primitive.isTaggedWithIgnoringEagerness(tag);
   }

--- a/src/som/interpreter/nodes/nary/EagerTernaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerTernaryPrimitiveNode.java
@@ -3,6 +3,7 @@ package som.interpreter.nodes.nary;
 import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
+import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -43,6 +44,9 @@ public final class EagerTernaryPrimitiveNode extends EagerPrimitive {
 
   @Override
   protected boolean isTaggedWith(final Class<?> tag) {
+    if (tag == StatementTag.class) {
+      return isMarkedAsRootExpression();
+    }
     assert !(primitive instanceof WrapperNode);
     return primitive.isTaggedWithIgnoringEagerness(tag);
   }

--- a/src/som/interpreter/nodes/nary/EagerUnaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerUnaryPrimitiveNode.java
@@ -3,6 +3,7 @@ package som.interpreter.nodes.nary;
 import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
+import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -33,6 +34,9 @@ public final class EagerUnaryPrimitiveNode extends EagerPrimitive {
 
   @Override
   protected boolean isTaggedWith(final Class<?> tag) {
+    if (tag == StatementTag.class) {
+      return isMarkedAsRootExpression();
+    }
     assert !(primitive instanceof WrapperNode);
     return primitive.isTaggedWithIgnoringEagerness(tag);
   }

--- a/src/tools/debugger/WebDebugger.java
+++ b/src/tools/debugger/WebDebugger.java
@@ -1,6 +1,5 @@
 package tools.debugger;
 
-import java.net.URI;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -150,28 +149,6 @@ public class WebDebugger extends TruffleInstrument implements SuspendedCallback 
     connector = new FrontendConnector(breakpoints, instrumenter, this,
         createJsonProcessor());
     connector.awaitClient();
-  }
-
-  public Source getSource(final URI sourceUri) {
-    for (Source source : this.rootNodes.keySet()) {
-      if ((source.getURI()).equals(sourceUri)) {
-        return source;
-      }
-    }
-    return null;
-  }
-
-  public Set<RootNode> getRootNodesBySource(final Source source) {
-    return rootNodes.get(source);
-  }
-
-  public Set<RootNode> getRootNodesBySource(final URI sourceUri) {
-    Set<RootNode> roots = null;
-    Source source = getSource(sourceUri);
-    if (source != null) {
-      roots = rootNodes.get(source);
-    }
-    return roots;
   }
 
   public Breakpoints getBreakpoints() {

--- a/src/tools/debugger/WebSocketHandler.java
+++ b/src/tools/debugger/WebSocketHandler.java
@@ -40,7 +40,7 @@ public class WebSocketHandler extends WebSocketServer {
       Respond respond = gson.fromJson(message, Respond.class);
       respond.process(connector, conn);
     } catch (Exception ex) {
-      VM.errorPrint("Error on parsing Json:" + message);
+      VM.errorPrint("Error while processing msg:" + message);
       ex.printStackTrace();
     }
   }

--- a/src/tools/debugger/message/SourceMessage.java
+++ b/src/tools/debugger/message/SourceMessage.java
@@ -71,7 +71,7 @@ public class SourceMessage extends Message {
       }
 
       methods.add(new MethodData(
-          m.getName(), definition, SourceCoordinate.create(m.getSourceSection())));
+          m.getName(), definition, SourceCoordinate.create(m.getRootNodeSource())));
     }
     return methods.toArray(new MethodData[0]);
   }

--- a/src/tools/debugger/session/Breakpoints.java
+++ b/src/tools/debugger/session/Breakpoints.java
@@ -26,7 +26,7 @@ import tools.debugger.WebDebugger;
 
 public class Breakpoints {
 
-  private DebuggerSession debuggerSession;
+  private final DebuggerSession debuggerSession;
 
   private final WebDebugger webDebugger;
 
@@ -40,28 +40,18 @@ public class Breakpoints {
    */
   private final Map<FullSourceCoordinate, BreakpointEnabling<MessageReceiveBreakpoint>> receiverBreakpoints;
 
-  private final Debugger debugger;
-
   public Breakpoints(final Debugger debugger, final WebDebugger webDebugger) {
     this.truffleBreakpoints = new HashMap<>();
-    this.debugger    = debugger;
     this.webDebugger = webDebugger;
     this.receiverBreakpoints = new HashMap<>();
-  }
-
-  private void ensureOpenDebuggerSession() {
-    if (debuggerSession == null) {
-      debuggerSession = debugger.startSession(webDebugger);
-    }
+    this.debuggerSession = debugger.startSession(webDebugger);
   }
 
   public void doSuspend(final MaterializedFrame frame, final SteppingLocation steppingLocation) {
-    ensureOpenDebuggerSession();
     debuggerSession.doSuspend(frame, steppingLocation);
   }
 
   public void prepareSteppingUntilNextRootNode() {
-    ensureOpenDebuggerSession();
     debuggerSession.prepareSteppingUntilNextRootNode();
   }
 
@@ -69,7 +59,6 @@ public class Breakpoints {
     Breakpoint bp = truffleBreakpoints.get(bId);
 
     if (bp == null) {
-      ensureOpenDebuggerSession();
       WebDebugger.log("LineBreakpoint: " + bId);
       bp = Breakpoint.newBuilder(bId.getURI()).
           lineIs(bId.getLine()).
@@ -84,7 +73,6 @@ public class Breakpoints {
   public Breakpoint addOrUpdate(final MessageSenderBreakpoint bId) {
     Breakpoint bp = truffleBreakpoints.get(bId);
     if (bp == null) {
-      ensureOpenDebuggerSession();
       WebDebugger.log("SetSectionBreakpoint: " + bId);
       bp = Breakpoint.newBuilder(bId.getCoordinate().uri).
           lineIs(bId.getCoordinate().startLine).
@@ -115,7 +103,6 @@ public class Breakpoints {
           ExpressionNode rootExpression = finder.getResult();
           assert rootExpression.getSourceSection() != null;
 
-          ensureOpenDebuggerSession();
           bp = Breakpoint.newBuilder(rootExpression.getSourceSection()).
               build();
           debuggerSession.install(bp);

--- a/src/tools/debugger/session/Breakpoints.java
+++ b/src/tools/debugger/session/Breakpoints.java
@@ -12,6 +12,7 @@ import com.oracle.truffle.api.debug.Debugger;
 import com.oracle.truffle.api.debug.DebuggerSession;
 import com.oracle.truffle.api.debug.DebuggerSession.SteppingLocation;
 import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeVisitor;
 import com.oracle.truffle.api.nodes.RootNode;
@@ -147,7 +148,7 @@ public class Breakpoints {
 
     @Override
     public boolean visit(final Node node) {
-      if (node instanceof ExpressionNode) {
+      if (node instanceof ExpressionNode && !(node instanceof WrapperNode)) {
         ExpressionNode expr = (ExpressionNode) node;
         if (expr.isMarkedAsRootExpression()) {
           result = expr;

--- a/tools/kompos/index.html
+++ b/tools/kompos/index.html
@@ -166,20 +166,20 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
   </div>
 
   <div class="btn-group btn-group-xs" role="group" aria-label="Basic Controls">
-    <button id="dbg-btn-resume" type="button" class="btn btn-default disabled"
+    <button id="dbg-btn-resume" type="button" class="btn btn-default disabled" title="Resume Execution"
             onclick="ctrl.resumeExecution();"><i class="fa fa-play"></i></button>
-    <button id="dbg-btn-pause"  type="button" class="btn btn-default"
+    <button id="dbg-btn-pause"  type="button" class="btn btn-default" title="Pause Execution"
             onclick="ctrl.pauseExecution();"><i class="fa fa-pause"></i></button>
-    <button id="dbg-btn-stop"   type="button" class="btn btn-default"
+    <button id="dbg-btn-stop"   type="button" class="btn btn-default" title="Stop Execution"
             onclick="ctrl.stopExecution();"><i class="fa fa-stop"></i></button>
   </div>
 
   <div class="btn-group btn-group-xs" role="group" aria-label="Stepping">
-    <button id="dbg-btn-step-into" type="button" class="btn btn-default disabled"
+    <button id="dbg-btn-step-into" type="button" class="btn btn-default disabled" title="Step Into"
             onclick="ctrl.stepInto();"><i class="fa fa-share" style="transform: rotate(90deg);"></i></button>
-    <button id="dbg-btn-step-over" type="button" class="btn btn-default disabled"
+    <button id="dbg-btn-step-over" type="button" class="btn btn-default disabled" title="Step Over"
             onclick="ctrl.stepOver();"><i class="fa fa-share"></i></button>
-    <button id="dbg-btn-return"    type="button" class="btn btn-default disabled"
+    <button id="dbg-btn-return"    type="button" class="btn btn-default disabled" title="Return from Method" 
             onclick="ctrl.returnFromExecution();"><i class="fa fa-reply" style="transform: scaleY(-1);"></i></button>
   </div>
 </div>

--- a/tools/kompos/src/controller.ts
+++ b/tools/kompos/src/controller.ts
@@ -141,11 +141,13 @@ export class Controller {
   }
 
   resumeExecution() {
+    if (!this.dbg.isSuspended()) { return; }
     this.vmConnection.sendDebuggerAction('resume', this.dbg.lastSuspendEventId);
     this.view.onContinueExecution();
   }
 
   pauseExecution() {
+    if (this.dbg.isSuspended()) { return; }
     // TODO
   }
 
@@ -154,18 +156,21 @@ export class Controller {
   }
 
   stepInto() {
+    if (!this.dbg.isSuspended()) { return; }
     this.dbg.setResumed();
     this.view.onContinueExecution();
     this.vmConnection.sendDebuggerAction('stepInto', this.dbg.lastSuspendEventId);
   }
 
   stepOver() {
+    if (!this.dbg.isSuspended()) { return; }
     this.dbg.setResumed();
     this.view.onContinueExecution();
     this.vmConnection.sendDebuggerAction('stepOver', this.dbg.lastSuspendEventId);
   }
 
   returnFromExecution() {
+    if (!this.dbg.isSuspended()) { return; }
     this.dbg.setResumed();
     this.view.onContinueExecution();
     this.vmConnection.sendDebuggerAction('return', this.dbg.lastSuspendEventId);

--- a/tools/kompos/src/debugger.ts
+++ b/tools/kompos/src/debugger.ts
@@ -26,7 +26,7 @@ export class Debugger {
    */
   private sections: IdMap<SourceCoordinate>;
 
-  private breakpoints:    IdMap<Breakpoint>[];
+  private breakpoints: IdMap<IdMap<Breakpoint>>;
 
   constructor() {
     this.suspended = false;
@@ -34,7 +34,7 @@ export class Debugger {
     this.uriToSourceId  = {};
     this.sources        = {};
     this.sections       = {};
-    this.breakpoints    = [];
+    this.breakpoints    = {};
   }
 
   getSourceId(uri: string): string {
@@ -101,9 +101,9 @@ export class Debugger {
 
   getEnabledBreakpoints(): Breakpoint[] {
     let bps = [];
-    for (let breakpoints of this.breakpoints) {
-      for (let key in breakpoints) {
-        let bp = breakpoints[key];
+    for (let sId in this.breakpoints) {
+      for (let key in this.breakpoints[sId]) {
+        let bp = this.breakpoints[sId][key];
         if (bp.isEnabled()) {
           bps.push(bp);
         }

--- a/tools/kompos/src/debugger.ts
+++ b/tools/kompos/src/debugger.ts
@@ -133,4 +133,8 @@ export class Debugger {
   setResumed() {
     this.suspended = false;
   }
+
+  isSuspended() {
+    return this.suspended;
+  }
 }

--- a/tools/kompos/src/messages.ts
+++ b/tools/kompos/src/messages.ts
@@ -39,12 +39,12 @@ export interface Method {
   sourceSection: SourceCoordinate;
 }
 
-interface Frame {
+export interface Frame {
   sourceSection: FullSourceCoordinate;
   methodName: string;
 }
 
-interface TopFrame {
+export interface TopFrame {
   arguments: string[];
   slots:     IdMap<string>;
 }

--- a/tools/kompos/src/view.ts
+++ b/tools/kompos/src/view.ts
@@ -3,7 +3,7 @@
 
 import {Controller} from './controller';
 import {Breakpoint, AsyncMethodRcvBreakpoint, MessageBreakpoint, Source, Method,
-  LineBreakpoint, SuspendEventMessage, IdMap,
+  LineBreakpoint, SuspendEventMessage, IdMap, Frame,
   SourceCoordinate, TaggedSourceCoordinate, getSectionId} from './messages';
 
 declare var ctrl: Controller;
@@ -359,7 +359,7 @@ function showSource(source: Source, sourceId: string) {
   files.appendChild(newFileElement);
 }
 
-function showVar(name, value, list) {
+function showVar(name: string, value: string, list: Element) {
   var entry = nodeFromTemplate("frame-state-tpl");
   var t = $(entry).find("th");
   t.html(name);
@@ -368,10 +368,10 @@ function showVar(name, value, list) {
   list.appendChild(entry);
 }
 
-function showFrame(frame, i, list) {
+function showFrame(frame: Frame, i: number, list: Element) {
   var stackEntry = frame.methodName;
   if (frame.sourceSection) {
-    stackEntry += ":" + frame.sourceSection.line + ":" + frame.sourceSection.column;
+    stackEntry += ":" + frame.sourceSection.startLine + ":" + frame.sourceSection.startColumn;
   }
   var entry = nodeFromTemplate("stack-frame-tpl");
   entry.setAttribute("id", "frame-" + i);

--- a/tools/kompos/tests/basic-protocol.ts
+++ b/tools/kompos/tests/basic-protocol.ts
@@ -31,6 +31,8 @@ interface OnMessageHandler {
   (event: OnMessageEvent): void;
 }
 
+const pingPongUri = 'file:' + resolve('tests/pingpong.som');
+
 function expectSourceCoordinate(section: SourceCoordinate) {
   expect(section).to.have.property('charLength');
   expect(section).to.have.property('startColumn');
@@ -221,7 +223,7 @@ describe('Basic Protocol', function() {
       const breakpoint: LineBreakpointData = {
         type: "LineBreakpoint",
         line: 52,
-        sourceUri: 'file:' + resolve('tests/pingpong.som'),
+        sourceUri: pingPongUri,
         enabled: true
       };
       connectionP = startSomAndConnect(getSuspendEvent, [breakpoint]);
@@ -241,7 +243,7 @@ describe('Basic Protocol', function() {
       return suspendP.then(msg => {
         expectFullSourceCoordinate(msg.stack[0].sourceSection);
         expect(msg.id).to.equal("se-0");
-        expect(msg.sourceUri).to.equal('file:' + resolve('tests/pingpong.som'));
+        expect(msg.sourceUri).to.equal(pingPongUri);
         expect(msg.topFrame.arguments[0]).to.equal("a PingPong");
         expect(msg.topFrame.slots['ping']).to.equal('a Nil');
       });
@@ -268,7 +270,7 @@ describe('Basic Protocol', function() {
         type: "MessageSenderBreakpoint",
         enabled: true,
         coord: {
-          uri:        'file:' + resolve('tests/pingpong.som'),
+          uri:         pingPongUri,
           startLine:   15,
           startColumn: 14,
           charLength:   3}};
@@ -306,7 +308,7 @@ describe('Basic Protocol', function() {
         type: "AsyncMessageReceiveBreakpoint",
         enabled: true,
         coord: {
-          uri:         'file:' + resolve('tests/pingpong.som'),
+          uri:         pingPongUri,
           startLine:   39,
           startColumn:  9,
           charLength:  88}
@@ -345,7 +347,7 @@ describe('Basic Protocol', function() {
         type: "MessageReceiveBreakpoint",
         enabled: true,
         coord: {
-          uri:        'file:' + resolve('tests/pingpong.som'),
+          uri:         pingPongUri,
           startLine:   15,
           startColumn: 14,
           charLength:   3}};
@@ -391,7 +393,7 @@ describe('Basic Protocol', function() {
         type: "MessageSenderBreakpoint",
         enabled: true,
         coord: {
-          uri:        'file:' + resolve('tests/pingpong.som'),
+          uri:         pingPongUri,
           startLine:   15,
           startColumn: 14,
           charLength:   3}};
@@ -434,8 +436,8 @@ describe('Basic Protocol', function() {
             const lbp: LineBreakpointData = {
               type: "LineBreakpoint",
               line: 21,
-              sourceUri: 'file:' + resolve('tests/pingpong.som'),
-              enabled: true
+              sourceUri: pingPongUri,
+              enabled:   true
             };
             send(con.socket, {action: "updateBreakpoint", breakpoint: lbp});
             send(con.socket, {action: "resume", suspendEvent: msgAfterStep.id});  
@@ -455,17 +457,17 @@ describe('Basic Protocol', function() {
           connectionP.then(con => {
             const lbp22: LineBreakpointData = {
               type: "LineBreakpoint",
-              line: 22,
-              sourceUri: 'file:' + resolve('tests/pingpong.som'),
-              enabled: true
+              line:      22,
+              sourceUri: pingPongUri,
+              enabled:   true
             };
             send(con.socket, {action: "updateBreakpoint", breakpoint: lbp22});
             
             const lbp21: LineBreakpointData = {
               type: "LineBreakpoint",
-              line: 21,
-              sourceUri: 'file:' + resolve('tests/pingpong.som'),
-              enabled: false
+              line:      21,
+              sourceUri: pingPongUri,
+              enabled:   false
             };
             send(con.socket, {action: "updateBreakpoint", breakpoint: lbp21});
             send(con.socket, {action: "resume", suspendEvent: msgAfterStep.id});

--- a/tools/kompos/tests/pingpong.som
+++ b/tools/kompos/tests/pingpong.som
@@ -61,7 +61,17 @@ class PingPongApp usingPlatform: platform = Value (
     public setupVerifiedRun: run = ( run problemSize: 1 )
   )
 
+  private testHalt = (
+    1 halt.
+    ^ 0
+  )
+
   public main: args = (
-    ^ (PingPong new: 3) benchmark
+    args size = 1 ifTrue: [
+      ^ (PingPong new: 3) benchmark ].
+    args size = 2 ifTrue: [
+      (args at: 2) = 'halt' ifTrue: [ ^ testHalt ].
+    ].
+    ^ 0
   )
 )

--- a/tools/tests/dym/expected-results/Bounce/general-stats.csv
+++ b/tools/tests/dym/expected-results/Bounce/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	26
 Lines Loaded	2076
 Lines Executed	180
-Lines With Statements	974
+Lines With Statements	920

--- a/tools/tests/dym/expected-results/Bounce/operations.csv
+++ b/tools/tests/dym/expected-results/Bounce/operations.csv
@@ -1,76 +1,76 @@
 Source Section	Operation	Category	Type	Invocations
-Bounce.som pos=1629 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1330
-Bounce.som pos=1629 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1330
-Bounce.som pos=1807 len=5	%	BasicPrimitiveOperation OpArithmetic StatementTag	int	99
-Bounce.som pos=1807 len=5	%	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	99
-Bounce.som pos=1841 len=5	%	BasicPrimitiveOperation OpArithmetic StatementTag	int	99
-Bounce.som pos=1841 len=5	%	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	99
-Bounce.som pos=1876 len=5	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	99
-Bounce.som pos=1876 len=5	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	99
-Bounce.som pos=1883 len=5	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	99
-Bounce.som pos=1883 len=5	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	99
-Bounce.som pos=1918 len=5	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	99
-Bounce.som pos=1918 len=5	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	99
-Bounce.som pos=1925 len=5	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	99
-Bounce.som pos=1925 len=5	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	99
-Bounce.som pos=2072 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	4999
-Bounce.som pos=2072 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	4999
-Bounce.som pos=2093 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	4999
-Bounce.som pos=2093 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	4999
-Bounce.som pos=2109 len=8	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4641
-Bounce.som pos=2109 len=8	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	358
-Bounce.som pos=2109 len=8	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4999
-Bounce.som pos=2159 len=10	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	357
-Bounce.som pos=2159 len=10	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	357
-Bounce.som pos=2166 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	357
-Bounce.som pos=2166 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	357
-Bounce.som pos=2198 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4645
-Bounce.som pos=2198 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	354
-Bounce.som pos=2198 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4999
-Bounce.som pos=2246 len=3	abs	BasicPrimitiveOperation OpArithmetic StatementTag	int	353
-Bounce.som pos=2246 len=3	abs	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	353
-Bounce.som pos=2282 len=8	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4644
-Bounce.som pos=2282 len=8	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	355
-Bounce.som pos=2282 len=8	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4999
-Bounce.som pos=2332 len=10	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	354
-Bounce.som pos=2332 len=10	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	354
-Bounce.som pos=2339 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	354
-Bounce.som pos=2339 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	354
-Bounce.som pos=2371 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4640
-Bounce.som pos=2371 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	359
-Bounce.som pos=2371 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4999
-Bounce.som pos=2419 len=3	abs	BasicPrimitiveOperation OpArithmetic StatementTag	int	358
-Bounce.som pos=2419 len=3	abs	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	358
-Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	399
-Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	399
-Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	399
-Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	399
-Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic StatementTag	int	399
-Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	399
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	55
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5157
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	5212
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	5157
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	5157
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	5
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	5
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	5
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	5
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	5
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	5
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	4999
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	4999
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	50
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	50
+Bounce.som pos=1629 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1330
+Bounce.som pos=1629 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1330
+Bounce.som pos=1807 len=5	%	BasicPrimitiveOperation OpArithmetic	int	99
+Bounce.som pos=1807 len=5	%	BasicPrimitiveOperation OpArithmetic	TOTAL	99
+Bounce.som pos=1841 len=5	%	BasicPrimitiveOperation OpArithmetic	int	99
+Bounce.som pos=1841 len=5	%	BasicPrimitiveOperation OpArithmetic	TOTAL	99
+Bounce.som pos=1876 len=5	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	99
+Bounce.som pos=1876 len=5	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	99
+Bounce.som pos=1883 len=5	-	BasicPrimitiveOperation OpArithmetic	int	99
+Bounce.som pos=1883 len=5	-	BasicPrimitiveOperation OpArithmetic	TOTAL	99
+Bounce.som pos=1918 len=5	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	99
+Bounce.som pos=1918 len=5	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	99
+Bounce.som pos=1925 len=5	-	BasicPrimitiveOperation OpArithmetic	int	99
+Bounce.som pos=1925 len=5	-	BasicPrimitiveOperation OpArithmetic	TOTAL	99
+Bounce.som pos=2072 len=6	+	BasicPrimitiveOperation OpArithmetic	int	4999
+Bounce.som pos=2072 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	4999
+Bounce.som pos=2093 len=6	+	BasicPrimitiveOperation OpArithmetic	int	4999
+Bounce.som pos=2093 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	4999
+Bounce.som pos=2109 len=8	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4641
+Bounce.som pos=2109 len=8	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	358
+Bounce.som pos=2109 len=8	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4999
+Bounce.som pos=2159 len=10	-	BasicPrimitiveOperation OpArithmetic	int	357
+Bounce.som pos=2159 len=10	-	BasicPrimitiveOperation OpArithmetic	TOTAL	357
+Bounce.som pos=2166 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	357
+Bounce.som pos=2166 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	357
+Bounce.som pos=2198 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4645
+Bounce.som pos=2198 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	354
+Bounce.som pos=2198 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4999
+Bounce.som pos=2246 len=3	abs	BasicPrimitiveOperation OpArithmetic	int	353
+Bounce.som pos=2246 len=3	abs	BasicPrimitiveOperation OpArithmetic	TOTAL	353
+Bounce.som pos=2282 len=8	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4644
+Bounce.som pos=2282 len=8	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	355
+Bounce.som pos=2282 len=8	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4999
+Bounce.som pos=2332 len=10	-	BasicPrimitiveOperation OpArithmetic	int	354
+Bounce.som pos=2332 len=10	-	BasicPrimitiveOperation OpArithmetic	TOTAL	354
+Bounce.som pos=2339 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	354
+Bounce.som pos=2339 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	354
+Bounce.som pos=2371 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4640
+Bounce.som pos=2371 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	359
+Bounce.som pos=2371 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4999
+Bounce.som pos=2419 len=3	abs	BasicPrimitiveOperation OpArithmetic	int	358
+Bounce.som pos=2419 len=3	abs	BasicPrimitiveOperation OpArithmetic	TOTAL	358
+Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	399
+Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	399
+Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	399
+Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	399
+Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic	int	399
+Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic	TOTAL	399
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	55
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5157
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	5212
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	5157
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	5157
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	5
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	5
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	5
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	5
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	5
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	5
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	4999
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	4999
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	arr	50
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	50
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	ref	99
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	99
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/DeltaBlue/general-stats.csv
+++ b/tools/tests/dym/expected-results/DeltaBlue/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	35
 Lines Loaded	2826
 Lines Executed	524
-Lines With Statements	1296
+Lines With Statements	1229

--- a/tools/tests/dym/expected-results/DeltaBlue/operations.csv
+++ b/tools/tests/dym/expected-results/DeltaBlue/operations.csv
@@ -1,86 +1,86 @@
 Source Section	Operation	Category	Type	Invocations
-Collections.som pos=4222 len=7	=	BasicPrimitiveOperation OpComparison StatementTag	int	7
-Collections.som pos=4222 len=7	=	BasicPrimitiveOperation OpComparison StatementTag	int	23
-Collections.som pos=4222 len=7	=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	30
-Collections.som pos=4240 len=6	=	BasicPrimitiveOperation OpComparison StatementTag	Symbol	22
-Collections.som pos=4240 len=6	=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	22
-Collections.som pos=4378 len=21	bitXor:	BasicPrimitiveOperation OpArithmetic StatementTag	int	38
-Collections.som pos=4378 len=21	bitXor:	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	38
-Collections.som pos=4392 len=6	>>>	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	38
-Collections.som pos=4392 len=6	>>>	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	38
+Collections.som pos=4222 len=7	=	BasicPrimitiveOperation OpComparison	int	7
+Collections.som pos=4222 len=7	=	BasicPrimitiveOperation OpComparison	int	23
+Collections.som pos=4222 len=7	=	BasicPrimitiveOperation OpComparison	TOTAL	30
+Collections.som pos=4240 len=6	=	BasicPrimitiveOperation OpComparison	Symbol	22
+Collections.som pos=4240 len=6	=	BasicPrimitiveOperation OpComparison	TOTAL	22
+Collections.som pos=4378 len=21	bitXor:	BasicPrimitiveOperation OpArithmetic	int	38
+Collections.som pos=4378 len=21	bitXor:	BasicPrimitiveOperation OpArithmetic	TOTAL	38
+Collections.som pos=4392 len=6	>>>	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	38
+Collections.som pos=4392 len=6	>>>	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	38
 Collections.som pos=4453 len=29	+	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	int	38
 Collections.som pos=4453 len=29	+	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	TOTAL	38
-Collections.som pos=4465 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	38
-Collections.som pos=4465 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	38
-Collections.som pos=4470 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	38
-Collections.som pos=4470 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	38
-Collections.som pos=4475 len=6	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	38
-Collections.som pos=4475 len=6	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	38
+Collections.som pos=4465 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	38
+Collections.som pos=4465 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	38
+Collections.som pos=4470 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	38
+Collections.som pos=4470 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	38
+Collections.som pos=4475 len=6	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	38
+Collections.som pos=4475 len=6	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	38
 Collections.som pos=4539 len=21	at:	ArrayRead BasicPrimitiveOperation RootTag StatementTag	ref	22
 Collections.som pos=4539 len=21	at:	ArrayRead BasicPrimitiveOperation RootTag StatementTag	TOTAL	22
-Collections.som pos=5286 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	2
-Collections.som pos=5286 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	13
-Collections.som pos=5286 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	15
-Collections.som pos=5356 len=50	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	13
-Collections.som pos=5356 len=50	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	13
-Collections.som pos=5433 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	13
-Collections.som pos=5433 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	13
-Collections.som pos=5546 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	15
-Collections.som pos=5546 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	15
-Collections.som pos=5556 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	15
-Collections.som pos=5556 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	15
-Collections.som pos=6019 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Collections.som pos=6019 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	6
-DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	2
-DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	3
-DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	14
-DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	25
-DeltaBlue.som pos=5750 len=7	<>	BasicPrimitiveOperation OpComparison StatementTag	int	12
-DeltaBlue.som pos=5750 len=7	<>	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	12
-DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	2
-DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	4
-DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	2
-DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	12
-DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	2
-DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	2
-DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	2
-DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	2
-DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	10
-DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	9
-DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	16
-DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	6
-DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	69
-DeltaBlue.som pos=6570 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	14
-DeltaBlue.som pos=6570 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	13
-DeltaBlue.som pos=6570 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	27
-DeltaBlue.som pos=7511 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	28
-DeltaBlue.som pos=7511 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	28
-DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	1
-DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	6
-DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	1
-DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	1
-DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	1
-DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	2
-DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	ref	6
-DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	18
-DeltaBlue.som pos=8261 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	7
-DeltaBlue.som pos=8261 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	3
-DeltaBlue.som pos=8261 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	10
-DeltaBlue.som pos=8797 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19
-DeltaBlue.som pos=8797 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19
-DeltaBlue.som pos=10011 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	1
-DeltaBlue.som pos=10011 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-DeltaBlue.som pos=10037 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	1
-DeltaBlue.som pos=10037 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-DeltaBlue.som pos=10043 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-DeltaBlue.som pos=10043 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-DeltaBlue.som pos=10488 len=4	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	99
-DeltaBlue.som pos=10488 len=4	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	99
-DeltaBlue.som pos=11318 len=7	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-DeltaBlue.som pos=11442 len=4	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-DeltaBlue.som pos=11602 len=15	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-DeltaBlue.som pos=11788 len=15	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Collections.som pos=5286 len=5	at:	ArrayRead BasicPrimitiveOperation	ref	2
+Collections.som pos=5286 len=5	at:	ArrayRead BasicPrimitiveOperation	ref	13
+Collections.som pos=5286 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	15
+Collections.som pos=5356 len=50	at:put:	ArrayWrite BasicPrimitiveOperation	ref	13
+Collections.som pos=5356 len=50	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	13
+Collections.som pos=5433 len=3	+	BasicPrimitiveOperation OpArithmetic	int	13
+Collections.som pos=5433 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	13
+Collections.som pos=5546 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	15
+Collections.som pos=5546 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	15
+Collections.som pos=5556 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	15
+Collections.som pos=5556 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	15
+Collections.som pos=6019 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Collections.som pos=6019 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	6
+DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	2
+DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	3
+DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	14
+DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	25
+DeltaBlue.som pos=5750 len=7	<>	BasicPrimitiveOperation OpComparison	int	12
+DeltaBlue.som pos=5750 len=7	<>	BasicPrimitiveOperation OpComparison	TOTAL	12
+DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	2
+DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	4
+DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	2
+DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	12
+DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	2
+DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	2
+DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	2
+DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	2
+DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	10
+DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	9
+DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	16
+DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	6
+DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	TOTAL	69
+DeltaBlue.som pos=6570 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	14
+DeltaBlue.som pos=6570 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	13
+DeltaBlue.som pos=6570 len=3	not	BasicPrimitiveOperation OpArithmetic	TOTAL	27
+DeltaBlue.som pos=7511 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	28
+DeltaBlue.som pos=7511 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	28
+DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison	ref	1
+DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison	ref	6
+DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison	ref	1
+DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison	ref	1
+DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison	ref	1
+DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison	ref	2
+DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison	ref	6
+DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison	TOTAL	18
+DeltaBlue.som pos=8261 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	7
+DeltaBlue.som pos=8261 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	3
+DeltaBlue.som pos=8261 len=3	not	BasicPrimitiveOperation OpArithmetic	TOTAL	10
+DeltaBlue.som pos=8797 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19
+DeltaBlue.som pos=8797 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19
+DeltaBlue.som pos=10011 len=5	at:	ArrayRead BasicPrimitiveOperation	ref	1
+DeltaBlue.som pos=10011 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+DeltaBlue.som pos=10037 len=9	at:	ArrayRead BasicPrimitiveOperation	ref	1
+DeltaBlue.som pos=10037 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+DeltaBlue.som pos=10043 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+DeltaBlue.som pos=10043 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+DeltaBlue.som pos=10488 len=4	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	99
+DeltaBlue.som pos=10488 len=4	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	99
+DeltaBlue.som pos=11318 len=7	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+DeltaBlue.som pos=11442 len=4	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+DeltaBlue.som pos=11602 len=15	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+DeltaBlue.som pos=11788 len=15	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 DeltaBlue.som pos=12858 len=27	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	int	2
 DeltaBlue.som pos=12858 len=27	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	TOTAL	2
 DeltaBlue.som pos=13018 len=27	<	BasicPrimitiveOperation OpComparison RootTag StatementTag	int	22
@@ -88,151 +88,151 @@ DeltaBlue.som pos=13018 len=27	<	BasicPrimitiveOperation OpComparison RootTag St
 DeltaBlue.som pos=13174 len=27	>	BasicPrimitiveOperation OpComparison RootTag StatementTag	int	3
 DeltaBlue.som pos=13174 len=27	>	BasicPrimitiveOperation OpComparison RootTag StatementTag	int	26
 DeltaBlue.som pos=13174 len=27	>	BasicPrimitiveOperation OpComparison RootTag StatementTag	TOTAL	29
-DeltaBlue.som pos=17447 len=6	=	BasicPrimitiveOperation OpComparison StatementTag	int	12
-DeltaBlue.som pos=17447 len=6	=	BasicPrimitiveOperation OpComparison StatementTag	int	7
-DeltaBlue.som pos=17447 len=6	=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	19
-DeltaBlue.som pos=18796 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	6
-DeltaBlue.som pos=18796 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	2
-DeltaBlue.som pos=18796 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	3
-DeltaBlue.som pos=18796 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	11
-DeltaBlue.som pos=18796 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	22
-DeltaBlue.som pos=20641 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	8
-DeltaBlue.som pos=20641 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
-DeltaBlue.som pos=20641 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	11
-DeltaBlue.som pos=20701 len=7	<>	BasicPrimitiveOperation OpComparison StatementTag	int	2
-DeltaBlue.som pos=20701 len=7	<>	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	2
-DeltaBlue.som pos=20861 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
-DeltaBlue.som pos=20861 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5
-DeltaBlue.som pos=20861 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	8
-DeltaBlue.som pos=20922 len=7	<>	BasicPrimitiveOperation OpComparison StatementTag	int	4
-DeltaBlue.som pos=20922 len=7	<>	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	4
-DeltaBlue.som pos=21759 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	Symbol	4
-DeltaBlue.som pos=21759 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	Symbol	5
-DeltaBlue.som pos=21759 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	9
-DeltaBlue.som pos=22050 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	Symbol	19
-DeltaBlue.som pos=22050 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	Symbol	60
-DeltaBlue.som pos=22050 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	79
-DeltaBlue.som pos=22371 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	Symbol	4
-DeltaBlue.som pos=22371 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	Symbol	5
-DeltaBlue.som pos=22371 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	9
-DeltaBlue.som pos=23515 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	Symbol	4
-DeltaBlue.som pos=23515 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	Symbol	203
-DeltaBlue.som pos=23515 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	207
-DeltaBlue.som pos=25001 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	Symbol	11
-DeltaBlue.som pos=25001 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	Symbol	58
-DeltaBlue.som pos=25001 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	69
-DeltaBlue.som pos=25051 len=13	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	58
-DeltaBlue.som pos=25051 len=13	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	58
-DeltaBlue.som pos=25066 len=14	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	58
-DeltaBlue.som pos=25066 len=14	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	58
-DeltaBlue.som pos=25122 len=14	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	10
-DeltaBlue.som pos=25122 len=14	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	10
-DeltaBlue.som pos=25138 len=13	/	BasicPrimitiveOperation OpArithmetic StatementTag	int	10
-DeltaBlue.som pos=25138 len=13	/	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	10
-DeltaBlue.som pos=25269 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	Symbol	2
-DeltaBlue.som pos=25269 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	Symbol	7
-DeltaBlue.som pos=25269 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	9
-DeltaBlue.som pos=25766 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	Symbol	2
-DeltaBlue.som pos=25766 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	Symbol	13
-DeltaBlue.som pos=25766 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	15
-DeltaBlue.som pos=26940 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	9
-DeltaBlue.som pos=26940 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	9
-DeltaBlue.som pos=27170 len=7	<>	BasicPrimitiveOperation OpComparison StatementTag	int	3
-DeltaBlue.som pos=27170 len=7	<>	BasicPrimitiveOperation OpComparison StatementTag	int	10
-DeltaBlue.som pos=27170 len=7	<>	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	13
-DeltaBlue.som pos=27846 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	5
-DeltaBlue.som pos=27846 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	5
-DeltaBlue.som pos=27846 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	10
-DeltaBlue.som pos=29880 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	1
-DeltaBlue.som pos=29880 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	2
-DeltaBlue.som pos=29880 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	1
-DeltaBlue.som pos=29880 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	1
-DeltaBlue.som pos=29880 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	4
-DeltaBlue.som pos=29880 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	9
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	259
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	744
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1003
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	744
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	744
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	8
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	8
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	8
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	8
+DeltaBlue.som pos=17447 len=6	=	BasicPrimitiveOperation OpComparison	int	12
+DeltaBlue.som pos=17447 len=6	=	BasicPrimitiveOperation OpComparison	int	7
+DeltaBlue.som pos=17447 len=6	=	BasicPrimitiveOperation OpComparison	TOTAL	19
+DeltaBlue.som pos=18796 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	6
+DeltaBlue.som pos=18796 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	2
+DeltaBlue.som pos=18796 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	3
+DeltaBlue.som pos=18796 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	11
+DeltaBlue.som pos=18796 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	22
+DeltaBlue.som pos=20641 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8
+DeltaBlue.som pos=20641 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
+DeltaBlue.som pos=20641 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	11
+DeltaBlue.som pos=20701 len=7	<>	BasicPrimitiveOperation OpComparison	int	2
+DeltaBlue.som pos=20701 len=7	<>	BasicPrimitiveOperation OpComparison	TOTAL	2
+DeltaBlue.som pos=20861 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
+DeltaBlue.som pos=20861 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5
+DeltaBlue.som pos=20861 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	8
+DeltaBlue.som pos=20922 len=7	<>	BasicPrimitiveOperation OpComparison	int	4
+DeltaBlue.som pos=20922 len=7	<>	BasicPrimitiveOperation OpComparison	TOTAL	4
+DeltaBlue.som pos=21759 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	Symbol	4
+DeltaBlue.som pos=21759 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	Symbol	5
+DeltaBlue.som pos=21759 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9
+DeltaBlue.som pos=22050 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	Symbol	19
+DeltaBlue.som pos=22050 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	Symbol	60
+DeltaBlue.som pos=22050 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	79
+DeltaBlue.som pos=22371 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	Symbol	4
+DeltaBlue.som pos=22371 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	Symbol	5
+DeltaBlue.som pos=22371 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9
+DeltaBlue.som pos=23515 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	Symbol	4
+DeltaBlue.som pos=23515 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	Symbol	203
+DeltaBlue.som pos=23515 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	207
+DeltaBlue.som pos=25001 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	Symbol	11
+DeltaBlue.som pos=25001 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	Symbol	58
+DeltaBlue.som pos=25001 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	69
+DeltaBlue.som pos=25051 len=13	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	58
+DeltaBlue.som pos=25051 len=13	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	58
+DeltaBlue.som pos=25066 len=14	+	BasicPrimitiveOperation OpArithmetic	int	58
+DeltaBlue.som pos=25066 len=14	+	BasicPrimitiveOperation OpArithmetic	TOTAL	58
+DeltaBlue.som pos=25122 len=14	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	10
+DeltaBlue.som pos=25122 len=14	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	10
+DeltaBlue.som pos=25138 len=13	/	BasicPrimitiveOperation OpArithmetic	int	10
+DeltaBlue.som pos=25138 len=13	/	BasicPrimitiveOperation OpArithmetic	TOTAL	10
+DeltaBlue.som pos=25269 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	Symbol	2
+DeltaBlue.som pos=25269 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	Symbol	7
+DeltaBlue.som pos=25269 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9
+DeltaBlue.som pos=25766 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	Symbol	2
+DeltaBlue.som pos=25766 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	Symbol	13
+DeltaBlue.som pos=25766 len=10	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	15
+DeltaBlue.som pos=26940 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	9
+DeltaBlue.som pos=26940 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9
+DeltaBlue.som pos=27170 len=7	<>	BasicPrimitiveOperation OpComparison	int	3
+DeltaBlue.som pos=27170 len=7	<>	BasicPrimitiveOperation OpComparison	int	10
+DeltaBlue.som pos=27170 len=7	<>	BasicPrimitiveOperation OpComparison	TOTAL	13
+DeltaBlue.som pos=27846 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	5
+DeltaBlue.som pos=27846 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	5
+DeltaBlue.som pos=27846 len=3	not	BasicPrimitiveOperation OpArithmetic	TOTAL	10
+DeltaBlue.som pos=29880 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	1
+DeltaBlue.som pos=29880 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	2
+DeltaBlue.som pos=29880 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	1
+DeltaBlue.som pos=29880 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	1
+DeltaBlue.som pos=29880 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	4
+DeltaBlue.som pos=29880 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	259
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	744
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1003
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	744
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	744
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	8
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	8
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	8
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	8
 Kernel.som pos=14361 len=5	at:	ArrayRead BasicPrimitiveOperation RootTag StatementTag	ref	100
 Kernel.som pos=14361 len=5	at:	ArrayRead BasicPrimitiveOperation RootTag StatementTag	TOTAL	100
 Kernel.som pos=14392 len=8	at:	ArrayRead BasicPrimitiveOperation RootTag StatementTag	ref	100
 Kernel.som pos=14392 len=8	at:	ArrayRead BasicPrimitiveOperation RootTag StatementTag	TOTAL	100
-Kernel.som pos=14396 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	100
-Kernel.som pos=14396 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	100
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	5
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	6
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	9
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	20
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	23
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	23
+Kernel.som pos=14396 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	100
+Kernel.som pos=14396 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	100
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	5
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	6
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	9
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	20
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	arr	23
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	23
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	ref	2
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	2
-Kernel.som pos=18341 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	4
-Kernel.som pos=18341 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	4
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=21459 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	223
-Kernel.som pos=21459 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	223
-Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	155
-Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	228
-Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	126
-Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	23
-Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	Symbol	7
-Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	539
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	83
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	17
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	100
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	100
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	100
-Kernel.som pos=22306 len=14	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	16
-Kernel.som pos=22306 len=14	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	16
-Kernel.som pos=22316 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	16
-Kernel.som pos=22316 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	16
+Kernel.som pos=18341 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	ref	4
+Kernel.som pos=18341 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	4
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	ref	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=21459 len=3	-	BasicPrimitiveOperation OpArithmetic	int	223
+Kernel.som pos=21459 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	223
+Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	155
+Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	228
+Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	126
+Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	23
+Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	Symbol	7
+Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	539
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	83
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	17
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	100
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	100
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	100
+Kernel.som pos=22306 len=14	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	16
+Kernel.som pos=22306 len=14	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	16
+Kernel.som pos=22316 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	16
+Kernel.som pos=22316 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	16
 Kernel.som pos=22367 len=26	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	ref	5
 Kernel.som pos=22367 len=26	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	ref	7
 Kernel.som pos=22367 len=26	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	ref	2
 Kernel.som pos=22367 len=26	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	ref	10
 Kernel.som pos=22367 len=26	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	24
-Kernel.som pos=22387 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	5
-Kernel.som pos=22387 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	7
-Kernel.som pos=22387 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	2
-Kernel.som pos=22387 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	10
-Kernel.som pos=22387 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	24
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	20
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	16
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	30
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	12
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	Symbol	7
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	15
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	100
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	100
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	100
-Kernel.som pos=23033 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	1
-Kernel.som pos=23033 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	12
-Kernel.som pos=23033 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	2
-Kernel.som pos=23033 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	5
-Kernel.som pos=23033 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	20
-Kernel.som pos=23122 len=19	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	1
-Kernel.som pos=23122 len=19	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	12
-Kernel.som pos=23122 len=19	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	2
-Kernel.som pos=23122 len=19	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	15
-Kernel.som pos=23174 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	15
-Kernel.som pos=23174 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	15
+Kernel.som pos=22387 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	5
+Kernel.som pos=22387 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	7
+Kernel.som pos=22387 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	2
+Kernel.som pos=22387 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	10
+Kernel.som pos=22387 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	24
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	20
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	16
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	30
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	12
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	Symbol	7
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	15
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	100
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	int	100
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	100
+Kernel.som pos=23033 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	1
+Kernel.som pos=23033 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	12
+Kernel.som pos=23033 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	2
+Kernel.som pos=23033 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	5
+Kernel.som pos=23033 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	20
+Kernel.som pos=23122 len=19	at:put:	ArrayWrite BasicPrimitiveOperation	ref	1
+Kernel.som pos=23122 len=19	at:put:	ArrayWrite BasicPrimitiveOperation	ref	12
+Kernel.som pos=23122 len=19	at:put:	ArrayWrite BasicPrimitiveOperation	ref	2
+Kernel.som pos=23122 len=19	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	15
+Kernel.som pos=23174 len=3	+	BasicPrimitiveOperation OpArithmetic	int	15
+Kernel.som pos=23174 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	15
 Kernel.som pos=24011 len=10	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	int	109
 Kernel.som pos=24011 len=10	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	int	33
 Kernel.som pos=24011 len=10	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	TOTAL	142
@@ -240,29 +240,29 @@ Kernel.som pos=24060 len=10	-	BasicPrimitiveOperation OpArithmetic RootTag State
 Kernel.som pos=24060 len=10	-	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	TOTAL	4
 Kernel.som pos=24109 len=4	size	BasicPrimitiveOperation OpLength RootTag StatementTag	arr	9
 Kernel.som pos=24109 len=4	size	BasicPrimitiveOperation OpLength RootTag StatementTag	TOTAL	9
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Kernel.som pos=24569 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	54
-Kernel.som pos=24569 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	54
-Kernel.som pos=24590 len=16	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	10
-Kernel.som pos=24590 len=16	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	9
-Kernel.som pos=24590 len=16	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	16
-Kernel.som pos=24590 len=16	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	6
-Kernel.som pos=24590 len=16	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	13
-Kernel.som pos=24590 len=16	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	54
-Kernel.som pos=24603 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	54
-Kernel.som pos=24603 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	54
-Kernel.som pos=24927 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	2
-Kernel.som pos=24927 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	2
-Kernel.som pos=24932 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	2
-Kernel.som pos=24932 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	2
-Kernel.som pos=24937 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2
-Kernel.som pos=24937 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	2
-Kernel.som pos=26939 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2
-Kernel.som pos=26939 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2
-Kernel.som pos=26939 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4
-Kernel.som pos=27012 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	2
-Kernel.som pos=27012 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	2
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	TOTAL	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	TOTAL	1
+Kernel.som pos=24569 len=3	+	BasicPrimitiveOperation OpArithmetic	int	54
+Kernel.som pos=24569 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	54
+Kernel.som pos=24590 len=16	at:	ArrayRead BasicPrimitiveOperation	ref	10
+Kernel.som pos=24590 len=16	at:	ArrayRead BasicPrimitiveOperation	ref	9
+Kernel.som pos=24590 len=16	at:	ArrayRead BasicPrimitiveOperation	ref	16
+Kernel.som pos=24590 len=16	at:	ArrayRead BasicPrimitiveOperation	ref	6
+Kernel.som pos=24590 len=16	at:	ArrayRead BasicPrimitiveOperation	ref	13
+Kernel.som pos=24590 len=16	at:	ArrayRead BasicPrimitiveOperation	TOTAL	54
+Kernel.som pos=24603 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	54
+Kernel.som pos=24603 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	54
+Kernel.som pos=24927 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	2
+Kernel.som pos=24927 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	2
+Kernel.som pos=24932 len=3	-	BasicPrimitiveOperation OpArithmetic	int	2
+Kernel.som pos=24932 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	2
+Kernel.som pos=24937 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
+Kernel.som pos=24937 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	2
+Kernel.som pos=26939 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
+Kernel.som pos=26939 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
+Kernel.som pos=26939 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4
+Kernel.som pos=27012 len=3	-	BasicPrimitiveOperation OpArithmetic	int	2
+Kernel.som pos=27012 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	2
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/Fannkuch/general-stats.csv
+++ b/tools/tests/dym/expected-results/Fannkuch/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	21
 Lines Loaded	2120
 Lines Executed	205
-Lines With Statements	995
+Lines With Statements	940

--- a/tools/tests/dym/expected-results/Fannkuch/operations.csv
+++ b/tools/tests/dym/expected-results/Fannkuch/operations.csv
@@ -1,90 +1,90 @@
 Source Section	Operation	Category	Type	Invocations
-Fannkuch.som pos=2008 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	61
-Fannkuch.som pos=2008 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	61
-Fannkuch.som pos=2015 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	38
-Fannkuch.som pos=2015 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	23
-Fannkuch.som pos=2015 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	61
-Fannkuch.som pos=2050 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	37
-Fannkuch.som pos=2050 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	37
-Fannkuch.som pos=2083 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	37
-Fannkuch.som pos=2083 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	37
-Fannkuch.som pos=2109 len=3	/	BasicPrimitiveOperation OpArithmetic StatementTag	int	37
-Fannkuch.som pos=2109 len=3	/	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	37
-Fannkuch.som pos=2147 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	49
-Fannkuch.som pos=2147 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	49
-Fannkuch.som pos=2177 len=18	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	49
-Fannkuch.som pos=2177 len=18	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	49
-Fannkuch.som pos=2192 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	49
-Fannkuch.som pos=2192 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	49
-Fannkuch.som pos=2215 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	49
-Fannkuch.som pos=2215 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	49
-Fannkuch.som pos=2247 len=25	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	49
-Fannkuch.som pos=2247 len=25	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	49
-Fannkuch.som pos=2262 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	49
-Fannkuch.som pos=2262 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	49
-Fannkuch.som pos=2411 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	23
-Fannkuch.som pos=2411 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	23
-Fannkuch.som pos=2500 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	39
-Fannkuch.som pos=2500 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	39
-Fannkuch.som pos=2523 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	39
-Fannkuch.som pos=2523 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	39
+Fannkuch.som pos=2008 len=5	at:	ArrayRead BasicPrimitiveOperation	int	61
+Fannkuch.som pos=2008 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	61
+Fannkuch.som pos=2015 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	38
+Fannkuch.som pos=2015 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	23
+Fannkuch.som pos=2015 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	61
+Fannkuch.som pos=2050 len=3	+	BasicPrimitiveOperation OpArithmetic	int	37
+Fannkuch.som pos=2050 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	37
+Fannkuch.som pos=2083 len=3	+	BasicPrimitiveOperation OpArithmetic	int	37
+Fannkuch.som pos=2083 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	37
+Fannkuch.som pos=2109 len=3	/	BasicPrimitiveOperation OpArithmetic	int	37
+Fannkuch.som pos=2109 len=3	/	BasicPrimitiveOperation OpArithmetic	TOTAL	37
+Fannkuch.som pos=2147 len=5	at:	ArrayRead BasicPrimitiveOperation	int	49
+Fannkuch.som pos=2147 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	49
+Fannkuch.som pos=2177 len=18	at:	ArrayRead BasicPrimitiveOperation	int	49
+Fannkuch.som pos=2177 len=18	at:	ArrayRead BasicPrimitiveOperation	TOTAL	49
+Fannkuch.som pos=2192 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	49
+Fannkuch.som pos=2192 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	49
+Fannkuch.som pos=2215 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	int	49
+Fannkuch.som pos=2215 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	49
+Fannkuch.som pos=2247 len=25	at:put:	ArrayWrite BasicPrimitiveOperation	int	49
+Fannkuch.som pos=2247 len=25	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	49
+Fannkuch.som pos=2262 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	49
+Fannkuch.som pos=2262 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	49
+Fannkuch.som pos=2411 len=4	size	BasicPrimitiveOperation OpLength	arr	23
+Fannkuch.som pos=2411 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	23
+Fannkuch.som pos=2500 len=5	at:	ArrayRead BasicPrimitiveOperation	int	39
+Fannkuch.som pos=2500 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	39
+Fannkuch.som pos=2523 len=3	-	BasicPrimitiveOperation OpArithmetic	int	39
+Fannkuch.som pos=2523 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	39
 Fannkuch.som pos=2543 len=27	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	59
 Fannkuch.som pos=2543 len=27	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	59
-Fannkuch.som pos=2560 len=9	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	59
-Fannkuch.som pos=2560 len=9	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	59
-Fannkuch.som pos=2566 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	59
-Fannkuch.som pos=2566 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	59
-Fannkuch.som pos=2587 len=15	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	39
-Fannkuch.som pos=2587 len=15	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	39
-Fannkuch.som pos=2626 len=41	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	39
-Fannkuch.som pos=2626 len=41	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	39
-Fannkuch.som pos=2652 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	39
-Fannkuch.som pos=2652 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	39
-Fannkuch.som pos=2659 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	39
-Fannkuch.som pos=2659 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	39
-Fannkuch.som pos=2664 len=3	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	39
-Fannkuch.som pos=2664 len=3	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	39
-Fannkuch.som pos=2703 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	39
-Fannkuch.som pos=2703 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	39
-Fannkuch.som pos=2728 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	22
-Fannkuch.som pos=2728 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	17
-Fannkuch.som pos=2728 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	39
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	107
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	262
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	369
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	239
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	239
+Fannkuch.som pos=2560 len=9	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	59
+Fannkuch.som pos=2560 len=9	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	59
+Fannkuch.som pos=2566 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	59
+Fannkuch.som pos=2566 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	59
+Fannkuch.som pos=2587 len=15	at:put:	ArrayWrite BasicPrimitiveOperation	int	39
+Fannkuch.som pos=2587 len=15	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	39
+Fannkuch.som pos=2626 len=41	at:put:	ArrayWrite BasicPrimitiveOperation	int	39
+Fannkuch.som pos=2626 len=41	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	39
+Fannkuch.som pos=2652 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	39
+Fannkuch.som pos=2652 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	39
+Fannkuch.som pos=2659 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	39
+Fannkuch.som pos=2659 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	39
+Fannkuch.som pos=2664 len=3	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	39
+Fannkuch.som pos=2664 len=3	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	39
+Fannkuch.som pos=2703 len=5	at:	ArrayRead BasicPrimitiveOperation	int	39
+Fannkuch.som pos=2703 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	39
+Fannkuch.som pos=2728 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	22
+Fannkuch.som pos=2728 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	17
+Fannkuch.som pos=2728 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	39
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	107
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	262
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	369
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	239
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	239
 Kernel.som pos=8589 len=12	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	3
 Kernel.som pos=8589 len=12	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	3
-Kernel.som pos=8767 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	19
-Kernel.som pos=8767 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4
-Kernel.som pos=8767 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	23
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	7
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	7
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	7
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	7
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	7
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	7
-Kernel.som pos=14857 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	95
-Kernel.som pos=14857 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	95
+Kernel.som pos=8767 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	19
+Kernel.som pos=8767 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4
+Kernel.som pos=8767 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	23
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	7
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	7
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	7
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	7
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	7
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	7
+Kernel.som pos=14857 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	95
+Kernel.som pos=14857 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	95
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	3
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	3
-Kernel.som pos=16989 len=7	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	23
-Kernel.som pos=16989 len=7	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	23
-Kernel.som pos=16997 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	23
-Kernel.som pos=16997 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	23
-Kernel.som pos=17073 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	95
-Kernel.som pos=17073 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	95
-Kernel.som pos=17102 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	95
-Kernel.som pos=17102 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	95
-Kernel.som pos=17196 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	23
-Kernel.som pos=17196 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	23
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Kernel.som pos=16989 len=7	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	23
+Kernel.som pos=16989 len=7	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	23
+Kernel.som pos=16997 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	23
+Kernel.som pos=16997 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	23
+Kernel.som pos=17073 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	int	95
+Kernel.som pos=17073 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	95
+Kernel.som pos=17102 len=3	+	BasicPrimitiveOperation OpArithmetic	int	95
+Kernel.som pos=17102 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	95
+Kernel.som pos=17196 len=4	size	BasicPrimitiveOperation OpLength	arr	23
+Kernel.som pos=17196 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	23
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/GraphSearch/general-stats.csv
+++ b/tools/tests/dym/expected-results/GraphSearch/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	25
 Lines Loaded	2150
 Lines Executed	241
-Lines With Statements	1032
+Lines With Statements	980

--- a/tools/tests/dym/expected-results/GraphSearch/operations.csv
+++ b/tools/tests/dym/expected-results/GraphSearch/operations.csv
@@ -1,196 +1,196 @@
 Source Section	Operation	Category	Type	Invocations
-GraphSearch.som pos=1191 len=32	rem:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	2999
-GraphSearch.som pos=1191 len=32	rem:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	2999
-GraphSearch.som pos=1209 len=10	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	2999
-GraphSearch.som pos=1209 len=10	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	2999
-GraphSearch.som pos=1220 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	2999
-GraphSearch.som pos=1220 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	2999
-GraphSearch.som pos=1225 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	2999
-GraphSearch.som pos=1225 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	2999
-GraphSearch.som pos=1229 len=10	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	2999
-GraphSearch.som pos=1229 len=10	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	2999
-GraphSearch.som pos=1345 len=14	rem:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8957
-GraphSearch.som pos=1345 len=14	rem:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8957
-GraphSearch.som pos=1361 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8957
-GraphSearch.som pos=1361 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8957
-GraphSearch.som pos=1365 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	8957
-GraphSearch.som pos=1365 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	8957
-GraphSearch.som pos=1403 len=32	rem:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8957
-GraphSearch.som pos=1403 len=32	rem:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8957
-GraphSearch.som pos=1419 len=11	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8957
-GraphSearch.som pos=1419 len=11	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8957
-GraphSearch.som pos=1431 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8957
-GraphSearch.som pos=1431 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8957
-GraphSearch.som pos=1437 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8957
-GraphSearch.som pos=1437 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8957
-GraphSearch.som pos=1441 len=11	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	8957
-GraphSearch.som pos=1441 len=11	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	8957
-GraphSearch.som pos=1471 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag VirtualInvokeReceiver	ref	8957
-GraphSearch.som pos=1471 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag VirtualInvokeReceiver	TOTAL	8957
-GraphSearch.som pos=1544 len=10	at:	ArrayRead BasicPrimitiveOperation StatementTag VirtualInvokeReceiver	ref	8957
-GraphSearch.som pos=1544 len=10	at:	ArrayRead BasicPrimitiveOperation StatementTag VirtualInvokeReceiver	TOTAL	8957
-GraphSearch.som pos=1722 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag VirtualInvokeReceiver	ref	2999
-GraphSearch.som pos=1722 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag VirtualInvokeReceiver	TOTAL	2999
-GraphSearch.som pos=1754 len=56	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	2999
-GraphSearch.som pos=1754 len=56	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	2999
-GraphSearch.som pos=1791 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	2999
-GraphSearch.som pos=1791 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	2999
-GraphSearch.som pos=1845 len=11	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	2999
-GraphSearch.som pos=1845 len=11	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	2999
-GraphSearch.som pos=2086 len=17	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	17915
-GraphSearch.som pos=2086 len=17	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	17915
-GraphSearch.som pos=2122 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	17915
-GraphSearch.som pos=2122 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	17915
-GraphSearch.som pos=2706 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition StatementTag	bool	18000
-GraphSearch.som pos=2706 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition StatementTag	bool	2999
-GraphSearch.som pos=2706 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition StatementTag	TOTAL	20999
-GraphSearch.som pos=2747 len=18	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	2999
-GraphSearch.som pos=2747 len=18	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	2999
-GraphSearch.som pos=2791 len=7	at:	ArrayRead BasicPrimitiveOperation StatementTag VirtualInvokeReceiver	ref	2999
-GraphSearch.som pos=2791 len=7	at:	ArrayRead BasicPrimitiveOperation StatementTag VirtualInvokeReceiver	TOTAL	2999
-GraphSearch.som pos=2843 len=7	at:	ArrayRead BasicPrimitiveOperation StatementTag VirtualInvokeReceiver	ref	2999
-GraphSearch.som pos=2843 len=7	at:	ArrayRead BasicPrimitiveOperation StatementTag VirtualInvokeReceiver	TOTAL	2999
-GraphSearch.som pos=2862 len=31	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	2999
-GraphSearch.som pos=2862 len=31	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	2999
-GraphSearch.som pos=2876 len=7	at:	ArrayRead BasicPrimitiveOperation StatementTag VirtualInvokeReceiver	ref	2999
-GraphSearch.som pos=2876 len=7	at:	ArrayRead BasicPrimitiveOperation StatementTag VirtualInvokeReceiver	TOTAL	2999
-GraphSearch.som pos=2895 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	2999
-GraphSearch.som pos=2895 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	2999
-GraphSearch.som pos=2977 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	17915
-GraphSearch.som pos=2977 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	17915
-GraphSearch.som pos=3012 len=6	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition StatementTag	bool	5639
-GraphSearch.som pos=3012 len=6	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition StatementTag	bool	12276
-GraphSearch.som pos=3012 len=6	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition StatementTag	TOTAL	17915
-GraphSearch.som pos=3052 len=30	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	5639
-GraphSearch.som pos=3052 len=30	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	5639
-GraphSearch.som pos=3070 len=7	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	5639
-GraphSearch.som pos=3070 len=7	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	5639
-GraphSearch.som pos=3079 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	5639
-GraphSearch.som pos=3079 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	5639
-GraphSearch.som pos=3118 len=16	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	5639
-GraphSearch.som pos=3118 len=16	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	5639
-GraphSearch.som pos=3261 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition StatementTag	bool	18000
-GraphSearch.som pos=3261 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition StatementTag	bool	2999
-GraphSearch.som pos=3261 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition StatementTag	TOTAL	20999
-GraphSearch.som pos=3305 len=17	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	2998
-GraphSearch.som pos=3305 len=17	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	2998
-GraphSearch.som pos=3349 len=17	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	2998
-GraphSearch.som pos=3349 len=17	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	2998
-GraphSearch.som pos=3424 len=18	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	2998
-GraphSearch.som pos=3424 len=18	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	2998
-GraphSearch.som pos=3562 len=46	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-GraphSearch.som pos=3710 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	2999
-GraphSearch.som pos=3710 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	2999
-GraphSearch.som pos=3733 len=19	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-GraphSearch.som pos=4080 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=2451 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2451 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2471 len=55	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2471 len=55	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2479 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2479 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2501 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2501 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2508 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2508 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2528 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic StatementTag	int	20915
-Harness.som pos=2528 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	20915
-Harness.som pos=2572 len=18	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2572 len=18	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2592 len=42	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2592 len=42	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2606 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2606 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2627 len=6	>>>	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2627 len=6	>>>	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2636 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic StatementTag	int	20915
-Harness.som pos=2636 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	20915
-Harness.som pos=2686 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2686 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2706 len=55	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2706 len=55	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2714 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2714 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2736 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2736 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2743 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2743 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2763 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic StatementTag	int	20915
-Harness.som pos=2763 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	20915
-Harness.som pos=2813 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2813 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2827 len=61	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2827 len=61	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2841 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2841 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2863 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2863 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2870 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2870 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2890 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic StatementTag	int	20915
-Harness.som pos=2890 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	20915
-Harness.som pos=2940 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2940 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2960 len=55	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2960 len=55	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2968 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2968 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2990 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2990 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=2997 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=2997 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=3017 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic StatementTag	int	20915
-Harness.som pos=3017 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	20915
-Harness.som pos=3061 len=18	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=3061 len=18	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=3081 len=42	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=3081 len=42	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=3095 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=3095 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=3116 len=6	>>>	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20915
-Harness.som pos=3116 len=6	>>>	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20915
-Harness.som pos=3125 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic StatementTag	int	20915
-Harness.som pos=3125 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	20915
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	9026
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	131717
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	140743
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	131717
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	131717
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	10
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	10
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	10
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	10
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	10
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	10
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	3000
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	2999
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	5999
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	9
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	9
+GraphSearch.som pos=1191 len=32	rem:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	2999
+GraphSearch.som pos=1191 len=32	rem:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	2999
+GraphSearch.som pos=1209 len=10	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	2999
+GraphSearch.som pos=1209 len=10	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	2999
+GraphSearch.som pos=1220 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	2999
+GraphSearch.som pos=1220 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	2999
+GraphSearch.som pos=1225 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	2999
+GraphSearch.som pos=1225 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	2999
+GraphSearch.som pos=1229 len=10	+	BasicPrimitiveOperation OpArithmetic	int	2999
+GraphSearch.som pos=1229 len=10	+	BasicPrimitiveOperation OpArithmetic	TOTAL	2999
+GraphSearch.som pos=1345 len=14	rem:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8957
+GraphSearch.som pos=1345 len=14	rem:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8957
+GraphSearch.som pos=1361 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8957
+GraphSearch.som pos=1361 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8957
+GraphSearch.som pos=1365 len=3	+	BasicPrimitiveOperation OpArithmetic	int	8957
+GraphSearch.som pos=1365 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	8957
+GraphSearch.som pos=1403 len=32	rem:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8957
+GraphSearch.som pos=1403 len=32	rem:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8957
+GraphSearch.som pos=1419 len=11	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8957
+GraphSearch.som pos=1419 len=11	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8957
+GraphSearch.som pos=1431 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8957
+GraphSearch.som pos=1431 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8957
+GraphSearch.som pos=1437 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8957
+GraphSearch.som pos=1437 len=3	abs	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8957
+GraphSearch.som pos=1441 len=11	+	BasicPrimitiveOperation OpArithmetic	int	8957
+GraphSearch.som pos=1441 len=11	+	BasicPrimitiveOperation OpArithmetic	TOTAL	8957
+GraphSearch.som pos=1471 len=5	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	ref	8957
+GraphSearch.som pos=1471 len=5	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	TOTAL	8957
+GraphSearch.som pos=1544 len=10	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	ref	8957
+GraphSearch.som pos=1544 len=10	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	TOTAL	8957
+GraphSearch.som pos=1722 len=5	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	ref	2999
+GraphSearch.som pos=1722 len=5	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	TOTAL	2999
+GraphSearch.som pos=1754 len=56	at:put:	ArrayWrite BasicPrimitiveOperation	ref	2999
+GraphSearch.som pos=1754 len=56	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	2999
+GraphSearch.som pos=1791 len=3	+	BasicPrimitiveOperation OpArithmetic	int	2999
+GraphSearch.som pos=1791 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	2999
+GraphSearch.som pos=1845 len=11	+	BasicPrimitiveOperation OpArithmetic	int	2999
+GraphSearch.som pos=1845 len=11	+	BasicPrimitiveOperation OpArithmetic	TOTAL	2999
+GraphSearch.som pos=2086 len=17	at:put:	ArrayWrite BasicPrimitiveOperation	int	17915
+GraphSearch.som pos=2086 len=17	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	17915
+GraphSearch.som pos=2122 len=3	+	BasicPrimitiveOperation OpArithmetic	int	17915
+GraphSearch.som pos=2122 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	17915
+GraphSearch.som pos=2706 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	bool	18000
+GraphSearch.som pos=2706 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	bool	2999
+GraphSearch.som pos=2706 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	TOTAL	20999
+GraphSearch.som pos=2747 len=18	at:put:	ArrayWrite BasicPrimitiveOperation	bool	2999
+GraphSearch.som pos=2747 len=18	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	2999
+GraphSearch.som pos=2791 len=7	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	ref	2999
+GraphSearch.som pos=2791 len=7	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	TOTAL	2999
+GraphSearch.som pos=2843 len=7	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	ref	2999
+GraphSearch.som pos=2843 len=7	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	TOTAL	2999
+GraphSearch.som pos=2862 len=31	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	2999
+GraphSearch.som pos=2862 len=31	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	2999
+GraphSearch.som pos=2876 len=7	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	ref	2999
+GraphSearch.som pos=2876 len=7	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	TOTAL	2999
+GraphSearch.som pos=2895 len=3	-	BasicPrimitiveOperation OpArithmetic	int	2999
+GraphSearch.som pos=2895 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	2999
+GraphSearch.som pos=2977 len=5	at:	ArrayRead BasicPrimitiveOperation	int	17915
+GraphSearch.som pos=2977 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	17915
+GraphSearch.som pos=3012 len=6	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	bool	5639
+GraphSearch.som pos=3012 len=6	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	bool	12276
+GraphSearch.som pos=3012 len=6	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	TOTAL	17915
+GraphSearch.som pos=3052 len=30	at:put:	ArrayWrite BasicPrimitiveOperation	int	5639
+GraphSearch.som pos=3052 len=30	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	5639
+GraphSearch.som pos=3070 len=7	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	5639
+GraphSearch.som pos=3070 len=7	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	5639
+GraphSearch.som pos=3079 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	5639
+GraphSearch.som pos=3079 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	5639
+GraphSearch.som pos=3118 len=16	at:put:	ArrayWrite BasicPrimitiveOperation	bool	5639
+GraphSearch.som pos=3118 len=16	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	5639
+GraphSearch.som pos=3261 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	bool	18000
+GraphSearch.som pos=3261 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	bool	2999
+GraphSearch.som pos=3261 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	TOTAL	20999
+GraphSearch.som pos=3305 len=17	at:put:	ArrayWrite BasicPrimitiveOperation	bool	2998
+GraphSearch.som pos=3305 len=17	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	2998
+GraphSearch.som pos=3349 len=17	at:put:	ArrayWrite BasicPrimitiveOperation	bool	2998
+GraphSearch.som pos=3349 len=17	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	2998
+GraphSearch.som pos=3424 len=18	at:put:	ArrayWrite BasicPrimitiveOperation	bool	2998
+GraphSearch.som pos=3424 len=18	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	2998
+GraphSearch.som pos=3562 len=46	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+GraphSearch.som pos=3710 len=3	+	BasicPrimitiveOperation OpArithmetic	int	2999
+GraphSearch.som pos=3710 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	2999
+GraphSearch.som pos=3733 len=19	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+GraphSearch.som pos=4080 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=2451 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2451 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2471 len=55	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2471 len=55	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2479 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2479 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2501 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2501 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2508 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2508 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2528 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic	int	20915
+Harness.som pos=2528 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic	TOTAL	20915
+Harness.som pos=2572 len=18	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2572 len=18	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2592 len=42	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2592 len=42	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2606 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2606 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2627 len=6	>>>	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2627 len=6	>>>	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2636 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic	int	20915
+Harness.som pos=2636 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic	TOTAL	20915
+Harness.som pos=2686 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2686 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2706 len=55	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2706 len=55	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2714 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2714 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2736 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2736 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2743 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2743 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2763 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic	int	20915
+Harness.som pos=2763 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic	TOTAL	20915
+Harness.som pos=2813 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2813 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2827 len=61	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2827 len=61	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2841 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2841 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2863 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2863 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2870 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2870 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2890 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic	int	20915
+Harness.som pos=2890 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic	TOTAL	20915
+Harness.som pos=2940 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2940 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2960 len=55	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2960 len=55	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2968 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2968 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2990 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2990 len=5	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=2997 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=2997 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=3017 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic	int	20915
+Harness.som pos=3017 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic	TOTAL	20915
+Harness.som pos=3061 len=18	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=3061 len=18	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=3081 len=42	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=3081 len=42	bitXor:	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=3095 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=3095 len=20	as32BitUnsignedValue	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=3116 len=6	>>>	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20915
+Harness.som pos=3116 len=6	>>>	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20915
+Harness.som pos=3125 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic	int	20915
+Harness.som pos=3125 len=18	as32BitSignedValue	BasicPrimitiveOperation OpArithmetic	TOTAL	20915
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	9026
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	131717
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	140743
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	131717
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	131717
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	10
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	10
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	10
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	10
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	10
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	10
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	3000
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	2999
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	5999
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	arr	9
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	9
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	bool	8999
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	20916
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	ref	3000
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	32915
-Kernel.som pos=21459 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	2999
-Kernel.som pos=21459 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	2999
-Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	17915
-Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	17915
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	17915
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	17915
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	17915
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	17915
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	17915
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	17915
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	17915
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	17915
+Kernel.som pos=21459 len=3	-	BasicPrimitiveOperation OpArithmetic	int	2999
+Kernel.som pos=21459 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	2999
+Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	17915
+Kernel.som pos=21496 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	17915
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	17915
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	17915
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	17915
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	17915
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	17915
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	17915
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	int	17915
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	17915
 Kernel.som pos=24060 len=10	-	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	int	2999
 Kernel.som pos=24060 len=10	-	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	TOTAL	2999
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/Json/general-stats.csv
+++ b/tools/tests/dym/expected-results/Json/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	39
 Lines Loaded	2792
 Lines Executed	362
-Lines With Statements	1364
+Lines With Statements	1271

--- a/tools/tests/dym/expected-results/Json/operations.csv
+++ b/tools/tests/dym/expected-results/Json/operations.csv
@@ -1,215 +1,215 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Json.som pos=27326 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	2801
-Json.som pos=27326 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	590
-Json.som pos=27326 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	3391
-Json.som pos=27377 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	2775
-Json.som pos=27377 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	26
-Json.som pos=27377 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	2801
-Json.som pos=27428 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	2772
-Json.som pos=27428 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	3
-Json.som pos=27428 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	2775
-Json.som pos=27479 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1421
-Json.som pos=27479 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1351
-Json.som pos=27479 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	2772
-Json.som pos=27530 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	868
-Json.som pos=27530 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	553
-Json.som pos=27530 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1421
-Json.som pos=27581 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	712
-Json.som pos=27581 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	156
-Json.som pos=27581 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	868
-Json.som pos=27759 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	704
-Json.som pos=27759 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	7
-Json.som pos=27759 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	711
-Json.som pos=27810 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	685
-Json.som pos=27810 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	19
-Json.som pos=27810 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	704
-Json.som pos=27861 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	443
-Json.som pos=27861 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	242
-Json.som pos=27861 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	685
-Json.som pos=27912 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	192
-Json.som pos=27912 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	251
-Json.som pos=27912 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	443
-Json.som pos=27963 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	173
-Json.som pos=27963 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	19
-Json.som pos=27963 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	192
-Json.som pos=28014 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	133
-Json.som pos=28014 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	40
-Json.som pos=28014 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	173
-Json.som pos=28065 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	96
-Json.som pos=28065 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	36
-Json.som pos=28065 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	132
-Json.som pos=28116 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	45
-Json.som pos=28116 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	50
-Json.som pos=28116 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	95
-Json.som pos=28167 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	27
-Json.som pos=28167 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	17
-Json.som pos=28167 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	44
-Json.som pos=28218 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	16
-Json.som pos=28218 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	11
-Json.som pos=28218 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	27
-Json.som pos=28269 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	16
-Json.som pos=28269 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	16
-Json.som pos=29712 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	597
-Json.som pos=29712 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	597
-Json.som pos=30600 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	12885
-Json.som pos=30600 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1949
-Json.som pos=30600 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	14834
-Json.som pos=30637 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	12885
-Json.som pos=30637 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	12885
-Json.som pos=31905 len=6	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	19
-Json.som pos=31905 len=6	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	692
-Json.som pos=31905 len=6	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	711
-Json.som pos=32307 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	711
-Json.som pos=32307 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	711
-Json.som pos=32347 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	711
-Json.som pos=32347 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	711
-Json.som pos=32602 len=4	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	4258
-Json.som pos=32602 len=4	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	5857
-Json.som pos=32602 len=4	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	10115
-Json.som pos=32927 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	25820
-Json.som pos=32927 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	25820
-Json.som pos=33026 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	25820
-Json.som pos=33026 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	25820
-Json.som pos=33054 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	25820
-Json.som pos=33054 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	25820
-Json.som pos=33118 len=15	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Json.som pos=33118 len=15	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	25819
-Json.som pos=33118 len=15	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	25820
-Json.som pos=33127 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	25820
-Json.som pos=33127 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	25820
-Json.som pos=33170 len=13	charAt:	ComplexPrimitiveOperation StatementTag StringAccess	str	25819
-Json.som pos=33170 len=13	charAt:	ComplexPrimitiveOperation StatementTag StringAccess	TOTAL	25819
-Json.som pos=33495 len=15	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	2660
-Json.som pos=33495 len=15	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	2660
-Json.som pos=33548 len=41	substringFrom:to:	ComplexPrimitiveOperation StatementTag StringAccess	str	2660
-Json.som pos=33548 len=41	substringFrom:to:	ComplexPrimitiveOperation StatementTag StringAccess	TOTAL	2660
-Json.som pos=33586 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	2660
-Json.som pos=33586 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	2660
-Json.som pos=34267 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	1
-Json.som pos=34267 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	8688
-Json.som pos=34267 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	8689
-Json.som pos=34306 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	1
-Json.som pos=34306 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	8688
-Json.som pos=34306 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	8689
-Json.som pos=34345 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	1
-Json.som pos=34345 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	8688
-Json.som pos=34345 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	8689
-Json.som pos=34384 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	1
-Json.som pos=34384 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	8688
-Json.som pos=34384 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	8689
-Json.som pos=34460 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	2441
-Json.som pos=34460 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	101
-Json.som pos=34460 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	2542
-Json.som pos=34498 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	2145
-Json.som pos=34498 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	296
-Json.som pos=34498 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	2441
-Json.som pos=34536 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1746
-Json.som pos=34536 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	399
-Json.som pos=34536 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	2145
-Json.som pos=34574 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1596
-Json.som pos=34574 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	150
-Json.som pos=34574 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1746
-Json.som pos=34612 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1525
-Json.som pos=34612 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	71
-Json.som pos=34612 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1596
-Json.som pos=34650 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1115
-Json.som pos=34650 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	409
-Json.som pos=34650 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1524
-Json.som pos=34688 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	990
-Json.som pos=34688 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	125
-Json.som pos=34688 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1115
-Json.som pos=34726 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	852
-Json.som pos=34726 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	138
-Json.som pos=34726 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	990
-Json.som pos=34764 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	747
-Json.som pos=34764 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	105
-Json.som pos=34764 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	852
-Json.som pos=34802 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	692
-Json.som pos=34802 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	55
-Json.som pos=34802 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	747
-Json.som pos=35094 len=5	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	597
-Json.som pos=35094 len=5	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	597
-Json.som pos=35129 len=23	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	597
-Json.som pos=35129 len=23	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	597
-Json.som pos=35149 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	597
-Json.som pos=35149 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	597
-Json.som pos=35637 len=8	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	2
-Json.som pos=35637 len=8	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	2
-Json.som pos=35647 len=5	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	2
-Json.som pos=35647 len=5	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	2
-Json.som pos=35654 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	2
-Json.som pos=35654 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	2
-Json.som pos=35720 len=4	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	600
-Json.som pos=35720 len=4	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	600
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Json.som pos=27326 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	2801
+Json.som pos=27326 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	590
+Json.som pos=27326 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	3391
+Json.som pos=27377 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	2775
+Json.som pos=27377 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	26
+Json.som pos=27377 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	2801
+Json.som pos=27428 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	2772
+Json.som pos=27428 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	3
+Json.som pos=27428 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	2775
+Json.som pos=27479 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1421
+Json.som pos=27479 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1351
+Json.som pos=27479 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	2772
+Json.som pos=27530 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	868
+Json.som pos=27530 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	553
+Json.som pos=27530 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1421
+Json.som pos=27581 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	712
+Json.som pos=27581 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	156
+Json.som pos=27581 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	868
+Json.som pos=27759 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	704
+Json.som pos=27759 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	7
+Json.som pos=27759 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	711
+Json.som pos=27810 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	685
+Json.som pos=27810 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	19
+Json.som pos=27810 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	704
+Json.som pos=27861 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	443
+Json.som pos=27861 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	242
+Json.som pos=27861 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	685
+Json.som pos=27912 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	192
+Json.som pos=27912 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	251
+Json.som pos=27912 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	443
+Json.som pos=27963 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	173
+Json.som pos=27963 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	19
+Json.som pos=27963 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	192
+Json.som pos=28014 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	133
+Json.som pos=28014 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	40
+Json.som pos=28014 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	173
+Json.som pos=28065 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	96
+Json.som pos=28065 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	36
+Json.som pos=28065 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	132
+Json.som pos=28116 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	45
+Json.som pos=28116 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	50
+Json.som pos=28116 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	95
+Json.som pos=28167 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	27
+Json.som pos=28167 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	17
+Json.som pos=28167 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	44
+Json.som pos=28218 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	16
+Json.som pos=28218 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	11
+Json.som pos=28218 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	27
+Json.som pos=28269 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	16
+Json.som pos=28269 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	16
+Json.som pos=29712 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	597
+Json.som pos=29712 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	597
+Json.som pos=30600 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	12885
+Json.som pos=30600 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1949
+Json.som pos=30600 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	14834
+Json.som pos=30637 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	12885
+Json.som pos=30637 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	12885
+Json.som pos=31905 len=6	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	19
+Json.som pos=31905 len=6	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	692
+Json.som pos=31905 len=6	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	711
+Json.som pos=32307 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	711
+Json.som pos=32307 len=3	not	BasicPrimitiveOperation OpArithmetic	TOTAL	711
+Json.som pos=32347 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	711
+Json.som pos=32347 len=3	not	BasicPrimitiveOperation OpArithmetic	TOTAL	711
+Json.som pos=32602 len=4	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	4258
+Json.som pos=32602 len=4	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	5857
+Json.som pos=32602 len=4	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	10115
+Json.som pos=32927 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	25820
+Json.som pos=32927 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	25820
+Json.som pos=33026 len=3	+	BasicPrimitiveOperation OpArithmetic	int	25820
+Json.som pos=33026 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	25820
+Json.som pos=33054 len=3	+	BasicPrimitiveOperation OpArithmetic	int	25820
+Json.som pos=33054 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	25820
+Json.som pos=33118 len=15	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Json.som pos=33118 len=15	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	25819
+Json.som pos=33118 len=15	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	25820
+Json.som pos=33127 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	25820
+Json.som pos=33127 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	25820
+Json.som pos=33170 len=13	charAt:	ComplexPrimitiveOperation StringAccess	str	25819
+Json.som pos=33170 len=13	charAt:	ComplexPrimitiveOperation StringAccess	TOTAL	25819
+Json.som pos=33495 len=15	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	2660
+Json.som pos=33495 len=15	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	2660
+Json.som pos=33548 len=41	substringFrom:to:	ComplexPrimitiveOperation StringAccess	str	2660
+Json.som pos=33548 len=41	substringFrom:to:	ComplexPrimitiveOperation StringAccess	TOTAL	2660
+Json.som pos=33586 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	2660
+Json.som pos=33586 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	2660
+Json.som pos=34267 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	1
+Json.som pos=34267 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	8688
+Json.som pos=34267 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	8689
+Json.som pos=34306 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	1
+Json.som pos=34306 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	8688
+Json.som pos=34306 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	8689
+Json.som pos=34345 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	1
+Json.som pos=34345 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	8688
+Json.som pos=34345 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	8689
+Json.som pos=34384 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	1
+Json.som pos=34384 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	8688
+Json.som pos=34384 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	8689
+Json.som pos=34460 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	2441
+Json.som pos=34460 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	101
+Json.som pos=34460 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	2542
+Json.som pos=34498 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	2145
+Json.som pos=34498 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	296
+Json.som pos=34498 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	2441
+Json.som pos=34536 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1746
+Json.som pos=34536 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	399
+Json.som pos=34536 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	2145
+Json.som pos=34574 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1596
+Json.som pos=34574 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	150
+Json.som pos=34574 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1746
+Json.som pos=34612 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1525
+Json.som pos=34612 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	71
+Json.som pos=34612 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1596
+Json.som pos=34650 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1115
+Json.som pos=34650 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	409
+Json.som pos=34650 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1524
+Json.som pos=34688 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	990
+Json.som pos=34688 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	125
+Json.som pos=34688 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1115
+Json.som pos=34726 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	852
+Json.som pos=34726 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	138
+Json.som pos=34726 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	990
+Json.som pos=34764 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	747
+Json.som pos=34764 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	105
+Json.som pos=34764 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	852
+Json.som pos=34802 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	692
+Json.som pos=34802 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	55
+Json.som pos=34802 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	747
+Json.som pos=35094 len=5	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	597
+Json.som pos=35094 len=5	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	597
+Json.som pos=35129 len=23	at:put:	ArrayWrite BasicPrimitiveOperation	int	597
+Json.som pos=35129 len=23	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	597
+Json.som pos=35149 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	597
+Json.som pos=35149 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	597
+Json.som pos=35637 len=8	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	2
+Json.som pos=35637 len=8	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	2
+Json.som pos=35647 len=5	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	2
+Json.som pos=35647 len=5	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	2
+Json.som pos=35654 len=3	-	BasicPrimitiveOperation OpArithmetic	int	2
+Json.som pos=35654 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	2
+Json.som pos=35720 len=4	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	600
+Json.som pos=35720 len=4	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	600
 Json.som pos=35726 len=3	+	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	int	600
 Json.som pos=35726 len=3	+	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	TOTAL	600
-Json.som pos=39692 len=5	=	BasicPrimitiveOperation OpComparison StatementTag	str	2
-Json.som pos=39692 len=5	=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	2
-Json.som pos=39730 len=5	=	BasicPrimitiveOperation OpComparison StatementTag	str	1
-Json.som pos=39730 len=5	=	BasicPrimitiveOperation OpComparison StatementTag	str	1
-Json.som pos=39730 len=5	=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	2
-Json.som pos=39768 len=5	=	BasicPrimitiveOperation OpComparison StatementTag	str	1
-Json.som pos=39768 len=5	=	BasicPrimitiveOperation OpComparison StatementTag	str	1
-Json.som pos=39768 len=5	=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	2
-Json.som pos=42650 len=4	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2
-Json.som pos=42650 len=4	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	2
-Json.som pos=44104 len=5	<>	BasicPrimitiveOperation OpComparison StatementTag VirtualInvokeReceiver	int	2
-Json.som pos=44104 len=5	<>	BasicPrimitiveOperation OpComparison StatementTag VirtualInvokeReceiver	TOTAL	2
-Json.som pos=44118 len=17	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	2
-Json.som pos=44118 len=17	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	2
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	162
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5179
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	5341
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	5179
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	5179
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	3
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	3
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	3
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	3
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	3
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	3
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	158
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	158
+Json.som pos=39692 len=5	=	BasicPrimitiveOperation OpComparison	str	2
+Json.som pos=39692 len=5	=	BasicPrimitiveOperation OpComparison	TOTAL	2
+Json.som pos=39730 len=5	=	BasicPrimitiveOperation OpComparison	str	1
+Json.som pos=39730 len=5	=	BasicPrimitiveOperation OpComparison	str	1
+Json.som pos=39730 len=5	=	BasicPrimitiveOperation OpComparison	TOTAL	2
+Json.som pos=39768 len=5	=	BasicPrimitiveOperation OpComparison	str	1
+Json.som pos=39768 len=5	=	BasicPrimitiveOperation OpComparison	str	1
+Json.som pos=39768 len=5	=	BasicPrimitiveOperation OpComparison	TOTAL	2
+Json.som pos=42650 len=4	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
+Json.som pos=42650 len=4	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	2
+Json.som pos=44104 len=5	<>	BasicPrimitiveOperation OpComparison VirtualInvokeReceiver	int	2
+Json.som pos=44104 len=5	<>	BasicPrimitiveOperation OpComparison VirtualInvokeReceiver	TOTAL	2
+Json.som pos=44118 len=17	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	2
+Json.som pos=44118 len=17	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	2
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	162
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5179
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	5341
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	5179
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	5179
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	3
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	3
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	3
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	3
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	3
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	3
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	arr	158
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	158
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	5023
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	5023
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	2
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	2
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	5
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3986
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	3988
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	3988
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	3988
-Kernel.som pos=22306 len=14	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=22306 len=14	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=22316 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	1
-Kernel.som pos=22316 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	ref	2
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	ref	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	str	2
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	5
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3986
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	3988
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	3988
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	3988
+Kernel.som pos=22306 len=14	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=22306 len=14	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=22316 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
+Kernel.som pos=22316 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
 Kernel.som pos=22367 len=26	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	ref	149
 Kernel.som pos=22367 len=26	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	149
-Kernel.som pos=22387 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	149
-Kernel.som pos=22387 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	149
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	553
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	619
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	712
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	156
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	1351
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	597
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	3988
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	3988
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	3988
+Kernel.som pos=22387 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	149
+Kernel.som pos=22387 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	149
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	553
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	619
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	712
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	156
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	1351
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	597
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	3988
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	int	3988
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	3988
 Kernel.som pos=24060 len=10	-	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	int	598
 Kernel.som pos=24060 len=10	-	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	TOTAL	598
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	int	5
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	5
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	int	5
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	5
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	int	5
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	TOTAL	5
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	int	5
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	TOTAL	5
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/LanguageFeatures.Dispatch/general-stats.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Dispatch/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	19
 Lines Loaded	2556
 Lines Executed	180
-Lines With Statements	1206
+Lines With Statements	1151

--- a/tools/tests/dym/expected-results/LanguageFeatures.Dispatch/operations.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Dispatch/operations.csv
@@ -1,68 +1,68 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	40044
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	40049
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	40042
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	40042
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	16
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	16
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	16
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	16
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	15
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	16
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	str	1
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	TOTAL	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	24
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	24
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	24
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	24
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	23
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	24
-Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-LanguageFeatures.som pos=9122 len=18	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	39999
-LanguageFeatures.som pos=9122 len=18	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	39999
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	40044
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	40049
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	40042
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	40042
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	16
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	16
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	16
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	16
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	15
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	16
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	str	1
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	TOTAL	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	24
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	24
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	int	24
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	24
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	23
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	24
+Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	TOTAL	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	TOTAL	1
+LanguageFeatures.som pos=9122 len=18	+	BasicPrimitiveOperation OpArithmetic	int	39999
+LanguageFeatures.som pos=9122 len=18	+	BasicPrimitiveOperation OpArithmetic	TOTAL	39999
 LanguageFeatures.som pos=9263 len=8	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	int	1
 LanguageFeatures.som pos=9263 len=8	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	TOTAL	1
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/LanguageFeatures.Fibonacci/general-stats.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Fibonacci/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	35
 Lines Loaded	2556
 Lines Executed	181
-Lines With Statements	1206
+Lines With Statements	1151

--- a/tools/tests/dym/expected-results/LanguageFeatures.Fibonacci/operations.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Fibonacci/operations.csv
@@ -1,75 +1,75 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	45
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	48
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	43
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	43
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	16
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	16
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	16
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	16
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	15
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	16
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	str	1
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	TOTAL	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	25
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	25
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	25
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	25
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	24
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	25
-Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-LanguageFeatures.som pos=1660 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	21889
-LanguageFeatures.som pos=1660 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	21892
-LanguageFeatures.som pos=1660 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	43781
-LanguageFeatures.som pos=1731 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	21889
-LanguageFeatures.som pos=1731 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	21889
-LanguageFeatures.som pos=1736 len=25	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	21871
-LanguageFeatures.som pos=1736 len=25	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	21871
-LanguageFeatures.som pos=1757 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	21889
-LanguageFeatures.som pos=1757 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	21889
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	45
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	48
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	43
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	43
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	16
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	16
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	16
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	16
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	15
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	16
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	str	1
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	TOTAL	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	25
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	25
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	int	25
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	25
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	24
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	25
+Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	TOTAL	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	TOTAL	1
+LanguageFeatures.som pos=1660 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	21889
+LanguageFeatures.som pos=1660 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	21892
+LanguageFeatures.som pos=1660 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	43781
+LanguageFeatures.som pos=1731 len=3	-	BasicPrimitiveOperation OpArithmetic	int	21889
+LanguageFeatures.som pos=1731 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	21889
+LanguageFeatures.som pos=1736 len=25	+	BasicPrimitiveOperation OpArithmetic	int	21871
+LanguageFeatures.som pos=1736 len=25	+	BasicPrimitiveOperation OpArithmetic	TOTAL	21871
+LanguageFeatures.som pos=1757 len=3	-	BasicPrimitiveOperation OpArithmetic	int	21889
+LanguageFeatures.som pos=1757 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	21889
 LanguageFeatures.som pos=1823 len=8	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	int	1
 LanguageFeatures.som pos=1823 len=8	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	TOTAL	1
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/LanguageFeatures.FieldLoop/general-stats.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.FieldLoop/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	15
 Lines Loaded	2556
 Lines Executed	212
-Lines With Statements	1206
+Lines With Statements	1152

--- a/tools/tests/dym/expected-results/LanguageFeatures.FieldLoop/operations.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.FieldLoop/operations.csv
@@ -1,130 +1,130 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	44
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	47
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	42
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	42
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	16
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	16
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	16
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	16
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	15
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	16
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	str	1
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	TOTAL	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	25
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	25
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	25
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	25
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	24
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	25
-Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-LanguageFeatures.som pos=2499 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-LanguageFeatures.som pos=2499 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	19999
-LanguageFeatures.som pos=2499 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	20000
-LanguageFeatures.som pos=2539 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=2539 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=2571 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=2571 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=2603 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=2603 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=2635 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=2635 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=2667 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=2667 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=2699 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=2699 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=2738 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=2738 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=2770 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=2770 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=2802 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=2802 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=2834 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=2834 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=2866 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=2866 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=2905 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=2905 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=2937 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=2937 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=2969 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=2969 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3001 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3001 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3033 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3033 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3072 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3072 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3104 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3104 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3136 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3136 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3168 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3168 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3200 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3200 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3239 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3239 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3271 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3271 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3303 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3303 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3335 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3335 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3367 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3367 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3406 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3406 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3438 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3438 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3470 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3470 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3502 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3502 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
-LanguageFeatures.som pos=3534 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	19999
-LanguageFeatures.som pos=3534 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	19999
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	44
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	47
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	42
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	42
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	16
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	16
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	16
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	16
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	15
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	16
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	str	1
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	TOTAL	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	25
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	25
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	int	25
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	25
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	24
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	25
+Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	TOTAL	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	TOTAL	1
+LanguageFeatures.som pos=2499 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+LanguageFeatures.som pos=2499 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	19999
+LanguageFeatures.som pos=2499 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	20000
+LanguageFeatures.som pos=2539 len=3	-	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=2539 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=2571 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=2571 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=2603 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=2603 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=2635 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=2635 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=2667 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=2667 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=2699 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=2699 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=2738 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=2738 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=2770 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=2770 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=2802 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=2802 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=2834 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=2834 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=2866 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=2866 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=2905 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=2905 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=2937 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=2937 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=2969 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=2969 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3001 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3001 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3033 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3033 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3072 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3072 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3104 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3104 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3136 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3136 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3168 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3168 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3200 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3200 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3239 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3239 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3271 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3271 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3303 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3303 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3335 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3335 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3367 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3367 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3406 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3406 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3438 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3438 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3470 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3470 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3502 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3502 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
+LanguageFeatures.som pos=3534 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999
+LanguageFeatures.som pos=3534 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
 LanguageFeatures.som pos=3624 len=8	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	TOTAL	0
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/LanguageFeatures.IntegerLoop/general-stats.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.IntegerLoop/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	17
 Lines Loaded	2556
 Lines Executed	180
-Lines With Statements	1206
+Lines With Statements	1151

--- a/tools/tests/dym/expected-results/LanguageFeatures.IntegerLoop/operations.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.IntegerLoop/operations.csv
@@ -1,70 +1,70 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Kernel.som pos=6487 len=6	-	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	int	1
 Kernel.som pos=6487 len=6	-	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	TOTAL	1
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	80049
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	80054
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	80047
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	80047
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	16
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	16
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	16
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	16
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	15
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	16
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	str	1
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	TOTAL	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	27
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	27
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	27
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	27
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	26
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	27
-Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-LanguageFeatures.som pos=4327 len=6	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	80001
-LanguageFeatures.som pos=4327 len=6	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	80001
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	80049
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	80054
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	80047
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	80047
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	16
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	16
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	16
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	16
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	15
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	16
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	str	1
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	TOTAL	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	27
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	27
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	int	27
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	27
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	26
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	27
+Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	TOTAL	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	TOTAL	1
+LanguageFeatures.som pos=4327 len=6	-	BasicPrimitiveOperation OpArithmetic	int	80001
+LanguageFeatures.som pos=4327 len=6	-	BasicPrimitiveOperation OpArithmetic	TOTAL	80001
 LanguageFeatures.som pos=4401 len=8	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	int	1
 LanguageFeatures.som pos=4401 len=8	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	TOTAL	1
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/LanguageFeatures.Loop/general-stats.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Loop/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	22
 Lines Loaded	2556
 Lines Executed	183
-Lines With Statements	1206
+Lines With Statements	1151

--- a/tools/tests/dym/expected-results/LanguageFeatures.Loop/operations.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Loop/operations.csv
@@ -1,72 +1,72 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	405
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	40440
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	40845
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	40438
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	40438
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	16
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	16
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	16
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	16
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	15
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	16
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	str	1
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	TOTAL	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	20
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	20
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	20
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	20
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	19
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	20
-Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-LanguageFeatures.som pos=4655 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	39999
-LanguageFeatures.som pos=4655 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	39999
-LanguageFeatures.som pos=4672 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	399
-LanguageFeatures.som pos=4672 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	399
-LanguageFeatures.som pos=4868 len=16	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	399
-LanguageFeatures.som pos=4868 len=16	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	399
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	405
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	40440
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	40845
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	40438
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	40438
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	16
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	16
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	16
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	16
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	15
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	16
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	str	1
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	TOTAL	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	20
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	20
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	int	20
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	20
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	19
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	20
+Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	TOTAL	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	TOTAL	1
+LanguageFeatures.som pos=4655 len=3	+	BasicPrimitiveOperation OpArithmetic	int	39999
+LanguageFeatures.som pos=4655 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	39999
+LanguageFeatures.som pos=4672 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	399
+LanguageFeatures.som pos=4672 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	399
+LanguageFeatures.som pos=4868 len=16	+	BasicPrimitiveOperation OpArithmetic	int	399
+LanguageFeatures.som pos=4868 len=16	+	BasicPrimitiveOperation OpArithmetic	TOTAL	399
 LanguageFeatures.som pos=4959 len=8	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	int	1
 LanguageFeatures.som pos=4959 len=8	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	TOTAL	1
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/LanguageFeatures.Recurse/general-stats.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Recurse/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	29
 Lines Loaded	2556
 Lines Executed	179
-Lines With Statements	1206
+Lines With Statements	1151

--- a/tools/tests/dym/expected-results/LanguageFeatures.Recurse/operations.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Recurse/operations.csv
@@ -1,73 +1,73 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	43
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	46
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	41
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	41
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	16
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	16
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	16
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	16
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	15
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	16
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	str	1
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	TOTAL	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	23
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	23
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	23
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	23
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	22
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	23
-Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-LanguageFeatures.som pos=6373 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	16384
-LanguageFeatures.som pos=6373 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	16381
-LanguageFeatures.som pos=6373 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	32765
-LanguageFeatures.som pos=6403 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	16381
-LanguageFeatures.som pos=6403 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	16381
-LanguageFeatures.som pos=6424 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	16381
-LanguageFeatures.som pos=6424 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	16381
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	43
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	46
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	41
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	41
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	16
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	16
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	16
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	16
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	15
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	16
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	str	1
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	TOTAL	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	23
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	23
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	int	23
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	23
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	22
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	23
+Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	TOTAL	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	TOTAL	1
+LanguageFeatures.som pos=6373 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	16384
+LanguageFeatures.som pos=6373 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	16381
+LanguageFeatures.som pos=6373 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	32765
+LanguageFeatures.som pos=6403 len=3	-	BasicPrimitiveOperation OpArithmetic	int	16381
+LanguageFeatures.som pos=6403 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	16381
+LanguageFeatures.som pos=6424 len=3	-	BasicPrimitiveOperation OpArithmetic	int	16381
+LanguageFeatures.som pos=6424 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	16381
 LanguageFeatures.som pos=6497 len=8	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	int	1
 LanguageFeatures.som pos=6497 len=8	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	TOTAL	1
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/List/general-stats.csv
+++ b/tools/tests/dym/expected-results/List/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	33
 Lines Loaded	2079
 Lines Executed	168
-Lines With Statements	976
+Lines With Statements	919

--- a/tools/tests/dym/expected-results/List/operations.csv
+++ b/tools/tests/dym/expected-results/List/operations.csv
@@ -1,27 +1,27 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	8
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	5
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	5
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	3
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	3
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	3
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	3
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	3
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	3
-List.som pos=1582 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	30
-List.som pos=1582 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
-List.som pos=1582 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	33
-List.som pos=1730 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	30
-List.som pos=1730 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	30
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	8
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	5
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	5
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	3
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	3
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	3
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	3
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	3
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	3
+List.som pos=1582 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	30
+List.som pos=1582 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
+List.som pos=1582 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	33
+List.som pos=1730 len=3	-	BasicPrimitiveOperation OpArithmetic	int	30
+List.som pos=1730 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	30
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/Mandelbrot/general-stats.csv
+++ b/tools/tests/dym/expected-results/Mandelbrot/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	13
 Lines Loaded	2131
 Lines Executed	174
-Lines With Statements	989
+Lines With Statements	934

--- a/tools/tests/dym/expected-results/Mandelbrot/operations.csv
+++ b/tools/tests/dym/expected-results/Mandelbrot/operations.csv
@@ -1,87 +1,87 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	10
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	12
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	10
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	10
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	9
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	9
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	9
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	9
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	9
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	9
-Mandelbrot.som pos=2634 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Mandelbrot.som pos=2938 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Mandelbrot.som pos=2938 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2
-Mandelbrot.som pos=2938 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	3
-Mandelbrot.som pos=2999 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	2
-Mandelbrot.som pos=2999 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	2
-Mandelbrot.som pos=3003 len=7	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	2
-Mandelbrot.som pos=3003 len=7	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	2
-Mandelbrot.som pos=3012 len=5	-	BasicPrimitiveOperation OpArithmetic StatementTag	float	2
-Mandelbrot.som pos=3012 len=5	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	2
-Mandelbrot.som pos=3062 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
-Mandelbrot.som pos=3062 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	8
-Mandelbrot.som pos=3062 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	11
-Mandelbrot.som pos=3230 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	8
-Mandelbrot.som pos=3230 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8
-Mandelbrot.som pos=3234 len=7	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	8
-Mandelbrot.som pos=3234 len=7	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8
-Mandelbrot.som pos=3243 len=5	-	BasicPrimitiveOperation OpArithmetic StatementTag	float	8
-Mandelbrot.som pos=3243 len=5	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	8
-Mandelbrot.som pos=3376 len=4	<	BasicPrimitiveOperation OpComparison StatementTag	int	4
-Mandelbrot.som pos=3376 len=4	<	BasicPrimitiveOperation OpComparison StatementTag	int	217
-Mandelbrot.som pos=3376 len=4	<	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	221
-Mandelbrot.som pos=3425 len=6	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	217
-Mandelbrot.som pos=3425 len=6	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	217
-Mandelbrot.som pos=3432 len=4	+	BasicPrimitiveOperation OpArithmetic StatementTag	float	217
-Mandelbrot.som pos=3432 len=4	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	217
-Mandelbrot.som pos=3466 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	217
-Mandelbrot.som pos=3466 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	217
-Mandelbrot.som pos=3471 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	217
-Mandelbrot.som pos=3471 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	217
-Mandelbrot.som pos=3476 len=4	+	BasicPrimitiveOperation OpArithmetic StatementTag	float	217
-Mandelbrot.som pos=3476 len=4	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	217
-Mandelbrot.som pos=3569 len=4	*	BasicPrimitiveOperation OpArithmetic StatementTag	float	217
-Mandelbrot.som pos=3569 len=4	*	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	217
-Mandelbrot.som pos=3604 len=4	*	BasicPrimitiveOperation OpArithmetic StatementTag	float	217
-Mandelbrot.som pos=3604 len=4	*	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	217
-Mandelbrot.som pos=3645 len=6	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	217
-Mandelbrot.som pos=3645 len=6	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	217
-Mandelbrot.som pos=3652 len=5	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	float	212
-Mandelbrot.som pos=3652 len=5	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	float	5
-Mandelbrot.som pos=3652 len=5	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	217
-Mandelbrot.som pos=3791 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	217
-Mandelbrot.som pos=3791 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	217
-Mandelbrot.som pos=3848 len=4	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8
-Mandelbrot.som pos=3848 len=4	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8
-Mandelbrot.som pos=3854 len=8	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	8
-Mandelbrot.som pos=3854 len=8	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	8
-Mandelbrot.som pos=3896 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	8
-Mandelbrot.som pos=3896 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	8
-Mandelbrot.som pos=4118 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	8
-Mandelbrot.som pos=4118 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	8
-Mandelbrot.som pos=4321 len=12	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5
-Mandelbrot.som pos=4321 len=12	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
-Mandelbrot.som pos=4321 len=12	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	8
-Mandelbrot.som pos=4329 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8
-Mandelbrot.som pos=4329 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8
-Mandelbrot.som pos=4388 len=15	<<	BasicPrimitiveOperation OpArithmetic StatementTag	int	2
-Mandelbrot.som pos=4388 len=15	<<	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	2
-Mandelbrot.som pos=4394 len=8	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	2
-Mandelbrot.som pos=4394 len=8	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	2
-Mandelbrot.som pos=4440 len=15	bitXor:	BasicPrimitiveOperation OpArithmetic StatementTag	int	2
-Mandelbrot.som pos=4440 len=15	bitXor:	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	2
-Mandelbrot.som pos=4558 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	8
-Mandelbrot.som pos=4558 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	8
-Mandelbrot.som pos=4593 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	2
-Mandelbrot.som pos=4593 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	2
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	10
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	12
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	10
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	10
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	9
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	9
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	9
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	9
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	9
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9
+Mandelbrot.som pos=2634 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Mandelbrot.som pos=2938 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Mandelbrot.som pos=2938 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
+Mandelbrot.som pos=2938 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	3
+Mandelbrot.som pos=2999 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	2
+Mandelbrot.som pos=2999 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	2
+Mandelbrot.som pos=3003 len=7	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	2
+Mandelbrot.som pos=3003 len=7	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	2
+Mandelbrot.som pos=3012 len=5	-	BasicPrimitiveOperation OpArithmetic	float	2
+Mandelbrot.som pos=3012 len=5	-	BasicPrimitiveOperation OpArithmetic	TOTAL	2
+Mandelbrot.som pos=3062 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
+Mandelbrot.som pos=3062 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8
+Mandelbrot.som pos=3062 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	11
+Mandelbrot.som pos=3230 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	8
+Mandelbrot.som pos=3230 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8
+Mandelbrot.som pos=3234 len=7	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	8
+Mandelbrot.som pos=3234 len=7	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8
+Mandelbrot.som pos=3243 len=5	-	BasicPrimitiveOperation OpArithmetic	float	8
+Mandelbrot.som pos=3243 len=5	-	BasicPrimitiveOperation OpArithmetic	TOTAL	8
+Mandelbrot.som pos=3376 len=4	<	BasicPrimitiveOperation OpComparison	int	4
+Mandelbrot.som pos=3376 len=4	<	BasicPrimitiveOperation OpComparison	int	217
+Mandelbrot.som pos=3376 len=4	<	BasicPrimitiveOperation OpComparison	TOTAL	221
+Mandelbrot.som pos=3425 len=6	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	217
+Mandelbrot.som pos=3425 len=6	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	217
+Mandelbrot.som pos=3432 len=4	+	BasicPrimitiveOperation OpArithmetic	float	217
+Mandelbrot.som pos=3432 len=4	+	BasicPrimitiveOperation OpArithmetic	TOTAL	217
+Mandelbrot.som pos=3466 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	217
+Mandelbrot.som pos=3466 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	217
+Mandelbrot.som pos=3471 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	217
+Mandelbrot.som pos=3471 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	217
+Mandelbrot.som pos=3476 len=4	+	BasicPrimitiveOperation OpArithmetic	float	217
+Mandelbrot.som pos=3476 len=4	+	BasicPrimitiveOperation OpArithmetic	TOTAL	217
+Mandelbrot.som pos=3569 len=4	*	BasicPrimitiveOperation OpArithmetic	float	217
+Mandelbrot.som pos=3569 len=4	*	BasicPrimitiveOperation OpArithmetic	TOTAL	217
+Mandelbrot.som pos=3604 len=4	*	BasicPrimitiveOperation OpArithmetic	float	217
+Mandelbrot.som pos=3604 len=4	*	BasicPrimitiveOperation OpArithmetic	TOTAL	217
+Mandelbrot.som pos=3645 len=6	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	217
+Mandelbrot.som pos=3645 len=6	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	217
+Mandelbrot.som pos=3652 len=5	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	float	212
+Mandelbrot.som pos=3652 len=5	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	float	5
+Mandelbrot.som pos=3652 len=5	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	217
+Mandelbrot.som pos=3791 len=3	+	BasicPrimitiveOperation OpArithmetic	int	217
+Mandelbrot.som pos=3791 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	217
+Mandelbrot.som pos=3848 len=4	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8
+Mandelbrot.som pos=3848 len=4	<<	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8
+Mandelbrot.som pos=3854 len=8	+	BasicPrimitiveOperation OpArithmetic	int	8
+Mandelbrot.som pos=3854 len=8	+	BasicPrimitiveOperation OpArithmetic	TOTAL	8
+Mandelbrot.som pos=3896 len=3	+	BasicPrimitiveOperation OpArithmetic	int	8
+Mandelbrot.som pos=3896 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	8
+Mandelbrot.som pos=4118 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8
+Mandelbrot.som pos=4118 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	8
+Mandelbrot.som pos=4321 len=12	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5
+Mandelbrot.som pos=4321 len=12	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
+Mandelbrot.som pos=4321 len=12	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	8
+Mandelbrot.som pos=4329 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8
+Mandelbrot.som pos=4329 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8
+Mandelbrot.som pos=4388 len=15	<<	BasicPrimitiveOperation OpArithmetic	int	2
+Mandelbrot.som pos=4388 len=15	<<	BasicPrimitiveOperation OpArithmetic	TOTAL	2
+Mandelbrot.som pos=4394 len=8	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	2
+Mandelbrot.som pos=4394 len=8	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	2
+Mandelbrot.som pos=4440 len=15	bitXor:	BasicPrimitiveOperation OpArithmetic	int	2
+Mandelbrot.som pos=4440 len=15	bitXor:	BasicPrimitiveOperation OpArithmetic	TOTAL	2
+Mandelbrot.som pos=4558 len=3	+	BasicPrimitiveOperation OpArithmetic	int	8
+Mandelbrot.som pos=4558 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	8
+Mandelbrot.som pos=4593 len=3	+	BasicPrimitiveOperation OpArithmetic	int	2
+Mandelbrot.som pos=4593 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	2
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/NBody/general-stats.csv
+++ b/tools/tests/dym/expected-results/NBody/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	22
 Lines Loaded	2216
 Lines Executed	252
-Lines With Statements	1068
+Lines With Statements	1012

--- a/tools/tests/dym/expected-results/NBody/operations.csv
+++ b/tools/tests/dym/expected-results/NBody/operations.csv
@@ -1,170 +1,170 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	31
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	88
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	119
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	88
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	88
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	4
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	4
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	4
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	4
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	19
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	19
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	3
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	3
-NBody.som pos=667 len=8	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-NBody.som pos=1389 len=17	+	BasicPrimitiveOperation OpArithmetic StatementTag	float	4
-NBody.som pos=1389 len=17	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	4
-NBody.som pos=1397 len=8	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	4
-NBody.som pos=1397 len=8	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-NBody.som pos=1425 len=17	+	BasicPrimitiveOperation OpArithmetic StatementTag	float	4
-NBody.som pos=1425 len=17	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	4
-NBody.som pos=1433 len=8	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	4
-NBody.som pos=1433 len=8	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-NBody.som pos=1461 len=17	+	BasicPrimitiveOperation OpArithmetic StatementTag	float	4
-NBody.som pos=1461 len=17	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	4
-NBody.som pos=1469 len=8	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	4
-NBody.som pos=1469 len=8	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-NBody.som pos=1669 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	2
-NBody.som pos=1669 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	2
-NBody.som pos=1726 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	14
-NBody.som pos=1726 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	14
-NBody.som pos=1744 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag VirtualInvokeReceiver	int	14
-NBody.som pos=1744 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag VirtualInvokeReceiver	TOTAL	14
-NBody.som pos=1759 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	14
-NBody.som pos=1759 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	14
-NBody.som pos=1851 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	29
-NBody.som pos=1851 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	29
-NBody.som pos=1882 len=9	-	BasicPrimitiveOperation OpArithmetic StatementTag	float	29
-NBody.som pos=1882 len=9	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	29
-NBody.som pos=1917 len=9	-	BasicPrimitiveOperation OpArithmetic StatementTag	float	29
-NBody.som pos=1917 len=9	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	29
-NBody.som pos=1952 len=9	-	BasicPrimitiveOperation OpArithmetic StatementTag	float	29
-NBody.som pos=1952 len=9	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	29
-NBody.som pos=1990 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=1990 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=1996 len=11	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=1996 len=11	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2002 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2002 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2008 len=11	+	BasicPrimitiveOperation OpArithmetic StatementTag	float	29
-NBody.som pos=2008 len=11	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	29
-NBody.som pos=2014 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2014 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2052 len=4	sqrt	BasicPrimitiveOperation OpArithmetic StatementTag	float	29
-NBody.som pos=2052 len=4	sqrt	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	29
-NBody.som pos=2083 len=24	//	BasicPrimitiveOperation OpArithmetic StatementTag	float	29
-NBody.som pos=2083 len=24	//	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	29
-NBody.som pos=2096 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2096 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2139 len=25	-	BasicPrimitiveOperation OpArithmetic StatementTag	float	29
-NBody.som pos=2139 len=25	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	29
-NBody.som pos=2145 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2145 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2158 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2158 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2195 len=25	-	BasicPrimitiveOperation OpArithmetic StatementTag	float	29
-NBody.som pos=2195 len=25	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	29
-NBody.som pos=2201 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2201 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2214 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2214 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2251 len=25	-	BasicPrimitiveOperation OpArithmetic StatementTag	float	29
-NBody.som pos=2251 len=25	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	29
-NBody.som pos=2257 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2257 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2270 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2270 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2308 len=25	+	BasicPrimitiveOperation OpArithmetic StatementTag	float	29
-NBody.som pos=2308 len=25	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	29
-NBody.som pos=2314 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2314 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2327 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2327 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2364 len=25	+	BasicPrimitiveOperation OpArithmetic StatementTag	float	29
-NBody.som pos=2364 len=25	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	29
-NBody.som pos=2370 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2370 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2383 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2383 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2420 len=25	+	BasicPrimitiveOperation OpArithmetic StatementTag	float	29
-NBody.som pos=2420 len=25	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	29
-NBody.som pos=2426 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2426 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2439 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	29
-NBody.som pos=2439 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	29
-NBody.som pos=2522 len=16	+	BasicPrimitiveOperation OpArithmetic StatementTag	float	14
-NBody.som pos=2522 len=16	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	14
-NBody.som pos=2528 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	14
-NBody.som pos=2528 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	14
-NBody.som pos=2563 len=16	+	BasicPrimitiveOperation OpArithmetic StatementTag	float	14
-NBody.som pos=2563 len=16	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	14
-NBody.som pos=2569 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	14
-NBody.som pos=2569 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	14
-NBody.som pos=2604 len=16	+	BasicPrimitiveOperation OpArithmetic StatementTag	float	14
-NBody.som pos=2604 len=16	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	14
-NBody.som pos=2610 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	14
-NBody.som pos=2610 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	14
-NBody.som pos=2787 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	4
-NBody.som pos=2787 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	4
-NBody.som pos=2814 len=135	+	BasicPrimitiveOperation OpArithmetic StatementTag	float	4
-NBody.som pos=2814 len=135	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	4
-NBody.som pos=2821 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	4
-NBody.som pos=2821 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-NBody.som pos=2834 len=114	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	4
-NBody.som pos=2834 len=114	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-NBody.som pos=2860 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	4
-NBody.som pos=2860 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-NBody.som pos=2872 len=37	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	4
-NBody.som pos=2872 len=37	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-NBody.som pos=2898 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	4
-NBody.som pos=2898 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-NBody.som pos=2910 len=37	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	4
-NBody.som pos=2910 len=37	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-NBody.som pos=2936 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	4
-NBody.som pos=2936 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-NBody.som pos=2966 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag VirtualInvokeReceiver	int	4
-NBody.som pos=2966 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag VirtualInvokeReceiver	TOTAL	4
-NBody.som pos=2981 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	4
-NBody.som pos=2981 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	4
-NBody.som pos=3042 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	9
-NBody.som pos=3042 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	9
-NBody.som pos=3078 len=9	-	BasicPrimitiveOperation OpArithmetic StatementTag	float	9
-NBody.som pos=3078 len=9	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	9
-NBody.som pos=3113 len=9	-	BasicPrimitiveOperation OpArithmetic StatementTag	float	9
-NBody.som pos=3113 len=9	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	9
-NBody.som pos=3148 len=9	-	BasicPrimitiveOperation OpArithmetic StatementTag	float	9
-NBody.som pos=3148 len=9	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	9
-NBody.som pos=3186 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	9
-NBody.som pos=3186 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	9
-NBody.som pos=3191 len=9	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	9
-NBody.som pos=3191 len=9	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	9
-NBody.som pos=3196 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	9
-NBody.som pos=3196 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	9
-NBody.som pos=3201 len=9	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	9
-NBody.som pos=3201 len=9	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	9
-NBody.som pos=3206 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	9
-NBody.som pos=3206 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	9
-NBody.som pos=3212 len=4	sqrt	BasicPrimitiveOperation OpArithmetic StatementTag	float	9
-NBody.som pos=3212 len=4	sqrt	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	9
-NBody.som pos=3235 len=41	-	BasicPrimitiveOperation OpArithmetic StatementTag	float	9
-NBody.som pos=3235 len=41	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	9
-NBody.som pos=3250 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	9
-NBody.som pos=3250 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	9
-NBody.som pos=3264 len=11	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	9
-NBody.som pos=3264 len=11	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	9
-NBody.som pos=4053 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	float	7
-NBody.som pos=4053 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	7
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	31
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	88
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	119
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	88
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	88
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	4
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	4
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	4
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	4
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	19
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	19
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	arr	3
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	3
+NBody.som pos=667 len=8	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+NBody.som pos=1389 len=17	+	BasicPrimitiveOperation OpArithmetic	float	4
+NBody.som pos=1389 len=17	+	BasicPrimitiveOperation OpArithmetic	TOTAL	4
+NBody.som pos=1397 len=8	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	4
+NBody.som pos=1397 len=8	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+NBody.som pos=1425 len=17	+	BasicPrimitiveOperation OpArithmetic	float	4
+NBody.som pos=1425 len=17	+	BasicPrimitiveOperation OpArithmetic	TOTAL	4
+NBody.som pos=1433 len=8	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	4
+NBody.som pos=1433 len=8	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+NBody.som pos=1461 len=17	+	BasicPrimitiveOperation OpArithmetic	float	4
+NBody.som pos=1461 len=17	+	BasicPrimitiveOperation OpArithmetic	TOTAL	4
+NBody.som pos=1469 len=8	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	4
+NBody.som pos=1469 len=8	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+NBody.som pos=1669 len=4	size	BasicPrimitiveOperation OpLength	arr	2
+NBody.som pos=1669 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	2
+NBody.som pos=1726 len=5	at:	ArrayRead BasicPrimitiveOperation	ref	14
+NBody.som pos=1726 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	14
+NBody.som pos=1744 len=3	+	BasicPrimitiveOperation OpArithmetic VirtualInvokeReceiver	int	14
+NBody.som pos=1744 len=3	+	BasicPrimitiveOperation OpArithmetic VirtualInvokeReceiver	TOTAL	14
+NBody.som pos=1759 len=4	size	BasicPrimitiveOperation OpLength	arr	14
+NBody.som pos=1759 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	14
+NBody.som pos=1851 len=5	at:	ArrayRead BasicPrimitiveOperation	ref	29
+NBody.som pos=1851 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	29
+NBody.som pos=1882 len=9	-	BasicPrimitiveOperation OpArithmetic	float	29
+NBody.som pos=1882 len=9	-	BasicPrimitiveOperation OpArithmetic	TOTAL	29
+NBody.som pos=1917 len=9	-	BasicPrimitiveOperation OpArithmetic	float	29
+NBody.som pos=1917 len=9	-	BasicPrimitiveOperation OpArithmetic	TOTAL	29
+NBody.som pos=1952 len=9	-	BasicPrimitiveOperation OpArithmetic	float	29
+NBody.som pos=1952 len=9	-	BasicPrimitiveOperation OpArithmetic	TOTAL	29
+NBody.som pos=1990 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=1990 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=1996 len=11	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=1996 len=11	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2002 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2002 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2008 len=11	+	BasicPrimitiveOperation OpArithmetic	float	29
+NBody.som pos=2008 len=11	+	BasicPrimitiveOperation OpArithmetic	TOTAL	29
+NBody.som pos=2014 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2014 len=4	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2052 len=4	sqrt	BasicPrimitiveOperation OpArithmetic	float	29
+NBody.som pos=2052 len=4	sqrt	BasicPrimitiveOperation OpArithmetic	TOTAL	29
+NBody.som pos=2083 len=24	//	BasicPrimitiveOperation OpArithmetic	float	29
+NBody.som pos=2083 len=24	//	BasicPrimitiveOperation OpArithmetic	TOTAL	29
+NBody.som pos=2096 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2096 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2139 len=25	-	BasicPrimitiveOperation OpArithmetic	float	29
+NBody.som pos=2139 len=25	-	BasicPrimitiveOperation OpArithmetic	TOTAL	29
+NBody.som pos=2145 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2145 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2158 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2158 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2195 len=25	-	BasicPrimitiveOperation OpArithmetic	float	29
+NBody.som pos=2195 len=25	-	BasicPrimitiveOperation OpArithmetic	TOTAL	29
+NBody.som pos=2201 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2201 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2214 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2214 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2251 len=25	-	BasicPrimitiveOperation OpArithmetic	float	29
+NBody.som pos=2251 len=25	-	BasicPrimitiveOperation OpArithmetic	TOTAL	29
+NBody.som pos=2257 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2257 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2270 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2270 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2308 len=25	+	BasicPrimitiveOperation OpArithmetic	float	29
+NBody.som pos=2308 len=25	+	BasicPrimitiveOperation OpArithmetic	TOTAL	29
+NBody.som pos=2314 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2314 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2327 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2327 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2364 len=25	+	BasicPrimitiveOperation OpArithmetic	float	29
+NBody.som pos=2364 len=25	+	BasicPrimitiveOperation OpArithmetic	TOTAL	29
+NBody.som pos=2370 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2370 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2383 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2383 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2420 len=25	+	BasicPrimitiveOperation OpArithmetic	float	29
+NBody.som pos=2420 len=25	+	BasicPrimitiveOperation OpArithmetic	TOTAL	29
+NBody.som pos=2426 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2426 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2439 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	29
+NBody.som pos=2439 len=5	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	29
+NBody.som pos=2522 len=16	+	BasicPrimitiveOperation OpArithmetic	float	14
+NBody.som pos=2522 len=16	+	BasicPrimitiveOperation OpArithmetic	TOTAL	14
+NBody.som pos=2528 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	14
+NBody.som pos=2528 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	14
+NBody.som pos=2563 len=16	+	BasicPrimitiveOperation OpArithmetic	float	14
+NBody.som pos=2563 len=16	+	BasicPrimitiveOperation OpArithmetic	TOTAL	14
+NBody.som pos=2569 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	14
+NBody.som pos=2569 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	14
+NBody.som pos=2604 len=16	+	BasicPrimitiveOperation OpArithmetic	float	14
+NBody.som pos=2604 len=16	+	BasicPrimitiveOperation OpArithmetic	TOTAL	14
+NBody.som pos=2610 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	14
+NBody.som pos=2610 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	14
+NBody.som pos=2787 len=5	at:	ArrayRead BasicPrimitiveOperation	ref	4
+NBody.som pos=2787 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	4
+NBody.som pos=2814 len=135	+	BasicPrimitiveOperation OpArithmetic	float	4
+NBody.som pos=2814 len=135	+	BasicPrimitiveOperation OpArithmetic	TOTAL	4
+NBody.som pos=2821 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	4
+NBody.som pos=2821 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+NBody.som pos=2834 len=114	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	4
+NBody.som pos=2834 len=114	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+NBody.som pos=2860 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	4
+NBody.som pos=2860 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+NBody.som pos=2872 len=37	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	4
+NBody.som pos=2872 len=37	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+NBody.som pos=2898 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	4
+NBody.som pos=2898 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+NBody.som pos=2910 len=37	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	4
+NBody.som pos=2910 len=37	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+NBody.som pos=2936 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	4
+NBody.som pos=2936 len=10	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+NBody.som pos=2966 len=3	+	BasicPrimitiveOperation OpArithmetic VirtualInvokeReceiver	int	4
+NBody.som pos=2966 len=3	+	BasicPrimitiveOperation OpArithmetic VirtualInvokeReceiver	TOTAL	4
+NBody.som pos=2981 len=4	size	BasicPrimitiveOperation OpLength	arr	4
+NBody.som pos=2981 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	4
+NBody.som pos=3042 len=5	at:	ArrayRead BasicPrimitiveOperation	ref	9
+NBody.som pos=3042 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	9
+NBody.som pos=3078 len=9	-	BasicPrimitiveOperation OpArithmetic	float	9
+NBody.som pos=3078 len=9	-	BasicPrimitiveOperation OpArithmetic	TOTAL	9
+NBody.som pos=3113 len=9	-	BasicPrimitiveOperation OpArithmetic	float	9
+NBody.som pos=3113 len=9	-	BasicPrimitiveOperation OpArithmetic	TOTAL	9
+NBody.som pos=3148 len=9	-	BasicPrimitiveOperation OpArithmetic	float	9
+NBody.som pos=3148 len=9	-	BasicPrimitiveOperation OpArithmetic	TOTAL	9
+NBody.som pos=3186 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	9
+NBody.som pos=3186 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	9
+NBody.som pos=3191 len=9	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	9
+NBody.som pos=3191 len=9	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	9
+NBody.som pos=3196 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	9
+NBody.som pos=3196 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	9
+NBody.som pos=3201 len=9	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	9
+NBody.som pos=3201 len=9	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	9
+NBody.som pos=3206 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	9
+NBody.som pos=3206 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	9
+NBody.som pos=3212 len=4	sqrt	BasicPrimitiveOperation OpArithmetic	float	9
+NBody.som pos=3212 len=4	sqrt	BasicPrimitiveOperation OpArithmetic	TOTAL	9
+NBody.som pos=3235 len=41	-	BasicPrimitiveOperation OpArithmetic	float	9
+NBody.som pos=3235 len=41	-	BasicPrimitiveOperation OpArithmetic	TOTAL	9
+NBody.som pos=3250 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	9
+NBody.som pos=3250 len=12	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	9
+NBody.som pos=3264 len=11	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	9
+NBody.som pos=3264 len=11	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	9
+NBody.som pos=4053 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	7
+NBody.som pos=4053 len=9	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	7
 NBody.som pos=4063 len=9	*	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	float	7
 NBody.som pos=4063 len=9	*	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	TOTAL	7
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/Permute/general-stats.csv
+++ b/tools/tests/dym/expected-results/Permute/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	40
 Lines Loaded	2060
 Lines Executed	163
-Lines With Statements	964
+Lines With Statements	911

--- a/tools/tests/dym/expected-results/Permute/operations.csv
+++ b/tools/tests/dym/expected-results/Permute/operations.csv
@@ -1,45 +1,45 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4
-Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	12
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	15
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	12
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	12
-Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	18100
-Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	25194
-Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	43294
-Kernel.som pos=8315 len=6	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	25194
-Kernel.som pos=8315 len=6	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	25194
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	6
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	6
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	6
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	6
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	6
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	6
-Permute.som pos=1518 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	43299
-Permute.som pos=1518 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	43299
-Permute.som pos=1532 len=4	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	25200
-Permute.som pos=1532 len=4	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	18099
-Permute.som pos=1532 len=4	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	43299
-Permute.som pos=1582 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	18099
-Permute.som pos=1582 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	18099
-Permute.som pos=1682 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	25194
-Permute.som pos=1682 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	25194
-Permute.som pos=1792 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	50389
-Permute.som pos=1792 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	50389
-Permute.som pos=1809 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	50389
-Permute.som pos=1809 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	50389
-Permute.som pos=1823 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	ref	50389
-Permute.som pos=1823 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	50389
-Permute.som pos=1841 len=14	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	50389
-Permute.som pos=1841 len=14	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	50389
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
+Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4
+Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	12
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	15
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	12
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	12
+Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	18100
+Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	25194
+Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	43294
+Kernel.som pos=8315 len=6	-	BasicPrimitiveOperation OpArithmetic	int	25194
+Kernel.som pos=8315 len=6	-	BasicPrimitiveOperation OpArithmetic	TOTAL	25194
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	6
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	6
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	6
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	6
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	6
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	6
+Permute.som pos=1518 len=3	+	BasicPrimitiveOperation OpArithmetic	int	43299
+Permute.som pos=1518 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	43299
+Permute.som pos=1532 len=4	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	25200
+Permute.som pos=1532 len=4	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	18099
+Permute.som pos=1532 len=4	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	43299
+Permute.som pos=1582 len=3	-	BasicPrimitiveOperation OpArithmetic	int	18099
+Permute.som pos=1582 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	18099
+Permute.som pos=1682 len=3	-	BasicPrimitiveOperation OpArithmetic	int	25194
+Permute.som pos=1682 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	25194
+Permute.som pos=1792 len=5	at:	ArrayRead BasicPrimitiveOperation	ref	50389
+Permute.som pos=1792 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	50389
+Permute.som pos=1809 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	ref	50389
+Permute.som pos=1809 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	50389
+Permute.som pos=1823 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	50389
+Permute.som pos=1823 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	50389
+Permute.som pos=1841 len=14	at:put:	ArrayWrite BasicPrimitiveOperation	ref	50389
+Permute.som pos=1841 len=14	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	50389
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/Queens/general-stats.csv
+++ b/tools/tests/dym/expected-results/Queens/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	52
 Lines Loaded	2071
 Lines Executed	168
-Lines With Statements	969
+Lines With Statements	914

--- a/tools/tests/dym/expected-results/Queens/operations.csv
+++ b/tools/tests/dym/expected-results/Queens/operations.csv
@@ -1,63 +1,63 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5458
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	46261
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	51719
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	45861
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	45861
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	5
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	5
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	5
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	5
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	5
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	5
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	199
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	199
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5458
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	46261
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	51719
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	45861
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	45861
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	5
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	5
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	5
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	5
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	5
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	5
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	arr	199
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	199
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	400
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	bool	1999
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	2399
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Queens.som pos=1860 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	5649
-Queens.som pos=1860 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	5649
-Queens.som pos=1935 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5599
-Queens.som pos=1935 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	50
-Queens.som pos=1935 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	5649
-Queens.som pos=1991 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	5599
-Queens.som pos=1991 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	5599
-Queens.som pos=2126 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	bool	27000
-Queens.som pos=2126 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	bool	16799
-Queens.som pos=2126 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	43799
-Queens.som pos=2146 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	bool	14800
-Queens.som pos=2146 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	bool	28999
-Queens.som pos=2146 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	43799
-Queens.som pos=2152 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	43799
-Queens.som pos=2152 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	43799
-Queens.som pos=2170 len=13	at:	ArrayRead BasicPrimitiveOperation StatementTag	bool	18850
-Queens.som pos=2170 len=13	at:	ArrayRead BasicPrimitiveOperation StatementTag	bool	24949
-Queens.som pos=2170 len=13	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	43799
-Queens.som pos=2176 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	43799
-Queens.som pos=2176 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	43799
-Queens.som pos=2180 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	43799
-Queens.som pos=2180 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	43799
-Queens.som pos=2241 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	5649
-Queens.som pos=2241 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	5250
-Queens.som pos=2241 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	10899
-Queens.som pos=2278 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	5649
-Queens.som pos=2278 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	5250
-Queens.som pos=2278 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	10899
-Queens.som pos=2284 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	10899
-Queens.som pos=2284 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	10899
-Queens.som pos=2315 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	5649
-Queens.som pos=2315 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	5250
-Queens.som pos=2315 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	10899
-Queens.som pos=2321 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	10899
-Queens.som pos=2321 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	10899
-Queens.som pos=2325 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	10899
-Queens.som pos=2325 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	10899
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Queens.som pos=1860 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	int	5649
+Queens.som pos=1860 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	5649
+Queens.som pos=1935 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5599
+Queens.som pos=1935 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	50
+Queens.som pos=1935 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	5649
+Queens.som pos=1991 len=3	+	BasicPrimitiveOperation OpArithmetic	int	5599
+Queens.som pos=1991 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	5599
+Queens.som pos=2126 len=5	at:	ArrayRead BasicPrimitiveOperation	bool	27000
+Queens.som pos=2126 len=5	at:	ArrayRead BasicPrimitiveOperation	bool	16799
+Queens.som pos=2126 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	43799
+Queens.som pos=2146 len=9	at:	ArrayRead BasicPrimitiveOperation	bool	14800
+Queens.som pos=2146 len=9	at:	ArrayRead BasicPrimitiveOperation	bool	28999
+Queens.som pos=2146 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	43799
+Queens.som pos=2152 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	43799
+Queens.som pos=2152 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	43799
+Queens.som pos=2170 len=13	at:	ArrayRead BasicPrimitiveOperation	bool	18850
+Queens.som pos=2170 len=13	at:	ArrayRead BasicPrimitiveOperation	bool	24949
+Queens.som pos=2170 len=13	at:	ArrayRead BasicPrimitiveOperation	TOTAL	43799
+Queens.som pos=2176 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	43799
+Queens.som pos=2176 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	43799
+Queens.som pos=2180 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	43799
+Queens.som pos=2180 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	43799
+Queens.som pos=2241 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	bool	5649
+Queens.som pos=2241 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	bool	5250
+Queens.som pos=2241 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	10899
+Queens.som pos=2278 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	bool	5649
+Queens.som pos=2278 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	bool	5250
+Queens.som pos=2278 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	10899
+Queens.som pos=2284 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	10899
+Queens.som pos=2284 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	10899
+Queens.som pos=2315 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	bool	5649
+Queens.som pos=2315 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	bool	5250
+Queens.som pos=2315 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	10899
+Queens.som pos=2321 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	10899
+Queens.som pos=2321 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	10899
+Queens.som pos=2325 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	10899
+Queens.som pos=2325 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	10899

--- a/tools/tests/dym/expected-results/Richards/general-stats.csv
+++ b/tools/tests/dym/expected-results/Richards/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	27
 Lines Loaded	2450
 Lines Executed	414
-Lines With Statements	1246
+Lines With Statements	1189

--- a/tools/tests/dym/expected-results/Richards/operations.csv
+++ b/tools/tests/dym/expected-results/Richards/operations.csv
@@ -1,123 +1,123 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2339
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	9355
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	11694
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	9355
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	9355
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	7
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	7
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	7
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	7
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	7
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	7
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	8
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	8
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2339
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	9355
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	11694
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	9355
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	9355
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	7
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	7
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	7
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	7
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	7
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	7
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	arr	8
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	8
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	32
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	ref	5
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	37
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Richards.som pos=1232 len=15	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	9295
-Richards.som pos=1232 len=15	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	18588
-Richards.som pos=1232 len=15	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	27883
-Richards.som pos=1277 len=33	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	9293
-Richards.som pos=1277 len=33	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	9294
-Richards.som pos=1277 len=33	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	18587
-Richards.som pos=2038 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	11626
-Richards.som pos=2038 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	11625
-Richards.som pos=2038 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	23251
-Richards.som pos=2087 len=11	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	9299
-Richards.som pos=2087 len=11	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2327
-Richards.som pos=2087 len=11	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	11626
-Richards.som pos=2239 len=30	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	20310
-Richards.som pos=2239 len=30	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	2941
-Richards.som pos=2239 len=30	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	23251
-Richards.som pos=2426 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	17984
-Richards.som pos=2426 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2325
-Richards.som pos=2426 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	20309
-Richards.som pos=2658 len=34	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	9299
-Richards.som pos=2658 len=34	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	8685
-Richards.som pos=2658 len=34	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	17984
-Richards.som pos=2894 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	9299
-Richards.som pos=2894 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	9299
-Richards.som pos=2955 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	9299
-Richards.som pos=2955 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	9299
-Richards.som pos=3429 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	9999
-Richards.som pos=3429 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	9999
-Richards.som pos=3449 len=12	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	9998
-Richards.som pos=3449 len=12	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Richards.som pos=3449 len=12	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	9999
-Richards.som pos=3549 len=20	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4991
-Richards.som pos=3549 len=20	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5007
-Richards.som pos=3549 len=20	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	9998
-Richards.som pos=3565 len=3	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	9998
-Richards.som pos=3565 len=3	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	9998
-Richards.som pos=3647 len=3	/	BasicPrimitiveOperation OpArithmetic StatementTag	int	5006
-Richards.som pos=3647 len=3	/	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	5006
-Richards.som pos=3776 len=3	/	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	4991
-Richards.som pos=3776 len=3	/	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4991
-Richards.som pos=3780 len=13	bitXor:	BasicPrimitiveOperation OpArithmetic StatementTag	int	4991
-Richards.som pos=3780 len=13	bitXor:	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	4991
-Richards.som pos=4558 len=19	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	5
-Richards.som pos=4558 len=19	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	5
-Richards.som pos=4946 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	2326
-Richards.som pos=4946 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	2327
-Richards.som pos=4946 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4653
-Richards.som pos=5063 len=18	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1163
-Richards.som pos=5063 len=18	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1163
-Richards.som pos=5063 len=18	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	2326
-Richards.som pos=5359 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	9307
-Richards.som pos=5359 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	9307
-Richards.som pos=5394 len=4	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	8950
-Richards.som pos=5394 len=4	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	357
-Richards.som pos=5394 len=4	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	9307
-Richards.som pos=5497 len=30	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	9307
-Richards.som pos=5497 len=30	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	9307
-Richards.som pos=5511 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	9307
-Richards.som pos=5511 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	9307
-Richards.som pos=5524 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	9307
-Richards.som pos=5524 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	9307
-Richards.som pos=7774 len=12	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	33244
-Richards.som pos=7774 len=12	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	33244
-Richards.som pos=7801 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	33244
-Richards.som pos=7801 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	33244
-Richards.som pos=7910 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	9296
-Richards.som pos=7910 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	9296
-Richards.som pos=8301 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	23245
-Richards.som pos=8301 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	23245
-Richards.som pos=8371 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	23245
-Richards.som pos=8371 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	23245
-Richards.som pos=8595 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	9998
-Richards.som pos=8595 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	9998
-Richards.som pos=8667 len=22	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	9998
-Richards.som pos=8667 len=22	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	9998
-Richards.som pos=9067 len=14	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	106603
-Richards.som pos=9067 len=14	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	1
-Richards.som pos=9067 len=14	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	106604
-Richards.som pos=9537 len=12	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	10127
-Richards.som pos=9537 len=12	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	9986
-Richards.som pos=9537 len=12	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	20113
-Richards.som pos=9613 len=23	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	340
-Richards.som pos=9613 len=23	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	10126
-Richards.som pos=9613 len=23	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	10466
-Richards.som pos=12003 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	41163
-Richards.som pos=12003 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	59879
-Richards.som pos=12003 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	101042
-Richards.som pos=12209 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	23249
-Richards.som pos=12209 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	23249
-Richards.som pos=13087 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	8487
-Richards.som pos=13087 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	14758
-Richards.som pos=13087 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	23245
-Richards.som pos=13196 len=18	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	11619
-Richards.som pos=13196 len=18	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3139
-Richards.som pos=13196 len=18	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	14758
-Richards.som pos=13495 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	8489
-Richards.som pos=13495 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	14760
-Richards.som pos=13495 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	23249
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Richards.som pos=1232 len=15	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	9295
+Richards.som pos=1232 len=15	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	18588
+Richards.som pos=1232 len=15	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	27883
+Richards.som pos=1277 len=33	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	9293
+Richards.som pos=1277 len=33	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	9294
+Richards.som pos=1277 len=33	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	18587
+Richards.som pos=2038 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	11626
+Richards.som pos=2038 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	11625
+Richards.som pos=2038 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	23251
+Richards.som pos=2087 len=11	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	9299
+Richards.som pos=2087 len=11	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2327
+Richards.som pos=2087 len=11	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	11626
+Richards.som pos=2239 len=30	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	20310
+Richards.som pos=2239 len=30	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	2941
+Richards.som pos=2239 len=30	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	23251
+Richards.som pos=2426 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	17984
+Richards.som pos=2426 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2325
+Richards.som pos=2426 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	20309
+Richards.som pos=2658 len=34	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	9299
+Richards.som pos=2658 len=34	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	8685
+Richards.som pos=2658 len=34	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	17984
+Richards.som pos=2894 len=9	at:	ArrayRead BasicPrimitiveOperation	int	9299
+Richards.som pos=2894 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	9299
+Richards.som pos=2955 len=3	+	BasicPrimitiveOperation OpArithmetic	int	9299
+Richards.som pos=2955 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	9299
+Richards.som pos=3429 len=3	-	BasicPrimitiveOperation OpArithmetic	int	9999
+Richards.som pos=3429 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	9999
+Richards.som pos=3449 len=12	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	9998
+Richards.som pos=3449 len=12	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Richards.som pos=3449 len=12	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9999
+Richards.som pos=3549 len=20	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4991
+Richards.som pos=3549 len=20	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5007
+Richards.som pos=3549 len=20	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9998
+Richards.som pos=3565 len=3	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	9998
+Richards.som pos=3565 len=3	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	9998
+Richards.som pos=3647 len=3	/	BasicPrimitiveOperation OpArithmetic	int	5006
+Richards.som pos=3647 len=3	/	BasicPrimitiveOperation OpArithmetic	TOTAL	5006
+Richards.som pos=3776 len=3	/	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	4991
+Richards.som pos=3776 len=3	/	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4991
+Richards.som pos=3780 len=13	bitXor:	BasicPrimitiveOperation OpArithmetic	int	4991
+Richards.som pos=3780 len=13	bitXor:	BasicPrimitiveOperation OpArithmetic	TOTAL	4991
+Richards.som pos=4558 len=19	at:put:	ArrayWrite BasicPrimitiveOperation	ref	5
+Richards.som pos=4558 len=19	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	5
+Richards.som pos=4946 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	2326
+Richards.som pos=4946 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	2327
+Richards.som pos=4946 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4653
+Richards.som pos=5063 len=18	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1163
+Richards.som pos=5063 len=18	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1163
+Richards.som pos=5063 len=18	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	2326
+Richards.som pos=5359 len=3	+	BasicPrimitiveOperation OpArithmetic	int	9307
+Richards.som pos=5359 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	9307
+Richards.som pos=5394 len=4	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8950
+Richards.som pos=5394 len=4	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	357
+Richards.som pos=5394 len=4	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9307
+Richards.som pos=5497 len=30	at:put:	ArrayWrite BasicPrimitiveOperation	int	9307
+Richards.som pos=5497 len=30	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	9307
+Richards.som pos=5511 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	9307
+Richards.som pos=5511 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	9307
+Richards.som pos=5524 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	9307
+Richards.som pos=5524 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	9307
+Richards.som pos=7774 len=12	at:	ArrayRead BasicPrimitiveOperation	ref	33244
+Richards.som pos=7774 len=12	at:	ArrayRead BasicPrimitiveOperation	TOTAL	33244
+Richards.som pos=7801 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	33244
+Richards.som pos=7801 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	33244
+Richards.som pos=7910 len=3	+	BasicPrimitiveOperation OpArithmetic	int	9296
+Richards.som pos=7910 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	9296
+Richards.som pos=8301 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	23245
+Richards.som pos=8301 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	23245
+Richards.som pos=8371 len=3	+	BasicPrimitiveOperation OpArithmetic	int	23245
+Richards.som pos=8371 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	23245
+Richards.som pos=8595 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	9998
+Richards.som pos=8595 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9998
+Richards.som pos=8667 len=22	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	9998
+Richards.som pos=8667 len=22	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9998
+Richards.som pos=9067 len=14	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	106603
+Richards.som pos=9067 len=14	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	1
+Richards.som pos=9067 len=14	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	106604
+Richards.som pos=9537 len=12	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	10127
+Richards.som pos=9537 len=12	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	9986
+Richards.som pos=9537 len=12	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	20113
+Richards.som pos=9613 len=23	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	340
+Richards.som pos=9613 len=23	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	10126
+Richards.som pos=9613 len=23	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	10466
+Richards.som pos=12003 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	41163
+Richards.som pos=12003 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	59879
+Richards.som pos=12003 len=3	not	BasicPrimitiveOperation OpArithmetic	TOTAL	101042
+Richards.som pos=12209 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	23249
+Richards.som pos=12209 len=3	not	BasicPrimitiveOperation OpArithmetic	TOTAL	23249
+Richards.som pos=13087 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	8487
+Richards.som pos=13087 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	14758
+Richards.som pos=13087 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	23245
+Richards.som pos=13196 len=18	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	11619
+Richards.som pos=13196 len=18	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3139
+Richards.som pos=13196 len=18	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	14758
+Richards.som pos=13495 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	8489
+Richards.som pos=13495 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	14760
+Richards.som pos=13495 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	23249

--- a/tools/tests/dym/expected-results/Sieve/general-stats.csv
+++ b/tools/tests/dym/expected-results/Sieve/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	22
 Lines Loaded	2056
 Lines Executed	159
-Lines With Statements	960
+Lines With Statements	905

--- a/tools/tests/dym/expected-results/Sieve/operations.csv
+++ b/tools/tests/dym/expected-results/Sieve/operations.csv
@@ -1,45 +1,45 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	7
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	20005
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	20012
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	20005
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	20005
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	4
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	4
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	4
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	4
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	1
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	1
+Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	7
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	20005
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	20012
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	20005
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	20005
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	4
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	4
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	4
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	4
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	arr	1
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	1
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	bool	9999
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	9999
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Sieve.som pos=1592 len=9	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition StatementTag	bool	8660
-Sieve.som pos=1592 len=9	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition StatementTag	bool	1337
-Sieve.som pos=1592 len=9	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition StatementTag	TOTAL	9997
-Sieve.som pos=1598 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	9997
-Sieve.som pos=1598 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	9997
-Sieve.som pos=1678 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1337
-Sieve.som pos=1678 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1337
-Sieve.som pos=1702 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1337
-Sieve.som pos=1702 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1337
-Sieve.som pos=1723 len=7	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1338
-Sieve.som pos=1723 len=7	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	22137
-Sieve.som pos=1723 len=7	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	23475
-Sieve.som pos=1782 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	22137
-Sieve.som pos=1782 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	22137
-Sieve.som pos=1788 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	22137
-Sieve.som pos=1788 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	22137
-Sieve.som pos=1811 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	22137
-Sieve.som pos=1811 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	22137
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Sieve.som pos=1592 len=9	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	bool	8660
+Sieve.som pos=1592 len=9	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	bool	1337
+Sieve.som pos=1592 len=9	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	TOTAL	9997
+Sieve.som pos=1598 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	9997
+Sieve.som pos=1598 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	9997
+Sieve.som pos=1678 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1337
+Sieve.som pos=1678 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1337
+Sieve.som pos=1702 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1337
+Sieve.som pos=1702 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1337
+Sieve.som pos=1723 len=7	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1338
+Sieve.som pos=1723 len=7	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	22137
+Sieve.som pos=1723 len=7	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	23475
+Sieve.som pos=1782 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	bool	22137
+Sieve.som pos=1782 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	22137
+Sieve.som pos=1788 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	22137
+Sieve.som pos=1788 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	22137
+Sieve.som pos=1811 len=3	+	BasicPrimitiveOperation OpArithmetic	int	22137
+Sieve.som pos=1811 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	22137

--- a/tools/tests/dym/expected-results/Sort.BubbleSort/general-stats.csv
+++ b/tools/tests/dym/expected-results/Sort.BubbleSort/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	25
 Lines Loaded	2156
 Lines Executed	211
-Lines With Statements	1022
+Lines With Statements	970

--- a/tools/tests/dym/expected-results/Sort.BubbleSort/operations.csv
+++ b/tools/tests/dym/expected-results/Sort.BubbleSort/operations.csv
@@ -1,128 +1,128 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	259
-Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	259
-Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	259
-Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	259
-Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic StatementTag	int	259
-Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	259
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	269
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	17568
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	17837
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	17566
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	17566
-Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2
-Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	259
-Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	261
-Kernel.som pos=8315 len=6	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	259
-Kernel.som pos=8315 len=6	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	259
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	4
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	4
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	4
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	3
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	str	1
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	TOTAL	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	14
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	14
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	14
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	14
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	13
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	14
-Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	259
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	259
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	3
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	3
+Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	259
+Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	259
+Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	259
+Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	259
+Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic	int	259
+Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic	TOTAL	259
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	269
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	17568
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	17837
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	17566
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	17566
+Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
+Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	259
+Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	261
+Kernel.som pos=8315 len=6	-	BasicPrimitiveOperation OpArithmetic	int	259
+Kernel.som pos=8315 len=6	-	BasicPrimitiveOperation OpArithmetic	TOTAL	259
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	4
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	4
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	4
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	3
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	str	1
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	TOTAL	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	14
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	14
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	int	14
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	14
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	13
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	14
+Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	259
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	259
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	arr	3
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	3
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	259
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	259
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Sort.som pos=1623 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	1
-Sort.som pos=1623 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	1
-Sort.som pos=1630 len=11	<>	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Sort.som pos=1630 len=11	<>	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Sort.som pos=1666 len=16	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	1
-Sort.som pos=1666 len=16	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	1
-Sort.som pos=1677 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	1
-Sort.som pos=1677 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Sort.som pos=1684 len=10	<>	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Sort.som pos=1684 len=10	<>	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Sort.som pos=1927 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	1
-Sort.som pos=1927 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	1
-Sort.som pos=1963 len=9	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	255
-Sort.som pos=1963 len=9	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	255
-Sort.som pos=1969 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	255
-Sort.som pos=1969 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	255
-Sort.som pos=1974 len=15	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	255
-Sort.som pos=1974 len=15	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	255
-Sort.som pos=1983 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	255
-Sort.som pos=1983 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	255
-Sort.som pos=2345 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	1
-Sort.som pos=2345 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	251
-Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	8
-Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	259
-Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	257
-Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2
-Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	259
-Sort.som pos=2594 len=4	size	BasicPrimitiveOperation OpLength StatementTag VirtualInvokeReceiver	arr	1
-Sort.som pos=2594 len=4	size	BasicPrimitiveOperation OpLength StatementTag VirtualInvokeReceiver	TOTAL	1
-Sort.som pos=2636 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	259
-Sort.som pos=2636 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	259
-Sort.som pos=2705 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	16769
-Sort.som pos=2705 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	16769
-Sort.som pos=2739 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	16769
-Sort.som pos=2739 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	16769
-Sort.som pos=2745 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	16769
-Sort.som pos=2745 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	16769
-Sort.som pos=2769 len=6	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	8609
-Sort.som pos=2769 len=6	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	8160
-Sort.som pos=2769 len=6	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	16769
-Sort.som pos=2819 len=15	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	8159
-Sort.som pos=2819 len=15	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	8159
-Sort.som pos=2856 len=22	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	8159
-Sort.som pos=2856 len=22	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	8159
-Sort.som pos=2862 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8159
-Sort.som pos=2862 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8159
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	TOTAL	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	TOTAL	1
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Sort.som pos=1623 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	1
+Sort.som pos=1623 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	1
+Sort.som pos=1630 len=11	<>	BasicPrimitiveOperation OpComparison	int	1
+Sort.som pos=1630 len=11	<>	BasicPrimitiveOperation OpComparison	TOTAL	1
+Sort.som pos=1666 len=16	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	1
+Sort.som pos=1666 len=16	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	1
+Sort.som pos=1677 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
+Sort.som pos=1677 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Sort.som pos=1684 len=10	<>	BasicPrimitiveOperation OpComparison	int	1
+Sort.som pos=1684 len=10	<>	BasicPrimitiveOperation OpComparison	TOTAL	1
+Sort.som pos=1927 len=4	size	BasicPrimitiveOperation OpLength	arr	1
+Sort.som pos=1927 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	1
+Sort.som pos=1963 len=9	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	255
+Sort.som pos=1963 len=9	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	255
+Sort.som pos=1969 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	255
+Sort.som pos=1969 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	255
+Sort.som pos=1974 len=15	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	255
+Sort.som pos=1974 len=15	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	255
+Sort.som pos=1983 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	255
+Sort.som pos=1983 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	255
+Sort.som pos=2345 len=5	at:	ArrayRead BasicPrimitiveOperation	int	1
+Sort.som pos=2345 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	251
+Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8
+Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	259
+Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	257
+Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
+Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	259
+Sort.som pos=2594 len=4	size	BasicPrimitiveOperation OpLength VirtualInvokeReceiver	arr	1
+Sort.som pos=2594 len=4	size	BasicPrimitiveOperation OpLength VirtualInvokeReceiver	TOTAL	1
+Sort.som pos=2636 len=3	-	BasicPrimitiveOperation OpArithmetic	int	259
+Sort.som pos=2636 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	259
+Sort.som pos=2705 len=5	at:	ArrayRead BasicPrimitiveOperation	int	16769
+Sort.som pos=2705 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	16769
+Sort.som pos=2739 len=9	at:	ArrayRead BasicPrimitiveOperation	int	16769
+Sort.som pos=2739 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	16769
+Sort.som pos=2745 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	16769
+Sort.som pos=2745 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	16769
+Sort.som pos=2769 len=6	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8609
+Sort.som pos=2769 len=6	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8160
+Sort.som pos=2769 len=6	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	16769
+Sort.som pos=2819 len=15	at:put:	ArrayWrite BasicPrimitiveOperation	int	8159
+Sort.som pos=2819 len=15	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	8159
+Sort.som pos=2856 len=22	at:put:	ArrayWrite BasicPrimitiveOperation	int	8159
+Sort.som pos=2856 len=22	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	8159
+Sort.som pos=2862 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8159
+Sort.som pos=2862 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8159

--- a/tools/tests/dym/expected-results/Sort.QuickSort/general-stats.csv
+++ b/tools/tests/dym/expected-results/Sort.QuickSort/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	40
 Lines Loaded	2156
 Lines Executed	216
-Lines With Statements	1022
+Lines With Statements	969

--- a/tools/tests/dym/expected-results/Sort.QuickSort/operations.csv
+++ b/tools/tests/dym/expected-results/Sort.QuickSort/operations.csv
@@ -1,148 +1,148 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1599
-Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1599
-Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1599
-Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1599
-Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic StatementTag	int	1599
-Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1599
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	9
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4817
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4826
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	4815
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	4815
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	4
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	4
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	4
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	3
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	str	1
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	TOTAL	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	13
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	13
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	13
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	13
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	12
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	13
-Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	1599
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	1599
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	3
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	3
+Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1599
+Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1599
+Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1599
+Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1599
+Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic	int	1599
+Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic	TOTAL	1599
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	9
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4817
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4826
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	4815
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	4815
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	4
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	4
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	4
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	3
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	str	1
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	TOTAL	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	13
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	13
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	int	13
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	13
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	12
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	13
+Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	1599
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	1599
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	arr	3
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	3
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	1599
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	1599
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Sort.som pos=1623 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	1
-Sort.som pos=1623 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	1
-Sort.som pos=1630 len=11	<>	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Sort.som pos=1630 len=11	<>	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Sort.som pos=1666 len=16	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	1
-Sort.som pos=1666 len=16	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	1
-Sort.som pos=1677 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	1
-Sort.som pos=1677 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Sort.som pos=1684 len=10	<>	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Sort.som pos=1684 len=10	<>	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Sort.som pos=1927 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	1
-Sort.som pos=1927 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	1
-Sort.som pos=1963 len=9	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	1595
-Sort.som pos=1963 len=9	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	1595
-Sort.som pos=1969 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1595
-Sort.som pos=1969 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1595
-Sort.som pos=1974 len=15	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1595
-Sort.som pos=1974 len=15	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1595
-Sort.som pos=1983 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	1595
-Sort.som pos=1983 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	1595
-Sort.som pos=2345 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	1
-Sort.som pos=2345 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1589
-Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	10
-Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1599
-Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1593
-Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	6
-Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1599
-Sort.som pos=3267 len=20	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	1397
-Sort.som pos=3267 len=20	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1397
-Sort.som pos=3276 len=6	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1397
-Sort.som pos=3276 len=6	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1397
-Sort.som pos=3284 len=3	/	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1397
-Sort.som pos=3284 len=3	/	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1397
-Sort.som pos=3332 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1398
-Sort.som pos=3332 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4415
-Sort.som pos=3332 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	5813
-Sort.som pos=3379 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	12147
-Sort.som pos=3379 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	12147
-Sort.som pos=3386 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4416
-Sort.som pos=3386 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	7731
-Sort.som pos=3386 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	12147
-Sort.som pos=3416 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	7731
-Sort.som pos=3416 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	7731
-Sort.som pos=3441 len=15	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4415
-Sort.som pos=3441 len=15	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5428
-Sort.som pos=3441 len=15	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	9843
-Sort.som pos=3450 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	9843
-Sort.som pos=3450 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	9843
-Sort.som pos=3479 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	5427
-Sort.som pos=3479 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	5427
-Sort.som pos=3500 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	430
-Sort.som pos=3500 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3985
-Sort.som pos=3500 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4415
-Sort.som pos=3578 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	3985
-Sort.som pos=3578 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	3985
-Sort.som pos=3605 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	3985
-Sort.som pos=3605 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	3985
-Sort.som pos=3623 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	3985
-Sort.som pos=3623 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	3985
-Sort.som pos=3651 len=14	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	3985
-Sort.som pos=3651 len=14	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	3985
-Sort.som pos=3688 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	3985
-Sort.som pos=3688 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	3985
-Sort.som pos=3714 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	3985
-Sort.som pos=3714 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	3985
-Sort.som pos=3742 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	734
-Sort.som pos=3742 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	663
-Sort.som pos=3742 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1397
-Sort.som pos=3805 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	666
-Sort.som pos=3805 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	731
-Sort.som pos=3805 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1397
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	TOTAL	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	TOTAL	1
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Sort.som pos=1623 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	1
+Sort.som pos=1623 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	1
+Sort.som pos=1630 len=11	<>	BasicPrimitiveOperation OpComparison	int	1
+Sort.som pos=1630 len=11	<>	BasicPrimitiveOperation OpComparison	TOTAL	1
+Sort.som pos=1666 len=16	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	1
+Sort.som pos=1666 len=16	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	1
+Sort.som pos=1677 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
+Sort.som pos=1677 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Sort.som pos=1684 len=10	<>	BasicPrimitiveOperation OpComparison	int	1
+Sort.som pos=1684 len=10	<>	BasicPrimitiveOperation OpComparison	TOTAL	1
+Sort.som pos=1927 len=4	size	BasicPrimitiveOperation OpLength	arr	1
+Sort.som pos=1927 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	1
+Sort.som pos=1963 len=9	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	1595
+Sort.som pos=1963 len=9	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	1595
+Sort.som pos=1969 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1595
+Sort.som pos=1969 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1595
+Sort.som pos=1974 len=15	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1595
+Sort.som pos=1974 len=15	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1595
+Sort.som pos=1983 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	1595
+Sort.som pos=1983 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	1595
+Sort.som pos=2345 len=5	at:	ArrayRead BasicPrimitiveOperation	int	1
+Sort.som pos=2345 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1589
+Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	10
+Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1599
+Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1593
+Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	6
+Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1599
+Sort.som pos=3267 len=20	at:	ArrayRead BasicPrimitiveOperation	int	1397
+Sort.som pos=3267 len=20	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1397
+Sort.som pos=3276 len=6	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1397
+Sort.som pos=3276 len=6	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1397
+Sort.som pos=3284 len=3	/	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1397
+Sort.som pos=3284 len=3	/	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1397
+Sort.som pos=3332 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1398
+Sort.som pos=3332 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4415
+Sort.som pos=3332 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	5813
+Sort.som pos=3379 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	12147
+Sort.som pos=3379 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	12147
+Sort.som pos=3386 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4416
+Sort.som pos=3386 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	7731
+Sort.som pos=3386 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	12147
+Sort.som pos=3416 len=3	+	BasicPrimitiveOperation OpArithmetic	int	7731
+Sort.som pos=3416 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	7731
+Sort.som pos=3441 len=15	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4415
+Sort.som pos=3441 len=15	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5428
+Sort.som pos=3441 len=15	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9843
+Sort.som pos=3450 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	9843
+Sort.som pos=3450 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	9843
+Sort.som pos=3479 len=3	-	BasicPrimitiveOperation OpArithmetic	int	5427
+Sort.som pos=3479 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	5427
+Sort.som pos=3500 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	430
+Sort.som pos=3500 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3985
+Sort.som pos=3500 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4415
+Sort.som pos=3578 len=5	at:	ArrayRead BasicPrimitiveOperation	int	3985
+Sort.som pos=3578 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	3985
+Sort.som pos=3605 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	int	3985
+Sort.som pos=3605 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	3985
+Sort.som pos=3623 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	3985
+Sort.som pos=3623 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	3985
+Sort.som pos=3651 len=14	at:put:	ArrayWrite BasicPrimitiveOperation	int	3985
+Sort.som pos=3651 len=14	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	3985
+Sort.som pos=3688 len=3	+	BasicPrimitiveOperation OpArithmetic	int	3985
+Sort.som pos=3688 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	3985
+Sort.som pos=3714 len=3	-	BasicPrimitiveOperation OpArithmetic	int	3985
+Sort.som pos=3714 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	3985
+Sort.som pos=3742 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	734
+Sort.som pos=3742 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	663
+Sort.som pos=3742 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1397
+Sort.som pos=3805 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	666
+Sort.som pos=3805 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	731
+Sort.som pos=3805 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1397

--- a/tools/tests/dym/expected-results/Sort.TreeSort/general-stats.csv
+++ b/tools/tests/dym/expected-results/Sort.TreeSort/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	45
 Lines Loaded	2156
 Lines Executed	211
-Lines With Statements	1022
+Lines With Statements	969

--- a/tools/tests/dym/expected-results/Sort.TreeSort/operations.csv
+++ b/tools/tests/dym/expected-results/Sort.TreeSort/operations.csv
@@ -1,98 +1,98 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1999
-Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1999
-Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1999
-Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1999
-Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic StatementTag	int	1999
-Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1999
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	9
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	6020
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	6029
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	6018
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	6018
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	4
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	4
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	4
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	4
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	3
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	str	1
-Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength StatementTag	TOTAL	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	str	1
-Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	1
-Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	12
-Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	12
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	12
-Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	12
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	11
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1
-Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	12
-Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	int	1999
-Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument StatementTag	TOTAL	1999
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	5
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	5
+Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1999
+Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1999
+Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1999
+Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1999
+Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic	int	1999
+Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic	TOTAL	1999
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	9
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	6020
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	6029
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	6018
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	6018
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	4
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	4
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	4
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	3
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	str	1
+Kernel.som pos=13031 len=6	length	BasicPrimitiveOperation OpLength	TOTAL	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13051 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13055 len=19	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13063 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13070 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	str	1
+Kernel.som pos=13115 len=6	length	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1
+Kernel.som pos=13122 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=13126 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	12
+Kernel.som pos=13181 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	12
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	int	12
+Kernel.som pos=13185 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	12
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	11
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
+Kernel.som pos=13190 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	12
+Kernel.som pos=13332 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13451 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=13545 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	1999
+Kernel.som pos=14540 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	1999
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	arr	5
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	5
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	1999
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	1999
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	arr	1
-Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument StatementTag	TOTAL	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
-Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	1
-Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	int	1
-Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Sort.som pos=2345 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	1
-Sort.som pos=2345 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1989
-Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	10
-Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1999
-Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1993
-Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	6
-Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1999
-Sort.som pos=4170 len=8	<	BasicPrimitiveOperation OpComparison StatementTag	int	995
-Sort.som pos=4170 len=8	<	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	995
-Sort.som pos=4239 len=8	>=	BasicPrimitiveOperation OpComparison StatementTag	int	1001
-Sort.som pos=4239 len=8	>=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	1001
-Sort.som pos=4308 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	12375
-Sort.som pos=4308 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	9942
-Sort.som pos=4308 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	22317
-Sort.som pos=4710 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1998
-Sort.som pos=4710 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Sort.som pos=4710 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1999
-Sort.som pos=4767 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	1
-Sort.som pos=4767 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
-Sort.som pos=4819 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	int	1997
-Sort.som pos=4819 len=5	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1997
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
+Kernel.som pos=21173 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Kernel.som pos=22178 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
+Kernel.som pos=22188 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
+Kernel.som pos=22452 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
+Kernel.som pos=22503 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24328 len=8	<=	BasicPrimitiveOperation OpComparison	TOTAL	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	int	1
+Kernel.som pos=24348 len=9	<	BasicPrimitiveOperation OpComparison	TOTAL	1
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Sort.som pos=2345 len=5	at:	ArrayRead BasicPrimitiveOperation	int	1
+Sort.som pos=2345 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1989
+Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	10
+Sort.som pos=2396 len=9	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1999
+Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1993
+Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	6
+Sort.som pos=2454 len=10	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1999
+Sort.som pos=4170 len=8	<	BasicPrimitiveOperation OpComparison	int	995
+Sort.som pos=4170 len=8	<	BasicPrimitiveOperation OpComparison	TOTAL	995
+Sort.som pos=4239 len=8	>=	BasicPrimitiveOperation OpComparison	int	1001
+Sort.som pos=4239 len=8	>=	BasicPrimitiveOperation OpComparison	TOTAL	1001
+Sort.som pos=4308 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	12375
+Sort.som pos=4308 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	9942
+Sort.som pos=4308 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	22317
+Sort.som pos=4710 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1998
+Sort.som pos=4710 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Sort.som pos=4710 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1999
+Sort.som pos=4767 len=5	at:	ArrayRead BasicPrimitiveOperation	int	1
+Sort.som pos=4767 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Sort.som pos=4819 len=5	at:	ArrayRead BasicPrimitiveOperation	int	1997
+Sort.som pos=4819 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1997

--- a/tools/tests/dym/expected-results/Storage/general-stats.csv
+++ b/tools/tests/dym/expected-results/Storage/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	71
 Lines Loaded	2050
 Lines Executed	160
-Lines With Statements	956
+Lines With Statements	902

--- a/tools/tests/dym/expected-results/Storage/operations.csv
+++ b/tools/tests/dym/expected-results/Storage/operations.csv
@@ -1,44 +1,44 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8191
-Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8191
-Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8191
-Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8191
-Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic StatementTag	int	8191
-Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	8191
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2733
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	10929
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	13662
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	10929
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	10929
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	6
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	6
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	6
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	6
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	6
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	6
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	arr	2729
-Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength StatementTag	TOTAL	2729
+Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8191
+Harness.som pos=2143 len=6	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8191
+Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8191
+Harness.som pos=2151 len=7	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8191
+Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic	int	8191
+Harness.som pos=2160 len=7	&	BasicPrimitiveOperation OpArithmetic	TOTAL	8191
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2733
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	10929
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	13662
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	10929
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	10929
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	6
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	6
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	6
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	6
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	6
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	6
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	arr	2729
+Kernel.som pos=14598 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	2729
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	arr	10914
 Kernel.som pos=16850 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	10914
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Storage.som pos=1613 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	10921
-Storage.som pos=1613 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	10921
-Storage.som pos=1632 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2729
-Storage.som pos=1632 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	8192
-Storage.som pos=1632 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	10921
-Storage.som pos=1682 len=4	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8191
-Storage.som pos=1682 len=4	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8191
-Storage.som pos=1687 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8191
-Storage.som pos=1687 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8191
-Storage.som pos=1779 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	10919
-Storage.som pos=1779 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	10919
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Storage.som pos=1613 len=3	+	BasicPrimitiveOperation OpArithmetic	int	10921
+Storage.som pos=1613 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	10921
+Storage.som pos=1632 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2729
+Storage.som pos=1632 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8192
+Storage.som pos=1632 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	10921
+Storage.som pos=1682 len=4	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8191
+Storage.som pos=1682 len=4	%	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8191
+Storage.som pos=1687 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8191
+Storage.som pos=1687 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8191
+Storage.som pos=1779 len=3	-	BasicPrimitiveOperation OpArithmetic	int	10919
+Storage.som pos=1779 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	10919

--- a/tools/tests/dym/expected-results/Towers/general-stats.csv
+++ b/tools/tests/dym/expected-results/Towers/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	30
 Lines Loaded	2094
 Lines Executed	177
-Lines With Statements	980
+Lines With Statements	927

--- a/tools/tests/dym/expected-results/Towers/operations.csv
+++ b/tools/tests/dym/expected-results/Towers/operations.csv
@@ -1,53 +1,53 @@
 Source Section	Operation	Category	Type	Invocations
-Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
-Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
-Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	8
-Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	11
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	8
-Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	8
-Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2
-Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	27
-Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	29
-Kernel.som pos=8315 len=6	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	27
-Kernel.som pos=8315 len=6	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	27
-Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	5
-Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	5
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	5
-Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	5
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	5
-Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	5
-Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	0
-Towers.som pos=1387 len=8	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	255
-Towers.som pos=1387 len=8	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	16154
-Towers.som pos=1387 len=8	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	16409
-Towers.som pos=1429 len=11	>=	BasicPrimitiveOperation OpComparison StatementTag	int	16153
-Towers.som pos=1429 len=11	>=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	16153
-Towers.som pos=1558 len=18	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	16409
-Towers.som pos=1558 len=18	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	16409
-Towers.som pos=1663 len=8	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	16381
-Towers.som pos=1663 len=8	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	16381
-Towers.som pos=1800 len=22	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	252
-Towers.som pos=1800 len=22	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	16129
-Towers.som pos=1800 len=22	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	16381
-Towers.som pos=2016 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	16381
-Towers.som pos=2016 len=3	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	16381
-Towers.som pos=2253 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	8189
-Towers.som pos=2253 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	8192
-Towers.som pos=2253 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	16381
-Towers.som pos=2377 len=10	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	int	8189
-Towers.som pos=2377 len=10	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument StatementTag	TOTAL	8189
-Towers.som pos=2388 len=8	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	8189
-Towers.som pos=2388 len=8	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	8189
-Towers.som pos=2425 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	8189
-Towers.som pos=2425 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	8189
-Towers.som pos=2544 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	8189
-Towers.som pos=2544 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	8189
+Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
+Harness.som pos=1822 len=7	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Harness.som pos=4605 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=5604 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8
+Kernel.som pos=8023 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	11
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	int	8
+Kernel.som pos=8070 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	8
+Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
+Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	27
+Kernel.som pos=8268 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	29
+Kernel.som pos=8315 len=6	-	BasicPrimitiveOperation OpArithmetic	int	27
+Kernel.som pos=8315 len=6	-	BasicPrimitiveOperation OpArithmetic	TOTAL	27
+Kernel.som pos=12598 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12641 len=13	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	5
+Kernel.som pos=12783 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	5
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	int	5
+Kernel.som pos=12787 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	5
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	5
+Kernel.som pos=12792 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	5
+Platform.som pos=981 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
+Towers.som pos=1387 len=8	at:	ArrayRead BasicPrimitiveOperation	ref	255
+Towers.som pos=1387 len=8	at:	ArrayRead BasicPrimitiveOperation	ref	16154
+Towers.som pos=1387 len=8	at:	ArrayRead BasicPrimitiveOperation	TOTAL	16409
+Towers.som pos=1429 len=11	>=	BasicPrimitiveOperation OpComparison	int	16153
+Towers.som pos=1429 len=11	>=	BasicPrimitiveOperation OpComparison	TOTAL	16153
+Towers.som pos=1558 len=18	at:put:	ArrayWrite BasicPrimitiveOperation	ref	16409
+Towers.som pos=1558 len=18	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	16409
+Towers.som pos=1663 len=8	at:	ArrayRead BasicPrimitiveOperation	ref	16381
+Towers.som pos=1663 len=8	at:	ArrayRead BasicPrimitiveOperation	TOTAL	16381
+Towers.som pos=1800 len=22	at:put:	ArrayWrite BasicPrimitiveOperation	ref	252
+Towers.som pos=1800 len=22	at:put:	ArrayWrite BasicPrimitiveOperation	ref	16129
+Towers.som pos=1800 len=22	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	16381
+Towers.som pos=2016 len=3	+	BasicPrimitiveOperation OpArithmetic	int	16381
+Towers.som pos=2016 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	16381
+Towers.som pos=2253 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8189
+Towers.som pos=2253 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8192
+Towers.som pos=2253 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	16381
+Towers.som pos=2377 len=10	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8189
+Towers.som pos=2377 len=10	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8189
+Towers.som pos=2388 len=8	-	BasicPrimitiveOperation OpArithmetic	int	8189
+Towers.som pos=2388 len=8	-	BasicPrimitiveOperation OpArithmetic	TOTAL	8189
+Towers.som pos=2425 len=3	-	BasicPrimitiveOperation OpArithmetic	int	8189
+Towers.som pos=2425 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	8189
+Towers.som pos=2544 len=3	-	BasicPrimitiveOperation OpArithmetic	int	8189
+Towers.som pos=2544 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	8189


### PR DESCRIPTION
These changes are supposed to make stepping in the debugger nicer by:

 - ignore implicit nodes for stepping
 - properly disable disabled buttons (not just visually)
 - add fly-over help to buttons
 - fix bug with breakpoint using the `#halt` message (e.g., `1 halt.` or `self halt.`) in code
 - fix issue with sending breakpoints after reconnecting
 - fixed asynchronous-message-received breakpoints