### PR TITLE
Fix lookup issues caused by incorrect outer object reads

### DIFF
--- a/core-lib/Actors.som
+++ b/core-lib/Actors.som
@@ -156,7 +156,6 @@ class Actors usingVmMirror: vmMirror usingKernel: kernel = Value (
     )
   )
 
-
   public createPromisePair = (
     ^ vmMirror actorsCreatePromisePair: nil.
   )

--- a/core-lib/TestSuite/ActorTests.som
+++ b/core-lib/TestSuite/ActorTests.som
@@ -434,4 +434,18 @@ class ActorTests usingPlatform: platform testFramework: minitest = Value (
   ) : (
     TEST_CONTEXT = ()
   )
+
+  public class RegressionTests = AsyncTestContext ()(
+    (* This test is to identify issues in the OuterObjectRead node.
+       It did not handle properly the different cases of outer scope
+       semantics, depending on the point in the inheritance tree, i.e.,
+       starting lexical scope. *)
+    public testFarReferenceLookupInKernel = (
+      | ref |
+      ref := (actors createActorFromValue: DeepChain).
+      assert: ref asString println equals: 'instance of FarReference'.
+    )
+  ) : (
+    TEST_CONTEXT = ()
+  )
 )

--- a/src/som/interpreter/nodes/OuterObjectRead.java
+++ b/src/som/interpreter/nodes/OuterObjectRead.java
@@ -1,6 +1,9 @@
 package som.interpreter.nodes;
 
+import java.math.BigInteger;
+
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
@@ -15,18 +18,32 @@ import som.interpreter.nodes.nary.ExprWithTagsNode;
 import som.interpreter.objectstorage.ClassFactory;
 import som.primitives.actors.ActorClasses;
 import som.vm.constants.KernelObj;
+import som.vmobjects.SArray;
+import som.vmobjects.SBlock;
 import som.vmobjects.SClass;
 import som.vmobjects.SObjectWithClass;
+import som.vmobjects.SSymbol;
 
 
+@ImportStatic(ActorClasses.class)
 @NodeChild(value = "receiver", type = ExpressionNode.class)
 public abstract class OuterObjectRead
     extends ExprWithTagsNode implements ISpecialSend {
 
   protected static final int INLINE_CACHE_SIZE = VmSettings.DYNAMIC_METRICS ? 100 : 3;
 
+  /**
+   * The level of lexical context. A level of 0 is self, level of 1 is the first
+   * outer lexical context, so, the directly enclosing object.
+   */
   protected final int contextLevel;
-  private final MixinDefinitionId mixinId;
+
+  /**
+   * Mixin where the lookup starts, can be a mixin different from the `self`.
+   * Thus, it can be one in the inheritance chain, for instance.
+   */
+  protected final MixinDefinitionId mixinId;
+
   private final MixinDefinitionId enclosingMixinId;
 
   private final ValueProfile enclosingObj;
@@ -54,6 +71,8 @@ public abstract class OuterObjectRead
   @Override
   public boolean isSuperSend() { return false; }
 
+  public abstract Object executeEvaluated(Object receiver);
+
   protected final SClass getEnclosingClass(final SObjectWithClass rcvr) {
     SClass lexicalClass = rcvr.getSOMClass().getClassCorrespondingTo(mixinId);
     assert lexicalClass != null;
@@ -76,7 +95,7 @@ public abstract class OuterObjectRead
   public final Object doForFurtherOuter(final SObjectWithClass receiver,
       @Cached("receiver.getSOMClass()") final SClass rcvrClass,
       @Cached("getEnclosingClass(receiver)") final SClass lexicalClass) {
-    return getEnclosingObject(receiver, lexicalClass);
+    return getEnclosingObject(lexicalClass);
   }
 
   protected final int getIdx(final SObjectWithClass rcvr) {
@@ -98,44 +117,16 @@ public abstract class OuterObjectRead
       @Cached("getIdx(receiver)") final int superclassIdx,
       @Cached("getEnclosingClass(receiver).getInstanceFactory()") final ClassFactory factory) {
     assert factory != null;
-    return getEnclosingObject(receiver, getEnclosingClassWithPotentialFailure(receiver, superclassIdx));
+    return getEnclosingObject(getEnclosingClassWithPotentialFailure(receiver, superclassIdx));
   }
 
   @Specialization(guards = {"contextLevel != 0"}, contains = "fixedLookup")
   public final Object fallback(final SObjectWithClass receiver) {
-    return getEnclosingObject(receiver, getEnclosingClass(receiver));
-  }
-
-  public abstract Object executeEvaluated(Object receiver);
-
-  protected static final boolean notSObjectWithClass(final Object receiver) {
-    return !(receiver instanceof SObjectWithClass) && !(receiver instanceof SFarReference);
-  }
-
-  protected static final boolean notSObjectWithClassClass(final Class<?> rcvrClass) {
-    return !rcvrClass.isAssignableFrom(SObjectWithClass.class) && !rcvrClass.isAssignableFrom(SFarReference.class);
-  }
-
-  @Specialization(guards = {"receiver.getClass() == rcvrClass",
-      "notSObjectWithClassClass(rcvrClass)"})
-  public Object doObject(final Object receiver, @Cached("receiver.getClass()") final Class<?> rcvrClass) {
-    return KernelObj.kernel;
-  }
-
-  @Specialization(guards = "notSObjectWithClass(receiver)")
-  public Object doObject(final Object receiver) {
-    return KernelObj.kernel;
-  }
-
-  @Specialization
-  public Object doFarReference(final SFarReference receiver) {
-    assert ActorClasses.ActorModule != null;
-    return ActorClasses.ActorModule;
+    return getEnclosingObject(getEnclosingClass(receiver));
   }
 
   @ExplodeLoop
-  private Object getEnclosingObject(final SObjectWithClass receiver,
-      final SClass lexicalClass) {
+  private Object getEnclosingObject(final SClass lexicalClass) {
     int ctxLevel = contextLevel - 1; // 0 is already covered with specialization
     SObjectWithClass enclosing = lexicalClass.getEnclosingObject();
 
@@ -145,6 +136,80 @@ public abstract class OuterObjectRead
     }
     return enclosingObj.profile(enclosing);
   }
+
+  /**
+   * Need to get the outer scope for FarReference, while in the Actors module.
+   */
+  @Specialization(guards = {"mixinId == FarRefId", "contextLevel == 1"})
+  public Object doFarReferenceInActorModuleScope(final SFarReference receiver) {
+    assert ActorClasses.ActorModule != null;
+    return ActorClasses.ActorModule;
+  }
+
+  /**
+   * Need to get the outer scope for FarReference, but it is not the actors module.
+   * Since there are only super classes in Kernel, we know it is going to be the Kernel.
+   */
+  @Specialization(guards = {"mixinId != FarRefId", "contextLevel == 1"})
+  public Object doFarReferenceInKernelModuleScope(final SFarReference receiver) {
+    return KernelObj.kernel;
+  }
+
+  /**
+   * Need to get outer scope of contextLevel == 0, which is self.
+   */
+  @Specialization(guards = {"contextLevel == 0"})
+  public SFarReference doFarReferenceDirect(final SFarReference receiver) {
+    return receiver;
+  }
+
+  @Specialization(guards = "contextLevel != 0")
+  public Object doBool(final boolean receiver) { return KernelObj.kernel; }
+
+  @Specialization(guards = "contextLevel != 0")
+  public Object doLong(final long receiver) { return KernelObj.kernel; }
+
+  @Specialization(guards = "contextLevel != 0")
+  public Object doString(final String receiver) { return KernelObj.kernel; }
+
+  @Specialization(guards = "contextLevel != 0")
+  public Object doBigInteger(final BigInteger receiver) { return KernelObj.kernel; }
+
+  @Specialization(guards = "contextLevel != 0")
+  public Object doDouble(final double receiver) { return KernelObj.kernel; }
+
+  @Specialization(guards = "contextLevel != 0")
+  public Object doSSymbol(final SSymbol receiver) { return KernelObj.kernel; }
+
+  @Specialization(guards = "contextLevel != 0")
+  public Object doSArray(final SArray receiver) { return KernelObj.kernel; }
+
+  @Specialization(guards = "contextLevel != 0")
+  public Object doSBlock(final SBlock receiver) { return KernelObj.kernel; }
+
+  @Specialization(guards = "contextLevel == 0")
+  public boolean doBoolDirect(final boolean receiver) { return receiver; }
+
+  @Specialization(guards = "contextLevel == 0")
+  public long doLongDirect(final long receiver) { return receiver; }
+
+  @Specialization(guards = "contextLevel == 0")
+  public String doStringDirect(final String receiver) { return receiver; }
+
+  @Specialization(guards = "contextLevel == 0")
+  public BigInteger doBigIntegerDirect(final BigInteger receiver) { return receiver; }
+
+  @Specialization(guards = "contextLevel == 0")
+  public Double doDoubleDirect(final double receiver) { return receiver; }
+
+  @Specialization(guards = "contextLevel == 0")
+  public SSymbol doSSymbolDirect(final SSymbol receiver) { return receiver; }
+
+  @Specialization(guards = "contextLevel == 0")
+  public SArray doSArrayDirect(final SArray receiver) { return receiver; }
+
+  @Specialization(guards = "contextLevel == 0")
+  public SBlock doSBlockDirect(final SBlock receiver) { return receiver; }
 
   @Override
   protected boolean isTaggedWith(final Class<?> tag) {

--- a/src/som/primitives/actors/ActorClasses.java
+++ b/src/som/primitives/actors/ActorClasses.java
@@ -5,6 +5,7 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
 
+import som.compiler.MixinBuilder.MixinDefinitionId;
 import som.interpreter.actors.SFarReference;
 import som.interpreter.actors.SPromise;
 import som.interpreter.actors.SPromise.SResolver;
@@ -15,6 +16,10 @@ import som.vmobjects.SObject.SImmutableObject;
 
 
 public final class ActorClasses {
+
+  @CompilationFinal public static SImmutableObject  ActorModule;
+  @CompilationFinal public static MixinDefinitionId FarRefId;
+
   @GenerateNodeFactory
   @Primitive(primitive = "actorsFarReferenceClass:")
   public abstract static class SetFarReferenceClassPrim extends UnaryExpressionNode {
@@ -23,6 +28,7 @@ public final class ActorClasses {
     @Specialization
     public final SClass setClass(final SClass value) {
       SFarReference.setSOMClass(value);
+      FarRefId = value.getMixinDefinition().getMixinId();
       return value;
     }
   }
@@ -63,7 +69,7 @@ public final class ActorClasses {
     }
   }
 
-  @CompilationFinal public static SImmutableObject ActorModule;
+
 
   @GenerateNodeFactory
   @Primitive(primitive = "actorsModule:")


### PR DESCRIPTION
- add specializations for the basic types
- remove crude hack to just return kernel
- handle lookup for SFarReference depending on mixinId and context level
- cache far ref mixin id
- add a little documentation

Unfortunately, this is currently blocked on #34.
Looks like it was hiding a place in the tests that becomes a megamorphic super send now.