### PR TITLE
Fix usage of StatementTag to fit with Truffle's expectations

### DIFF
--- a/src/som/compiler/MixinBuilder.java
+++ b/src/som/compiler/MixinBuilder.java
@@ -46,6 +46,7 @@ import som.interpreter.SomLanguage;
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.IsValueCheckNode;
 import som.interpreter.nodes.dispatch.Dispatchable;
+import som.interpreter.objectstorage.InitializerFieldWrite;
 import som.primitives.NewObjectPrimNodeGen;
 import som.vm.Symbols;
 import som.vmobjects.SInvokable;
@@ -313,11 +314,14 @@ public final class MixinBuilder {
 
     if (init != null) {
       ExpressionNode self = initializer.getSelfRead(source);
-      slotAndInitExprs.add(slot.getInitializerWriteNode(self, init, source));
+      InitializerFieldWrite write = slot.getInitializerWriteNode(self, init, source);
+      write.markAsStatement();
+      slotAndInitExprs.add(write);
     }
   }
 
   public void addInitializerExpression(final ExpressionNode expression) {
+    expression.markAsStatement();
     slotAndInitExprs.add(expression);
   }
 

--- a/src/som/interpreter/Method.java
+++ b/src/som/interpreter/Method.java
@@ -128,7 +128,6 @@ public final class Method extends Invokable {
   public SourceSection getRootNodeSource() {
     ExpressionNode root = SOMNode.unwrapIfNecessary(expressionOrSequence);
     assert root.isMarkedAsRootExpression();
-    assert root.assertIsStatement();
 
     return root.getSourceSection();
   }

--- a/src/som/interpreter/SNodeFactory.java
+++ b/src/som/interpreter/SNodeFactory.java
@@ -99,6 +99,10 @@ public final class SNodeFactory {
 
   public static ExpressionNode createSequence(
       final List<ExpressionNode> expressions, final SourceSection source) {
+    for (ExpressionNode statement : expressions) {
+      statement.markAsStatement();
+    }
+
     if (expressions.size() == 0) {
       return new NilLiteralNode(source);
     } else if (expressions.size() == 1) {

--- a/src/som/interpreter/actors/EventualSendNode.java
+++ b/src/som/interpreter/actors/EventualSendNode.java
@@ -9,7 +9,6 @@ import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
@@ -291,8 +290,6 @@ public class EventualSendNode extends ExprWithTagsNode {
     @Override
     protected boolean isTaggedWith(final Class<?> tag) {
       if (tag == EventualMessageSend.class) {
-        return true;
-      } else if (tag == StatementTag.class) {
         return true;
       }
       return super.isTaggedWith(tag);

--- a/src/som/interpreter/actors/ReceivedRootNode.java
+++ b/src/som/interpreter/actors/ReceivedRootNode.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -75,14 +74,6 @@ public abstract class ReceivedRootNode extends RootNode {
     @Override
     public Object executeGeneric(final VirtualFrame frame) {
       return null;
-    }
-
-    @Override
-    protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
-      if (tag == StatementTag.class) {
-        return isMarkedAsRootExpression();
-      }
-      return super.isTaggedWithIgnoringEagerness(tag);
     }
   }
 }

--- a/src/som/interpreter/nodes/ArgumentReadNode.java
+++ b/src/som/interpreter/nodes/ArgumentReadNode.java
@@ -2,7 +2,6 @@ package som.interpreter.nodes;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.profiles.ValueProfile;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -56,8 +55,6 @@ public abstract class ArgumentReadNode {
         return true;
       } else if (tag == LocalArgRead.class) {
         return true;
-      } else if (tag == StatementTag.class) {
-        return isMarkedAsRootExpression();
       } else {
         return super.isTaggedWith(tag);
       }
@@ -167,8 +164,6 @@ public abstract class ArgumentReadNode {
         return true;
       } else if (tag == LocalArgRead.class) {
         return true;
-      } else if (tag == StatementTag.class) {
-        return isMarkedAsRootExpression();
       } else {
         return super.isTaggedWith(tag);
       }

--- a/src/som/interpreter/nodes/ExpressionNode.java
+++ b/src/som/interpreter/nodes/ExpressionNode.java
@@ -73,6 +73,8 @@ public abstract class ExpressionNode extends SOMNode {
 
   public void markAsVirtualInvokeReceiver()  { throw new UnsupportedOperationException(); }
 
+  public void markAsStatement()  { throw new UnsupportedOperationException(); }
+
   public abstract Object executeGeneric(final VirtualFrame frame);
 
   @Override

--- a/src/som/interpreter/nodes/InternalObjectArrayNode.java
+++ b/src/som/interpreter/nodes/InternalObjectArrayNode.java
@@ -1,7 +1,6 @@
 package som.interpreter.nodes;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.NodeCost;
 import com.oracle.truffle.api.nodes.NodeInfo;
@@ -32,13 +31,5 @@ public final class InternalObjectArrayNode extends ExprWithTagsNode {
   @Override
   public Object executeGeneric(final VirtualFrame frame) {
     return executeObjectArray(frame);
-  }
-
-  @Override
-  protected boolean isTaggedWith(final Class<?> tag) {
-    if (tag == StatementTag.class) {
-      return false;
-    }
-    return super.isTaggedWith(tag);
   }
 }

--- a/src/som/interpreter/nodes/IsValueCheckNode.java
+++ b/src/som/interpreter/nodes/IsValueCheckNode.java
@@ -1,7 +1,6 @@
 package som.interpreter.nodes;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
@@ -141,13 +140,5 @@ public abstract class IsValueCheckNode extends UnaryExpressionNode {
   @Override
   public Object executeGeneric(final VirtualFrame frame) {
     return executeEvaluated(frame, self.executeGeneric(frame));
-  }
-
-  @Override
-  protected final boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
-    if (tag == StatementTag.class) {
-      return false;
-    }
-    return super.isTaggedWithIgnoringEagerness(tag);
   }
 }

--- a/src/som/interpreter/nodes/LocalVariableNode.java
+++ b/src/som/interpreter/nodes/LocalVariableNode.java
@@ -7,7 +7,6 @@ import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.FrameSlotTypeException;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.Variable.Local;
@@ -55,8 +54,6 @@ public abstract class LocalVariableNode extends ExprWithTagsNode {
   protected boolean isTaggedWith(final Class<?> tag) {
     if (tag == LocalVariableTag.class) {
       return true;
-    } else if (tag == StatementTag.class) {
-      return isMarkedAsRootExpression();
     } else {
       return super.isTaggedWith(tag);
     }

--- a/src/som/interpreter/nodes/MessageSendNode.java
+++ b/src/som/interpreter/nodes/MessageSendNode.java
@@ -7,7 +7,6 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
 import com.oracle.truffle.api.instrumentation.StandardTags.CallTag;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeCost;
@@ -80,8 +79,6 @@ public final class MessageSendNode {
     @Override
     protected boolean isTaggedWith(final Class<?> tag) {
       if (tag == CallTag.class) {
-        return true;
-      } else if (tag == StatementTag.class) {
         return true;
       }
       return super.isTaggedWith(tag);

--- a/src/som/interpreter/nodes/NonLocalVariableNode.java
+++ b/src/som/interpreter/nodes/NonLocalVariableNode.java
@@ -8,7 +8,6 @@ import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.FrameSlotTypeException;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.InlinerAdaptToEmbeddedOuterContext;
@@ -45,8 +44,6 @@ public abstract class NonLocalVariableNode extends ContextualNode {
   protected boolean isTaggedWith(final Class<?> tag) {
     if (tag == LocalVariableTag.class) {
       return true;
-    } else if (tag == StatementTag.class) {
-      return isMarkedAsRootExpression();
     } else {
       return super.isTaggedWith(tag);
     }

--- a/src/som/interpreter/nodes/OuterObjectRead.java
+++ b/src/som/interpreter/nodes/OuterObjectRead.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.profiles.ValueProfile;
 import com.oracle.truffle.api.source.SourceSection;
@@ -210,12 +209,4 @@ public abstract class OuterObjectRead
 
   @Specialization(guards = "contextLevel == 0")
   public SBlock doSBlockDirect(final SBlock receiver) { return receiver; }
-
-  @Override
-  protected boolean isTaggedWith(final Class<?> tag) {
-    if (tag == StatementTag.class) {
-      return isMarkedAsRootExpression();
-    }
-    return super.isTaggedWith(tag);
-  }
 }

--- a/src/som/interpreter/nodes/ResolvingImplicitReceiverSend.java
+++ b/src/som/interpreter/nodes/ResolvingImplicitReceiverSend.java
@@ -3,7 +3,6 @@ package som.interpreter.nodes;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.MixinBuilder.MixinDefinitionId;
@@ -91,14 +90,6 @@ public final class ResolvingImplicitReceiverSend extends AbstractMessageSendNode
       }
     }
     return replacedBy;
-  }
-
-  @Override
-  protected boolean isTaggedWith(final Class<?> tag) {
-    if (tag == StatementTag.class) {
-      return isMarkedAsRootExpression();
-    }
-    return super.isTaggedWith(tag);
   }
 
   @Override

--- a/src/som/interpreter/nodes/SequenceNode.java
+++ b/src/som/interpreter/nodes/SequenceNode.java
@@ -22,7 +22,6 @@
 package som.interpreter.nodes;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeCost;
@@ -65,14 +64,6 @@ public final class SequenceNode extends ExprWithTagsNode {
       return true;
     }
     return false;
-  }
-
-  @Override
-  protected boolean isTaggedWith(final Class<?> tag) {
-    if (tag == StatementTag.class) {
-      return isMarkedAsRootExpression();
-    }
-    return super.isTaggedWith(tag);
   }
 
   @Override

--- a/src/som/interpreter/nodes/UninitializedVariableNode.java
+++ b/src/som/interpreter/nodes/UninitializedVariableNode.java
@@ -4,7 +4,6 @@ import static som.interpreter.TruffleCompiler.transferToInterpreterAndInvalidate
 
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.Variable.Local;
@@ -67,8 +66,6 @@ public abstract class UninitializedVariableNode extends ContextualNode {
     protected boolean isTaggedWith(final Class<?> tag) {
       if (tag == LocalVarRead.class) {
         return true;
-      } else if (tag == StatementTag.class) {
-        return isMarkedAsRootExpression();
       } else {
         return super.isTaggedWith(tag);
       }
@@ -152,8 +149,6 @@ public abstract class UninitializedVariableNode extends ContextualNode {
     protected boolean isTaggedWith(final Class<?> tag) {
       if (tag == LocalVarWrite.class) {
         return true;
-      } else if (tag == StatementTag.class) {
-        return isMarkedAsRootExpression();
       } else {
         return super.isTaggedWith(tag);
       }

--- a/src/som/interpreter/nodes/literals/LiteralNode.java
+++ b/src/som/interpreter/nodes/literals/LiteralNode.java
@@ -23,7 +23,6 @@ package som.interpreter.nodes.literals;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.NodeCost;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.source.SourceSection;
@@ -66,8 +65,6 @@ public abstract class LiteralNode extends ExprWithTagsNode
   protected boolean isTaggedWith(final Class<?> tag) {
     if (tag == LiteralTag.class) {
       return true;
-    } else if (tag == StatementTag.class) {
-      return isMarkedAsRootExpression();
     } else {
       return super.isTaggedWith(tag);
     }

--- a/src/som/interpreter/nodes/nary/EagerBinaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerBinaryPrimitiveNode.java
@@ -3,7 +3,6 @@ package som.interpreter.nodes.nary;
 import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -39,9 +38,6 @@ public final class EagerBinaryPrimitiveNode extends EagerPrimitive {
 
   @Override
   protected boolean isTaggedWith(final Class<?> tag) {
-    if (tag == StatementTag.class) {
-      return isMarkedAsRootExpression();
-    }
     assert !(primitive instanceof WrapperNode);
     return primitive.isTaggedWithIgnoringEagerness(tag);
   }

--- a/src/som/interpreter/nodes/nary/EagerTernaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerTernaryPrimitiveNode.java
@@ -3,7 +3,6 @@ package som.interpreter.nodes.nary;
 import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -44,9 +43,6 @@ public final class EagerTernaryPrimitiveNode extends EagerPrimitive {
 
   @Override
   protected boolean isTaggedWith(final Class<?> tag) {
-    if (tag == StatementTag.class) {
-      return isMarkedAsRootExpression();
-    }
     assert !(primitive instanceof WrapperNode);
     return primitive.isTaggedWithIgnoringEagerness(tag);
   }

--- a/src/som/interpreter/nodes/nary/EagerUnaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerUnaryPrimitiveNode.java
@@ -3,7 +3,6 @@ package som.interpreter.nodes.nary;
 import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -34,9 +33,6 @@ public final class EagerUnaryPrimitiveNode extends EagerPrimitive {
 
   @Override
   protected boolean isTaggedWith(final Class<?> tag) {
-    if (tag == StatementTag.class) {
-      return isMarkedAsRootExpression();
-    }
     assert !(primitive instanceof WrapperNode);
     return primitive.isTaggedWithIgnoringEagerness(tag);
   }

--- a/src/som/interpreter/nodes/nary/ExprWithTagsNode.java
+++ b/src/som/interpreter/nodes/nary/ExprWithTagsNode.java
@@ -45,6 +45,11 @@ public abstract class ExprWithTagsNode extends ExpressionNode {
    */
   private static final byte VIRTUAL_INVOKE_RECEIVER = 1 << 4;
 
+  /**
+   * Indicate that this node is the first/root node of a statement.
+   */
+  private static final byte STATEMENT = 1 << 5;
+
   public ExprWithTagsNode(final SourceSection sourceSection) {
     super(sourceSection);
   }
@@ -110,6 +115,12 @@ public abstract class ExprWithTagsNode extends ExpressionNode {
   }
 
   @Override
+  public void markAsStatement() {
+    assert getSourceSection() != null;
+    tagWith(STATEMENT);
+  }
+
+  @Override
   protected void onReplace(final Node newNode, final CharSequence reason) {
     if (newNode instanceof WrapperNode) { return; }
 
@@ -126,7 +137,7 @@ public abstract class ExprWithTagsNode extends ExpressionNode {
   @Override
   protected boolean isTaggedWith(final Class<?> tag) {
     if (tag == StatementTag.class) {
-      return true;
+      return isTagged(STATEMENT);
     } else if (tag == RootTag.class) {
       return isTagged(ROOT_EXPR);
     } else if (tag == LoopBody.class) {

--- a/tools/tests/dym/expected-results/Bounce/general-stats.csv
+++ b/tools/tests/dym/expected-results/Bounce/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	26
 Lines Loaded	2078
 Lines Executed	182
-Lines With Statements	838
+Lines With Statements	920

--- a/tools/tests/dym/expected-results/Bounce/operations.csv
+++ b/tools/tests/dym/expected-results/Bounce/operations.csv
@@ -54,9 +54,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	55
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5157
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	5212
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	55
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5157
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	5212
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	5157
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	5157
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/DeltaBlue/general-stats.csv
+++ b/tools/tests/dym/expected-results/DeltaBlue/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	35
 Lines Loaded	2828
 Lines Executed	526
-Lines With Statements	1155
+Lines With Statements	1244

--- a/tools/tests/dym/expected-results/DeltaBlue/operations.csv
+++ b/tools/tests/dym/expected-results/DeltaBlue/operations.csv
@@ -2,10 +2,10 @@ Source Section	Operation	Category	Type	Invocations
 Collections.som pos=4222 len=7	=	BasicPrimitiveOperation OpComparison	int	7
 Collections.som pos=4222 len=7	=	BasicPrimitiveOperation OpComparison	int	23
 Collections.som pos=4222 len=7	=	BasicPrimitiveOperation OpComparison	TOTAL	30
-Collections.som pos=4240 len=6	=	BasicPrimitiveOperation OpComparison	Symbol	22
-Collections.som pos=4240 len=6	=	BasicPrimitiveOperation OpComparison	TOTAL	22
-Collections.som pos=4378 len=21	bitXor:	BasicPrimitiveOperation OpArithmetic	int	38
-Collections.som pos=4378 len=21	bitXor:	BasicPrimitiveOperation OpArithmetic	TOTAL	38
+Collections.som pos=4240 len=6	=	BasicPrimitiveOperation OpComparison StatementTag	Symbol	22
+Collections.som pos=4240 len=6	=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	22
+Collections.som pos=4378 len=21	bitXor:	BasicPrimitiveOperation OpArithmetic StatementTag	int	38
+Collections.som pos=4378 len=21	bitXor:	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	38
 Collections.som pos=4392 len=6	>>>	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	38
 Collections.som pos=4392 len=6	>>>	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	38
 Collections.som pos=4453 len=29	+	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	int	38
@@ -21,8 +21,8 @@ Collections.som pos=4539 len=21	at:	ArrayRead BasicPrimitiveOperation RootTag St
 Collections.som pos=5286 len=5	at:	ArrayRead BasicPrimitiveOperation	ref	2
 Collections.som pos=5286 len=5	at:	ArrayRead BasicPrimitiveOperation	ref	13
 Collections.som pos=5286 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	15
-Collections.som pos=5356 len=50	at:put:	ArrayWrite BasicPrimitiveOperation	ref	13
-Collections.som pos=5356 len=50	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	13
+Collections.som pos=5356 len=50	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	13
+Collections.som pos=5356 len=50	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	13
 Collections.som pos=5433 len=3	+	BasicPrimitiveOperation OpArithmetic	int	13
 Collections.som pos=5433 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	13
 Collections.som pos=5546 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	15
@@ -31,11 +31,11 @@ Collections.som pos=5556 len=4	size	BasicPrimitiveOperation OpLength PrimitiveAr
 Collections.som pos=5556 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	15
 Collections.som pos=6019 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
 Collections.som pos=6019 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
-DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	6
-DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	2
-DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	3
-DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	14
-DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	25
+DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	6
+DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	2
+DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	3
+DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	14
+DeltaBlue.som pos=2636 len=6	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	25
 DeltaBlue.som pos=5750 len=7	<>	BasicPrimitiveOperation OpComparison	int	12
 DeltaBlue.som pos=5750 len=7	<>	BasicPrimitiveOperation OpComparison	TOTAL	12
 DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	2
@@ -51,9 +51,9 @@ DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	9
 DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	16
 DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	ref	6
 DeltaBlue.som pos=6535 len=15	==	BasicPrimitiveOperation OpComparison	TOTAL	69
-DeltaBlue.som pos=6570 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	14
-DeltaBlue.som pos=6570 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	13
-DeltaBlue.som pos=6570 len=3	not	BasicPrimitiveOperation OpArithmetic	TOTAL	27
+DeltaBlue.som pos=6570 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	14
+DeltaBlue.som pos=6570 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	13
+DeltaBlue.som pos=6570 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	27
 DeltaBlue.som pos=7511 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	28
 DeltaBlue.som pos=7511 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	28
 DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison	ref	1
@@ -64,9 +64,9 @@ DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison	ref	1
 DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison	ref	2
 DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison	ref	6
 DeltaBlue.som pos=8226 len=15	==	BasicPrimitiveOperation OpComparison	TOTAL	18
-DeltaBlue.som pos=8261 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	7
-DeltaBlue.som pos=8261 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	3
-DeltaBlue.som pos=8261 len=3	not	BasicPrimitiveOperation OpArithmetic	TOTAL	10
+DeltaBlue.som pos=8261 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	7
+DeltaBlue.som pos=8261 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	3
+DeltaBlue.som pos=8261 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	10
 DeltaBlue.som pos=8797 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19
 DeltaBlue.som pos=8797 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	19
 DeltaBlue.som pos=10011 len=5	at:	ArrayRead BasicPrimitiveOperation	ref	1
@@ -155,9 +155,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	259
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	744
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1003
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	259
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	744
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1003
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	744
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	744
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -182,10 +182,10 @@ Kernel.som pos=14597 len=4	size	BasicPrimitiveOperation OpLength	arr	23
 Kernel.som pos=14597 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	23
 Kernel.som pos=16849 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	ref	2
 Kernel.som pos=16849 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	2
-Kernel.som pos=18340 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	ref	4
-Kernel.som pos=18340 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	4
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	ref	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=18340 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	4
+Kernel.som pos=18340 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	4
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=21458 len=3	-	BasicPrimitiveOperation OpArithmetic	int	223
 Kernel.som pos=21458 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	223
 Kernel.som pos=21495 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	155
@@ -213,13 +213,13 @@ Kernel.som pos=22386 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgume
 Kernel.som pos=22386 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	2
 Kernel.som pos=22386 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	10
 Kernel.som pos=22386 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	24
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	20
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	16
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	30
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	12
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	Symbol	7
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	15
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	100
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	20
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	16
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	30
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	12
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	Symbol	7
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	15
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	100
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	int	100
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	100
 Kernel.som pos=23032 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	1
@@ -227,10 +227,10 @@ Kernel.som pos=23032 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpCom
 Kernel.som pos=23032 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	2
 Kernel.som pos=23032 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	5
 Kernel.som pos=23032 len=9	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	20
-Kernel.som pos=23121 len=19	at:put:	ArrayWrite BasicPrimitiveOperation	ref	1
-Kernel.som pos=23121 len=19	at:put:	ArrayWrite BasicPrimitiveOperation	ref	12
-Kernel.som pos=23121 len=19	at:put:	ArrayWrite BasicPrimitiveOperation	ref	2
-Kernel.som pos=23121 len=19	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	15
+Kernel.som pos=23121 len=19	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	1
+Kernel.som pos=23121 len=19	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	12
+Kernel.som pos=23121 len=19	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	2
+Kernel.som pos=23121 len=19	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	15
 Kernel.som pos=23173 len=3	+	BasicPrimitiveOperation OpArithmetic	int	15
 Kernel.som pos=23173 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	15
 Kernel.som pos=24010 len=10	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	int	109
@@ -246,12 +246,12 @@ Kernel.som pos=24347 len=9	<	BasicPrimitiveOperation OpComparison	int	1
 Kernel.som pos=24347 len=9	<	BasicPrimitiveOperation OpComparison	TOTAL	1
 Kernel.som pos=24568 len=3	+	BasicPrimitiveOperation OpArithmetic	int	54
 Kernel.som pos=24568 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	54
-Kernel.som pos=24589 len=16	at:	ArrayRead BasicPrimitiveOperation	ref	10
-Kernel.som pos=24589 len=16	at:	ArrayRead BasicPrimitiveOperation	ref	9
-Kernel.som pos=24589 len=16	at:	ArrayRead BasicPrimitiveOperation	ref	16
-Kernel.som pos=24589 len=16	at:	ArrayRead BasicPrimitiveOperation	ref	6
-Kernel.som pos=24589 len=16	at:	ArrayRead BasicPrimitiveOperation	ref	13
-Kernel.som pos=24589 len=16	at:	ArrayRead BasicPrimitiveOperation	TOTAL	54
+Kernel.som pos=24589 len=16	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	10
+Kernel.som pos=24589 len=16	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	9
+Kernel.som pos=24589 len=16	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	16
+Kernel.som pos=24589 len=16	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	6
+Kernel.som pos=24589 len=16	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	13
+Kernel.som pos=24589 len=16	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	54
 Kernel.som pos=24602 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	54
 Kernel.som pos=24602 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	54
 Kernel.som pos=24926 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	2

--- a/tools/tests/dym/expected-results/Fannkuch/general-stats.csv
+++ b/tools/tests/dym/expected-results/Fannkuch/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	21
 Lines Loaded	2122
 Lines Executed	207
-Lines With Statements	859
+Lines With Statements	941

--- a/tools/tests/dym/expected-results/Fannkuch/operations.csv
+++ b/tools/tests/dym/expected-results/Fannkuch/operations.csv
@@ -1,9 +1,9 @@
 Source Section	Operation	Category	Type	Invocations
 Fannkuch.som pos=2008 len=5	at:	ArrayRead BasicPrimitiveOperation	int	61
 Fannkuch.som pos=2008 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	61
-Fannkuch.som pos=2015 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	38
-Fannkuch.som pos=2015 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	23
-Fannkuch.som pos=2015 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	61
+Fannkuch.som pos=2015 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	38
+Fannkuch.som pos=2015 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	23
+Fannkuch.som pos=2015 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	61
 Fannkuch.som pos=2050 len=3	+	BasicPrimitiveOperation OpArithmetic	int	37
 Fannkuch.som pos=2050 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	37
 Fannkuch.som pos=2083 len=3	+	BasicPrimitiveOperation OpArithmetic	int	37
@@ -16,10 +16,10 @@ Fannkuch.som pos=2177 len=18	at:	ArrayRead BasicPrimitiveOperation	int	49
 Fannkuch.som pos=2177 len=18	at:	ArrayRead BasicPrimitiveOperation	TOTAL	49
 Fannkuch.som pos=2192 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	49
 Fannkuch.som pos=2192 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	49
-Fannkuch.som pos=2215 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	int	49
-Fannkuch.som pos=2215 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	49
-Fannkuch.som pos=2247 len=25	at:put:	ArrayWrite BasicPrimitiveOperation	int	49
-Fannkuch.som pos=2247 len=25	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	49
+Fannkuch.som pos=2215 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	49
+Fannkuch.som pos=2215 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	49
+Fannkuch.som pos=2247 len=25	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	49
+Fannkuch.som pos=2247 len=25	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	49
 Fannkuch.som pos=2262 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	49
 Fannkuch.som pos=2262 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	49
 Fannkuch.som pos=2411 len=4	size	BasicPrimitiveOperation OpLength	arr	23
@@ -34,10 +34,10 @@ Fannkuch.som pos=2560 len=9	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgum
 Fannkuch.som pos=2560 len=9	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	59
 Fannkuch.som pos=2566 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	59
 Fannkuch.som pos=2566 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	59
-Fannkuch.som pos=2587 len=15	at:put:	ArrayWrite BasicPrimitiveOperation	int	39
-Fannkuch.som pos=2587 len=15	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	39
-Fannkuch.som pos=2626 len=41	at:put:	ArrayWrite BasicPrimitiveOperation	int	39
-Fannkuch.som pos=2626 len=41	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	39
+Fannkuch.som pos=2587 len=15	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	39
+Fannkuch.som pos=2587 len=15	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	39
+Fannkuch.som pos=2626 len=41	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	39
+Fannkuch.som pos=2626 len=41	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	39
 Fannkuch.som pos=2652 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	39
 Fannkuch.som pos=2652 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	39
 Fannkuch.som pos=2659 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	39
@@ -55,9 +55,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	107
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	262
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	369
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	107
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	262
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	369
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	239
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	239
 Kernel.som pos=8588 len=12	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	3
@@ -81,8 +81,8 @@ Kernel.som pos=16988 len=7	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgum
 Kernel.som pos=16988 len=7	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	23
 Kernel.som pos=16996 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	23
 Kernel.som pos=16996 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	23
-Kernel.som pos=17072 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	int	95
-Kernel.som pos=17072 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	95
+Kernel.som pos=17072 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	95
+Kernel.som pos=17072 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	95
 Kernel.som pos=17101 len=3	+	BasicPrimitiveOperation OpArithmetic	int	95
 Kernel.som pos=17101 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	95
 Kernel.som pos=17195 len=4	size	BasicPrimitiveOperation OpLength	arr	23

--- a/tools/tests/dym/expected-results/GraphSearch/general-stats.csv
+++ b/tools/tests/dym/expected-results/GraphSearch/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	25
 Lines Loaded	2152
 Lines Executed	243
-Lines With Statements	894
+Lines With Statements	975

--- a/tools/tests/dym/expected-results/GraphSearch/operations.csv
+++ b/tools/tests/dym/expected-results/GraphSearch/operations.csv
@@ -31,21 +31,21 @@ GraphSearch.som pos=1544 len=10	at:	ArrayRead BasicPrimitiveOperation VirtualInv
 GraphSearch.som pos=1544 len=10	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	TOTAL	8957
 GraphSearch.som pos=1722 len=5	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	ref	2999
 GraphSearch.som pos=1722 len=5	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	TOTAL	2999
-GraphSearch.som pos=1754 len=56	at:put:	ArrayWrite BasicPrimitiveOperation	ref	2999
-GraphSearch.som pos=1754 len=56	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	2999
+GraphSearch.som pos=1754 len=56	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	2999
+GraphSearch.som pos=1754 len=56	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	2999
 GraphSearch.som pos=1791 len=3	+	BasicPrimitiveOperation OpArithmetic	int	2999
 GraphSearch.som pos=1791 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	2999
 GraphSearch.som pos=1845 len=11	+	BasicPrimitiveOperation OpArithmetic	int	2999
 GraphSearch.som pos=1845 len=11	+	BasicPrimitiveOperation OpArithmetic	TOTAL	2999
-GraphSearch.som pos=2086 len=17	at:put:	ArrayWrite BasicPrimitiveOperation	int	17915
-GraphSearch.som pos=2086 len=17	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	17915
+GraphSearch.som pos=2086 len=17	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	17915
+GraphSearch.som pos=2086 len=17	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	17915
 GraphSearch.som pos=2122 len=3	+	BasicPrimitiveOperation OpArithmetic	int	17915
 GraphSearch.som pos=2122 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	17915
 GraphSearch.som pos=2706 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	bool	18000
 GraphSearch.som pos=2706 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	bool	2999
 GraphSearch.som pos=2706 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	TOTAL	20999
-GraphSearch.som pos=2747 len=18	at:put:	ArrayWrite BasicPrimitiveOperation	bool	2999
-GraphSearch.som pos=2747 len=18	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	2999
+GraphSearch.som pos=2747 len=18	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	2999
+GraphSearch.som pos=2747 len=18	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	2999
 GraphSearch.som pos=2791 len=7	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	ref	2999
 GraphSearch.som pos=2791 len=7	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	TOTAL	2999
 GraphSearch.som pos=2843 len=7	at:	ArrayRead BasicPrimitiveOperation VirtualInvokeReceiver	ref	2999
@@ -61,23 +61,23 @@ GraphSearch.som pos=2977 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	17915
 GraphSearch.som pos=3012 len=6	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	bool	5639
 GraphSearch.som pos=3012 len=6	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	bool	12276
 GraphSearch.som pos=3012 len=6	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	TOTAL	17915
-GraphSearch.som pos=3052 len=30	at:put:	ArrayWrite BasicPrimitiveOperation	int	5639
-GraphSearch.som pos=3052 len=30	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	5639
+GraphSearch.som pos=3052 len=30	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	5639
+GraphSearch.som pos=3052 len=30	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	5639
 GraphSearch.som pos=3070 len=7	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	5639
 GraphSearch.som pos=3070 len=7	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	5639
 GraphSearch.som pos=3079 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	5639
 GraphSearch.som pos=3079 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	5639
-GraphSearch.som pos=3118 len=16	at:put:	ArrayWrite BasicPrimitiveOperation	bool	5639
-GraphSearch.som pos=3118 len=16	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	5639
+GraphSearch.som pos=3118 len=16	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	5639
+GraphSearch.som pos=3118 len=16	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	5639
 GraphSearch.som pos=3261 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	bool	18000
 GraphSearch.som pos=3261 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	bool	2999
 GraphSearch.som pos=3261 len=7	at:	ArrayRead BasicPrimitiveOperation ControlFlowCondition	TOTAL	20999
-GraphSearch.som pos=3305 len=17	at:put:	ArrayWrite BasicPrimitiveOperation	bool	2998
-GraphSearch.som pos=3305 len=17	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	2998
-GraphSearch.som pos=3349 len=17	at:put:	ArrayWrite BasicPrimitiveOperation	bool	2998
-GraphSearch.som pos=3349 len=17	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	2998
-GraphSearch.som pos=3424 len=18	at:put:	ArrayWrite BasicPrimitiveOperation	bool	2998
-GraphSearch.som pos=3424 len=18	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	2998
+GraphSearch.som pos=3305 len=17	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	2998
+GraphSearch.som pos=3305 len=17	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	2998
+GraphSearch.som pos=3349 len=17	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	2998
+GraphSearch.som pos=3349 len=17	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	2998
+GraphSearch.som pos=3424 len=18	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	2998
+GraphSearch.som pos=3424 len=18	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	2998
 GraphSearch.som pos=3562 len=46	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 GraphSearch.som pos=3710 len=3	+	BasicPrimitiveOperation OpArithmetic	int	2999
 GraphSearch.som pos=3710 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	2999
@@ -157,9 +157,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	9026
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	131717
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	140743
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	9026
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	131717
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	140743
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	131717
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	131717
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -187,8 +187,8 @@ Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpCom
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	17915
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	17915
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	17915
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	17915
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	17915
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	17915
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	17915
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	int	17915
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	17915
 Kernel.som pos=24059 len=10	-	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	int	2999

--- a/tools/tests/dym/expected-results/Json/general-stats.csv
+++ b/tools/tests/dym/expected-results/Json/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	39
 Lines Loaded	2794
 Lines Executed	364
-Lines With Statements	1176
+Lines With Statements	1301

--- a/tools/tests/dym/expected-results/Json/operations.csv
+++ b/tools/tests/dym/expected-results/Json/operations.csv
@@ -57,9 +57,9 @@ Json.som pos=28269 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpCompar
 Json.som pos=28269 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	16
 Json.som pos=29712 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	597
 Json.som pos=29712 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	597
-Json.som pos=30600 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	12885
-Json.som pos=30600 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1949
-Json.som pos=30600 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	14834
+Json.som pos=30600 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	12885
+Json.som pos=30600 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	str	1949
+Json.som pos=30600 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	14834
 Json.som pos=30637 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	12885
 Json.som pos=30637 len=6	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	12885
 Json.som pos=31905 len=6	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	19
@@ -67,8 +67,8 @@ Json.som pos=31905 len=6	<>	BasicPrimitiveOperation ControlFlowCondition OpCompa
 Json.som pos=31905 len=6	<>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	711
 Json.som pos=32307 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	711
 Json.som pos=32307 len=3	not	BasicPrimitiveOperation OpArithmetic	TOTAL	711
-Json.som pos=32347 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	711
-Json.som pos=32347 len=3	not	BasicPrimitiveOperation OpArithmetic	TOTAL	711
+Json.som pos=32347 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	711
+Json.som pos=32347 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	711
 Json.som pos=32602 len=4	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	4258
 Json.som pos=32602 len=4	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	5857
 Json.som pos=32602 len=4	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	10115
@@ -135,16 +135,16 @@ Json.som pos=34802 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpCompar
 Json.som pos=34802 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	747
 Json.som pos=35094 len=5	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	597
 Json.som pos=35094 len=5	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	597
-Json.som pos=35129 len=23	at:put:	ArrayWrite BasicPrimitiveOperation	int	597
-Json.som pos=35129 len=23	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	597
+Json.som pos=35129 len=23	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	597
+Json.som pos=35129 len=23	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	597
 Json.som pos=35149 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	597
 Json.som pos=35149 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	597
 Json.som pos=35637 len=8	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	2
 Json.som pos=35637 len=8	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	2
 Json.som pos=35647 len=5	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	2
 Json.som pos=35647 len=5	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	2
-Json.som pos=35654 len=3	-	BasicPrimitiveOperation OpArithmetic	int	2
-Json.som pos=35654 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	2
+Json.som pos=35654 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	int	2
+Json.som pos=35654 len=3	-	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	2
 Json.som pos=35720 len=4	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	600
 Json.som pos=35720 len=4	&	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	600
 Json.som pos=35726 len=3	+	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	int	600
@@ -163,9 +163,9 @@ Json.som pos=44104 len=5	<>	BasicPrimitiveOperation OpComparison VirtualInvokeRe
 Json.som pos=44104 len=5	<>	BasicPrimitiveOperation OpComparison VirtualInvokeReceiver	TOTAL	2
 Json.som pos=44118 len=17	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	2
 Json.som pos=44118 len=17	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	2
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	162
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5179
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	5341
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	162
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5179
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	5341
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	5179
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	5179
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -180,10 +180,10 @@ Kernel.som pos=14597 len=4	size	BasicPrimitiveOperation OpLength	arr	158
 Kernel.som pos=14597 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	158
 Kernel.som pos=16849 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	5023
 Kernel.som pos=16849 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	5023
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	ref	2
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	ref	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	str	2
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	5
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	2
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	ref	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	2
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	5
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3986
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	3988
@@ -197,13 +197,13 @@ Kernel.som pos=22366 len=26	at:put:	ArrayWrite BasicPrimitiveOperation RootTag S
 Kernel.som pos=22366 len=26	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	149
 Kernel.som pos=22386 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	149
 Kernel.som pos=22386 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	149
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	553
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	619
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	712
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	156
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	ref	1351
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	597
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	3988
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	553
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	619
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	712
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	156
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	1351
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	597
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	3988
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	int	3988
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	3988
 Kernel.som pos=24059 len=10	-	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	int	598

--- a/tools/tests/dym/expected-results/LanguageFeatures.Dispatch/general-stats.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Dispatch/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	19
 Lines Loaded	2558
 Lines Executed	182
-Lines With Statements	1043
+Lines With Statements	1138

--- a/tools/tests/dym/expected-results/LanguageFeatures.Dispatch/operations.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Dispatch/operations.csv
@@ -5,9 +5,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	40044
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	40049
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	40044
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	40049
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	40042
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	40042
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -43,18 +43,18 @@ Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComp
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	24
 Kernel.som pos=13331 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
 Kernel.som pos=24327 len=8	<=	BasicPrimitiveOperation OpComparison	int	1

--- a/tools/tests/dym/expected-results/LanguageFeatures.Fibonacci/general-stats.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Fibonacci/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	35
 Lines Loaded	2558
 Lines Executed	183
-Lines With Statements	1043
+Lines With Statements	1139

--- a/tools/tests/dym/expected-results/LanguageFeatures.Fibonacci/operations.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Fibonacci/operations.csv
@@ -5,9 +5,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	45
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	48
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	45
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	48
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	43
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	43
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -43,18 +43,18 @@ Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComp
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	25
 Kernel.som pos=13331 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
 Kernel.som pos=24327 len=8	<=	BasicPrimitiveOperation OpComparison	int	1
@@ -66,8 +66,8 @@ LanguageFeatures.som pos=1660 len=4	<=	BasicPrimitiveOperation ControlFlowCondit
 LanguageFeatures.som pos=1660 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	43781
 LanguageFeatures.som pos=1731 len=3	-	BasicPrimitiveOperation OpArithmetic	int	21889
 LanguageFeatures.som pos=1731 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	21889
-LanguageFeatures.som pos=1736 len=25	+	BasicPrimitiveOperation OpArithmetic	int	21871
-LanguageFeatures.som pos=1736 len=25	+	BasicPrimitiveOperation OpArithmetic	TOTAL	21871
+LanguageFeatures.som pos=1736 len=25	+	BasicPrimitiveOperation OpArithmetic StatementTag	int	21871
+LanguageFeatures.som pos=1736 len=25	+	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	21871
 LanguageFeatures.som pos=1757 len=3	-	BasicPrimitiveOperation OpArithmetic	int	21889
 LanguageFeatures.som pos=1757 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	21889
 LanguageFeatures.som pos=1823 len=8	=	BasicPrimitiveOperation OpComparison RootTag StatementTag	int	1

--- a/tools/tests/dym/expected-results/LanguageFeatures.FieldLoop/general-stats.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.FieldLoop/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	15
 Lines Loaded	2558
 Lines Executed	214
-Lines With Statements	1044
+Lines With Statements	1137

--- a/tools/tests/dym/expected-results/LanguageFeatures.FieldLoop/operations.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.FieldLoop/operations.csv
@@ -5,9 +5,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	44
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	47
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	44
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	47
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	42
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	42
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -43,27 +43,27 @@ Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComp
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	25
 Kernel.som pos=13331 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
 Kernel.som pos=24327 len=8	<=	BasicPrimitiveOperation OpComparison	int	1
 Kernel.som pos=24327 len=8	<=	BasicPrimitiveOperation OpComparison	TOTAL	1
 Kernel.som pos=24347 len=9	<	BasicPrimitiveOperation OpComparison	int	1
 Kernel.som pos=24347 len=9	<	BasicPrimitiveOperation OpComparison	TOTAL	1
-LanguageFeatures.som pos=2499 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
-LanguageFeatures.som pos=2499 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	19999
-LanguageFeatures.som pos=2499 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	20000
+LanguageFeatures.som pos=2499 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
+LanguageFeatures.som pos=2499 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	19999
+LanguageFeatures.som pos=2499 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	20000
 LanguageFeatures.som pos=2539 len=3	-	BasicPrimitiveOperation OpArithmetic	int	19999
 LanguageFeatures.som pos=2539 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	19999
 LanguageFeatures.som pos=2571 len=3	+	BasicPrimitiveOperation OpArithmetic	int	19999

--- a/tools/tests/dym/expected-results/LanguageFeatures.IntegerLoop/general-stats.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.IntegerLoop/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	17
 Lines Loaded	2558
 Lines Executed	182
-Lines With Statements	1043
+Lines With Statements	1138

--- a/tools/tests/dym/expected-results/LanguageFeatures.IntegerLoop/operations.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.IntegerLoop/operations.csv
@@ -7,9 +7,9 @@ Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Kernel.som pos=6486 len=6	-	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	int	1
 Kernel.som pos=6486 len=6	-	BasicPrimitiveOperation OpArithmetic RootTag StatementTag	TOTAL	1
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	80049
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	80054
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	80049
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	80054
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	80047
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	80047
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -45,18 +45,18 @@ Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComp
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	27
 Kernel.som pos=13331 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
 Kernel.som pos=24327 len=8	<=	BasicPrimitiveOperation OpComparison	int	1

--- a/tools/tests/dym/expected-results/LanguageFeatures.Loop/general-stats.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Loop/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	22
 Lines Loaded	2558
 Lines Executed	185
-Lines With Statements	1044
+Lines With Statements	1138

--- a/tools/tests/dym/expected-results/LanguageFeatures.Loop/operations.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Loop/operations.csv
@@ -5,9 +5,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	405
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	40440
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	40845
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	405
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	40440
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	40845
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	40438
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	40438
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -43,18 +43,18 @@ Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComp
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	20
 Kernel.som pos=13331 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
 Kernel.som pos=24327 len=8	<=	BasicPrimitiveOperation OpComparison	int	1

--- a/tools/tests/dym/expected-results/LanguageFeatures.Recurse/general-stats.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Recurse/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	29
 Lines Loaded	2558
 Lines Executed	181
-Lines With Statements	1043
+Lines With Statements	1138

--- a/tools/tests/dym/expected-results/LanguageFeatures.Recurse/operations.csv
+++ b/tools/tests/dym/expected-results/LanguageFeatures.Recurse/operations.csv
@@ -5,9 +5,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	43
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	46
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	43
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	46
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	41
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	41
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -43,18 +43,18 @@ Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComp
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	23
 Kernel.som pos=13331 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
 Kernel.som pos=24327 len=8	<=	BasicPrimitiveOperation OpComparison	int	1

--- a/tools/tests/dym/expected-results/List/general-stats.csv
+++ b/tools/tests/dym/expected-results/List/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	33
 Lines Loaded	2081
 Lines Executed	170
-Lines With Statements	837
+Lines With Statements	922

--- a/tools/tests/dym/expected-results/List/operations.csv
+++ b/tools/tests/dym/expected-results/List/operations.csv
@@ -6,9 +6,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	8
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	8
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	5
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	5
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/Mandelbrot/general-stats.csv
+++ b/tools/tests/dym/expected-results/Mandelbrot/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	13
 Lines Loaded	2133
 Lines Executed	176
-Lines With Statements	848
+Lines With Statements	935

--- a/tools/tests/dym/expected-results/Mandelbrot/operations.csv
+++ b/tools/tests/dym/expected-results/Mandelbrot/operations.csv
@@ -5,9 +5,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	10
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	12
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	10
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	12
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	10
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	10
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -19,27 +19,27 @@ Kernel.som pos=12786 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	9
 Kernel.som pos=12791 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	9
 Kernel.som pos=12791 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9
 Mandelbrot.som pos=2634 len=5	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Mandelbrot.som pos=2938 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
-Mandelbrot.som pos=2938 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
-Mandelbrot.som pos=2938 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	3
+Mandelbrot.som pos=2938 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
+Mandelbrot.som pos=2938 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2
+Mandelbrot.som pos=2938 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	3
 Mandelbrot.som pos=2999 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	2
 Mandelbrot.som pos=2999 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	2
 Mandelbrot.som pos=3003 len=7	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	2
 Mandelbrot.som pos=3003 len=7	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	2
 Mandelbrot.som pos=3012 len=5	-	BasicPrimitiveOperation OpArithmetic	float	2
 Mandelbrot.som pos=3012 len=5	-	BasicPrimitiveOperation OpArithmetic	TOTAL	2
-Mandelbrot.som pos=3062 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
-Mandelbrot.som pos=3062 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8
-Mandelbrot.som pos=3062 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	11
+Mandelbrot.som pos=3062 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
+Mandelbrot.som pos=3062 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	8
+Mandelbrot.som pos=3062 len=6	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	11
 Mandelbrot.som pos=3230 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	8
 Mandelbrot.som pos=3230 len=3	*	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8
 Mandelbrot.som pos=3234 len=7	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	8
 Mandelbrot.som pos=3234 len=7	//	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8
 Mandelbrot.som pos=3243 len=5	-	BasicPrimitiveOperation OpArithmetic	float	8
 Mandelbrot.som pos=3243 len=5	-	BasicPrimitiveOperation OpArithmetic	TOTAL	8
-Mandelbrot.som pos=3376 len=4	<	BasicPrimitiveOperation OpComparison	int	4
-Mandelbrot.som pos=3376 len=4	<	BasicPrimitiveOperation OpComparison	int	217
-Mandelbrot.som pos=3376 len=4	<	BasicPrimitiveOperation OpComparison	TOTAL	221
+Mandelbrot.som pos=3376 len=4	<	BasicPrimitiveOperation OpComparison StatementTag	int	4
+Mandelbrot.som pos=3376 len=4	<	BasicPrimitiveOperation OpComparison StatementTag	int	217
+Mandelbrot.som pos=3376 len=4	<	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	221
 Mandelbrot.som pos=3425 len=6	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	float	217
 Mandelbrot.som pos=3425 len=6	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	217
 Mandelbrot.som pos=3432 len=4	+	BasicPrimitiveOperation OpArithmetic	float	217

--- a/tools/tests/dym/expected-results/NBody/general-stats.csv
+++ b/tools/tests/dym/expected-results/NBody/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	22
 Lines Loaded	2218
 Lines Executed	254
-Lines With Statements	928
+Lines With Statements	1014

--- a/tools/tests/dym/expected-results/NBody/operations.csv
+++ b/tools/tests/dym/expected-results/NBody/operations.csv
@@ -5,9 +5,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	31
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	88
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	119
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	31
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	88
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	119
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	88
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	88
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/Permute/general-stats.csv
+++ b/tools/tests/dym/expected-results/Permute/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	40
 Lines Loaded	2062
 Lines Executed	165
-Lines With Statements	829
+Lines With Statements	910

--- a/tools/tests/dym/expected-results/Permute/operations.csv
+++ b/tools/tests/dym/expected-results/Permute/operations.csv
@@ -7,14 +7,14 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	12
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	15
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	12
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	15
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	12
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	12
-Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	18100
-Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	25194
-Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	43294
+Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	18100
+Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	25194
+Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	43294
 Kernel.som pos=8314 len=6	-	BasicPrimitiveOperation OpArithmetic	int	25194
 Kernel.som pos=8314 len=6	-	BasicPrimitiveOperation OpArithmetic	TOTAL	25194
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -36,10 +36,10 @@ Permute.som pos=1682 len=3	-	BasicPrimitiveOperation OpArithmetic	int	25194
 Permute.som pos=1682 len=3	-	BasicPrimitiveOperation OpArithmetic	TOTAL	25194
 Permute.som pos=1792 len=5	at:	ArrayRead BasicPrimitiveOperation	ref	50389
 Permute.som pos=1792 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	50389
-Permute.som pos=1809 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	ref	50389
-Permute.som pos=1809 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	50389
+Permute.som pos=1809 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	50389
+Permute.som pos=1809 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	50389
 Permute.som pos=1823 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	ref	50389
 Permute.som pos=1823 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	50389
-Permute.som pos=1841 len=14	at:put:	ArrayWrite BasicPrimitiveOperation	ref	50389
-Permute.som pos=1841 len=14	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	50389
+Permute.som pos=1841 len=14	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	50389
+Permute.som pos=1841 len=14	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	50389
 Platform.som pos=1041 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/Queens/general-stats.csv
+++ b/tools/tests/dym/expected-results/Queens/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	52
 Lines Loaded	2073
 Lines Executed	170
-Lines With Statements	831
+Lines With Statements	915

--- a/tools/tests/dym/expected-results/Queens/operations.csv
+++ b/tools/tests/dym/expected-results/Queens/operations.csv
@@ -5,9 +5,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5458
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	46261
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	51719
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5458
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	46261
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	51719
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	45861
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	45861
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -24,8 +24,8 @@ Kernel.som pos=16849 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag S
 Kernel.som pos=16849 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	bool	1999
 Kernel.som pos=16849 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	2399
 Platform.som pos=1041 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Queens.som pos=1860 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	int	5649
-Queens.som pos=1860 len=12	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	5649
+Queens.som pos=1860 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	5649
+Queens.som pos=1860 len=12	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	5649
 Queens.som pos=1935 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5599
 Queens.som pos=1935 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	50
 Queens.som pos=1935 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	5649
@@ -46,17 +46,17 @@ Queens.som pos=2176 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgume
 Queens.som pos=2176 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	43799
 Queens.som pos=2180 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	43799
 Queens.som pos=2180 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	43799
-Queens.som pos=2241 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	bool	5649
-Queens.som pos=2241 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	bool	5250
-Queens.som pos=2241 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	10899
-Queens.som pos=2278 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	bool	5649
-Queens.som pos=2278 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	bool	5250
-Queens.som pos=2278 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	10899
+Queens.som pos=2241 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	5649
+Queens.som pos=2241 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	5250
+Queens.som pos=2241 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	10899
+Queens.som pos=2278 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	5649
+Queens.som pos=2278 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	5250
+Queens.som pos=2278 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	10899
 Queens.som pos=2284 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	10899
 Queens.som pos=2284 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	10899
-Queens.som pos=2315 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	bool	5649
-Queens.som pos=2315 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	bool	5250
-Queens.som pos=2315 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	10899
+Queens.som pos=2315 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	5649
+Queens.som pos=2315 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	5250
+Queens.som pos=2315 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	10899
 Queens.som pos=2321 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	10899
 Queens.som pos=2321 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	10899
 Queens.som pos=2325 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	10899

--- a/tools/tests/dym/expected-results/Richards/general-stats.csv
+++ b/tools/tests/dym/expected-results/Richards/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	27
 Lines Loaded	2452
 Lines Executed	416
-Lines With Statements	1100
+Lines With Statements	1181

--- a/tools/tests/dym/expected-results/Richards/operations.csv
+++ b/tools/tests/dym/expected-results/Richards/operations.csv
@@ -5,9 +5,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2339
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	9355
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	11694
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2339
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	9355
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	11694
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	9355
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	9355
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -65,8 +65,8 @@ Richards.som pos=3776 len=3	/	BasicPrimitiveOperation OpArithmetic PrimitiveArgu
 Richards.som pos=3776 len=3	/	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	4991
 Richards.som pos=3780 len=13	bitXor:	BasicPrimitiveOperation OpArithmetic	int	4991
 Richards.som pos=3780 len=13	bitXor:	BasicPrimitiveOperation OpArithmetic	TOTAL	4991
-Richards.som pos=4558 len=19	at:put:	ArrayWrite BasicPrimitiveOperation	ref	5
-Richards.som pos=4558 len=19	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	5
+Richards.som pos=4558 len=19	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	5
+Richards.som pos=4558 len=19	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	5
 Richards.som pos=4946 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	2326
 Richards.som pos=4946 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	2327
 Richards.som pos=4946 len=7	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4653
@@ -78,8 +78,8 @@ Richards.som pos=5359 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	9307
 Richards.som pos=5394 len=4	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8950
 Richards.som pos=5394 len=4	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	357
 Richards.som pos=5394 len=4	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9307
-Richards.som pos=5497 len=30	at:put:	ArrayWrite BasicPrimitiveOperation	int	9307
-Richards.som pos=5497 len=30	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	9307
+Richards.som pos=5497 len=30	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	9307
+Richards.som pos=5497 len=30	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	9307
 Richards.som pos=5511 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	9307
 Richards.som pos=5511 len=12	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	9307
 Richards.som pos=5524 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	9307
@@ -98,20 +98,20 @@ Richards.som pos=8595 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpCo
 Richards.som pos=8595 len=4	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9998
 Richards.som pos=8667 len=22	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	9998
 Richards.som pos=8667 len=22	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9998
-Richards.som pos=9067 len=14	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	106603
-Richards.som pos=9067 len=14	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	1
-Richards.som pos=9067 len=14	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	106604
+Richards.som pos=9067 len=14	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	106603
+Richards.som pos=9067 len=14	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	1
+Richards.som pos=9067 len=14	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	106604
 Richards.som pos=9537 len=12	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	10127
 Richards.som pos=9537 len=12	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	9986
 Richards.som pos=9537 len=12	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	20113
-Richards.som pos=9613 len=23	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	340
-Richards.som pos=9613 len=23	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	10126
-Richards.som pos=9613 len=23	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	10466
+Richards.som pos=9613 len=23	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	340
+Richards.som pos=9613 len=23	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	ref	10126
+Richards.som pos=9613 len=23	==	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	10466
 Richards.som pos=12003 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	41163
 Richards.som pos=12003 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	59879
 Richards.som pos=12003 len=3	not	BasicPrimitiveOperation OpArithmetic	TOTAL	101042
-Richards.som pos=12209 len=3	not	BasicPrimitiveOperation OpArithmetic	bool	23249
-Richards.som pos=12209 len=3	not	BasicPrimitiveOperation OpArithmetic	TOTAL	23249
+Richards.som pos=12209 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	bool	23249
+Richards.som pos=12209 len=3	not	BasicPrimitiveOperation OpArithmetic StatementTag	TOTAL	23249
 Richards.som pos=13087 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	8487
 Richards.som pos=13087 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	ref	14758
 Richards.som pos=13087 len=8	==	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	23245

--- a/tools/tests/dym/expected-results/Sieve/general-stats.csv
+++ b/tools/tests/dym/expected-results/Sieve/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	22
 Lines Loaded	2058
 Lines Executed	161
-Lines With Statements	823
+Lines With Statements	906

--- a/tools/tests/dym/expected-results/Sieve/operations.csv
+++ b/tools/tests/dym/expected-results/Sieve/operations.csv
@@ -7,9 +7,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	7
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	20005
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	20012
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	7
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	20005
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	20012
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	20005
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	20005
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -34,11 +34,11 @@ Sieve.som pos=1678 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1337
 Sieve.som pos=1678 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1337
 Sieve.som pos=1702 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1337
 Sieve.som pos=1702 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1337
-Sieve.som pos=1723 len=7	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1338
-Sieve.som pos=1723 len=7	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	22137
-Sieve.som pos=1723 len=7	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	23475
-Sieve.som pos=1782 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	bool	22137
-Sieve.som pos=1782 len=20	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	22137
+Sieve.som pos=1723 len=7	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1338
+Sieve.som pos=1723 len=7	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	22137
+Sieve.som pos=1723 len=7	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	23475
+Sieve.som pos=1782 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	bool	22137
+Sieve.som pos=1782 len=20	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	22137
 Sieve.som pos=1788 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	22137
 Sieve.som pos=1788 len=3	-	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	22137
 Sieve.som pos=1811 len=3	+	BasicPrimitiveOperation OpArithmetic	int	22137

--- a/tools/tests/dym/expected-results/Sort.BubbleSort/general-stats.csv
+++ b/tools/tests/dym/expected-results/Sort.BubbleSort/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	25
 Lines Loaded	2158
 Lines Executed	213
-Lines With Statements	884
+Lines With Statements	963

--- a/tools/tests/dym/expected-results/Sort.BubbleSort/operations.csv
+++ b/tools/tests/dym/expected-results/Sort.BubbleSort/operations.csv
@@ -11,14 +11,14 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	269
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	17568
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	17837
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	269
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	17568
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	17837
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	17566
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	17566
-Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
-Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	259
-Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	261
+Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2
+Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	259
+Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	261
 Kernel.som pos=8314 len=6	-	BasicPrimitiveOperation OpArithmetic	int	259
 Kernel.som pos=8314 len=6	-	BasicPrimitiveOperation OpArithmetic	TOTAL	259
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -54,8 +54,8 @@ Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComp
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	14
 Kernel.som pos=13331 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
 Kernel.som pos=14539 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	259
@@ -64,14 +64,14 @@ Kernel.som pos=14597 len=4	size	BasicPrimitiveOperation OpLength	arr	3
 Kernel.som pos=14597 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	3
 Kernel.som pos=16849 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	259
 Kernel.som pos=16849 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	259
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
 Kernel.som pos=24327 len=8	<=	BasicPrimitiveOperation OpComparison	int	1
@@ -120,9 +120,9 @@ Sort.som pos=2745 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument
 Sort.som pos=2769 len=6	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8609
 Sort.som pos=2769 len=6	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8160
 Sort.som pos=2769 len=6	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	16769
-Sort.som pos=2819 len=15	at:put:	ArrayWrite BasicPrimitiveOperation	int	8159
-Sort.som pos=2819 len=15	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	8159
-Sort.som pos=2856 len=22	at:put:	ArrayWrite BasicPrimitiveOperation	int	8159
-Sort.som pos=2856 len=22	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	8159
+Sort.som pos=2819 len=15	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	8159
+Sort.som pos=2819 len=15	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	8159
+Sort.som pos=2856 len=22	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	8159
+Sort.som pos=2856 len=22	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	8159
 Sort.som pos=2862 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	8159
 Sort.som pos=2862 len=3	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	8159

--- a/tools/tests/dym/expected-results/Sort.QuickSort/general-stats.csv
+++ b/tools/tests/dym/expected-results/Sort.QuickSort/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	40
 Lines Loaded	2158
 Lines Executed	218
-Lines With Statements	885
+Lines With Statements	963

--- a/tools/tests/dym/expected-results/Sort.QuickSort/operations.csv
+++ b/tools/tests/dym/expected-results/Sort.QuickSort/operations.csv
@@ -11,9 +11,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	9
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4817
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4826
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	9
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4817
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	4826
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	4815
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	4815
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -49,8 +49,8 @@ Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComp
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	13
 Kernel.som pos=13331 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
 Kernel.som pos=14539 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	1599
@@ -59,14 +59,14 @@ Kernel.som pos=14597 len=4	size	BasicPrimitiveOperation OpLength	arr	3
 Kernel.som pos=14597 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	3
 Kernel.som pos=16849 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	1599
 Kernel.som pos=16849 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	1599
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
 Kernel.som pos=24327 len=8	<=	BasicPrimitiveOperation OpComparison	int	1
@@ -108,19 +108,19 @@ Sort.som pos=3276 len=6	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument
 Sort.som pos=3276 len=6	+	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1397
 Sort.som pos=3284 len=3	/	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	int	1397
 Sort.som pos=3284 len=3	/	BasicPrimitiveOperation OpArithmetic PrimitiveArgument	TOTAL	1397
-Sort.som pos=3332 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1398
-Sort.som pos=3332 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4415
-Sort.som pos=3332 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	5813
+Sort.som pos=3332 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1398
+Sort.som pos=3332 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4415
+Sort.som pos=3332 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	5813
 Sort.som pos=3379 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	12147
 Sort.som pos=3379 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	12147
-Sort.som pos=3386 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4416
-Sort.som pos=3386 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	7731
-Sort.som pos=3386 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	12147
+Sort.som pos=3386 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4416
+Sort.som pos=3386 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	7731
+Sort.som pos=3386 len=7	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	12147
 Sort.som pos=3416 len=3	+	BasicPrimitiveOperation OpArithmetic	int	7731
 Sort.som pos=3416 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	7731
-Sort.som pos=3441 len=15	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	4415
-Sort.som pos=3441 len=15	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	5428
-Sort.som pos=3441 len=15	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	9843
+Sort.som pos=3441 len=15	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	4415
+Sort.som pos=3441 len=15	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	5428
+Sort.som pos=3441 len=15	<	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	9843
 Sort.som pos=3450 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	9843
 Sort.som pos=3450 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	9843
 Sort.som pos=3479 len=3	-	BasicPrimitiveOperation OpArithmetic	int	5427
@@ -130,12 +130,12 @@ Sort.som pos=3500 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpCompar
 Sort.som pos=3500 len=4	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	4415
 Sort.som pos=3578 len=5	at:	ArrayRead BasicPrimitiveOperation	int	3985
 Sort.som pos=3578 len=5	at:	ArrayRead BasicPrimitiveOperation	TOTAL	3985
-Sort.som pos=3605 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	int	3985
-Sort.som pos=3605 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	3985
+Sort.som pos=3605 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	3985
+Sort.som pos=3605 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	3985
 Sort.som pos=3623 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	3985
 Sort.som pos=3623 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	TOTAL	3985
-Sort.som pos=3651 len=14	at:put:	ArrayWrite BasicPrimitiveOperation	int	3985
-Sort.som pos=3651 len=14	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	3985
+Sort.som pos=3651 len=14	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	int	3985
+Sort.som pos=3651 len=14	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	3985
 Sort.som pos=3688 len=3	+	BasicPrimitiveOperation OpArithmetic	int	3985
 Sort.som pos=3688 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	3985
 Sort.som pos=3714 len=3	-	BasicPrimitiveOperation OpArithmetic	int	3985

--- a/tools/tests/dym/expected-results/Sort.TreeSort/general-stats.csv
+++ b/tools/tests/dym/expected-results/Sort.TreeSort/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	45
 Lines Loaded	2158
 Lines Executed	213
-Lines With Statements	882
+Lines With Statements	963

--- a/tools/tests/dym/expected-results/Sort.TreeSort/operations.csv
+++ b/tools/tests/dym/expected-results/Sort.TreeSort/operations.csv
@@ -11,9 +11,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	9
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	6020
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	6029
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	9
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	6020
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	6029
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	6018
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	6018
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -49,8 +49,8 @@ Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComp
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	str	1
 Kernel.som pos=13189 len=9	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	12
 Kernel.som pos=13331 len=14	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
-Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	1
+Kernel.som pos=13450 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=13544 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
 Kernel.som pos=14539 len=5	at:	ArrayRead BasicPrimitiveOperation PrimitiveArgument	int	1999
@@ -59,14 +59,14 @@ Kernel.som pos=14597 len=4	size	BasicPrimitiveOperation OpLength	arr	5
 Kernel.som pos=14597 len=4	size	BasicPrimitiveOperation OpLength	TOTAL	5
 Kernel.som pos=16849 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	int	1999
 Kernel.som pos=16849 len=22	at:put:	ArrayWrite BasicPrimitiveOperation RootTag StatementTag	TOTAL	1999
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	str	1
-Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=21172 len=9	at:	ArrayRead BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	1
 Kernel.som pos=22177 len=14	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	arr	1
 Kernel.som pos=22187 len=4	size	BasicPrimitiveOperation OpLength PrimitiveArgument	TOTAL	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	str	1
-Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	str	1
+Kernel.som pos=22451 len=24	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	int	1
 Kernel.som pos=22502 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	1
 Kernel.som pos=24327 len=8	<=	BasicPrimitiveOperation OpComparison	int	1

--- a/tools/tests/dym/expected-results/Storage/general-stats.csv
+++ b/tools/tests/dym/expected-results/Storage/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	71
 Lines Loaded	2052
 Lines Executed	162
-Lines With Statements	820
+Lines With Statements	902

--- a/tools/tests/dym/expected-results/Storage/operations.csv
+++ b/tools/tests/dym/expected-results/Storage/operations.csv
@@ -13,9 +13,9 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2733
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	10929
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	13662
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2733
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	10929
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	13662
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	10929
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	10929
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0

--- a/tools/tests/dym/expected-results/Towers/general-stats.csv
+++ b/tools/tests/dym/expected-results/Towers/general-stats.csv
@@ -2,4 +2,4 @@ Statistic	Value
 Max Stack Height	30
 Lines Loaded	2096
 Lines Executed	179
-Lines With Statements	845
+Lines With Statements	926

--- a/tools/tests/dym/expected-results/Towers/operations.csv
+++ b/tools/tests/dym/expected-results/Towers/operations.csv
@@ -7,14 +7,14 @@ Harness.som pos=6326 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComp
 Harness.som pos=6405 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6481 len=3	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
 Harness.som pos=6615 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	3
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8
-Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	11
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	3
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	8
+Kernel.som pos=8022 len=8	<=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	11
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	int	8
 Kernel.som pos=8069 len=6	+	BasicPrimitiveOperation OpArithmetic	TOTAL	8
-Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	2
-Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	27
-Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	29
+Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	2
+Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	int	27
+Kernel.som pos=8267 len=8	>=	BasicPrimitiveOperation ControlFlowCondition OpComparison StatementTag	TOTAL	29
 Kernel.som pos=8314 len=6	-	BasicPrimitiveOperation OpArithmetic	int	27
 Kernel.som pos=8314 len=6	-	BasicPrimitiveOperation OpArithmetic	TOTAL	27
 Kernel.som pos=12597 len=13	>	BasicPrimitiveOperation ControlFlowCondition OpComparison	TOTAL	0
@@ -29,15 +29,15 @@ Platform.som pos=1041 len=3	<	BasicPrimitiveOperation ControlFlowCondition OpCom
 Towers.som pos=1387 len=8	at:	ArrayRead BasicPrimitiveOperation	ref	255
 Towers.som pos=1387 len=8	at:	ArrayRead BasicPrimitiveOperation	ref	16154
 Towers.som pos=1387 len=8	at:	ArrayRead BasicPrimitiveOperation	TOTAL	16409
-Towers.som pos=1429 len=11	>=	BasicPrimitiveOperation OpComparison	int	16153
-Towers.som pos=1429 len=11	>=	BasicPrimitiveOperation OpComparison	TOTAL	16153
-Towers.som pos=1558 len=18	at:put:	ArrayWrite BasicPrimitiveOperation	ref	16409
-Towers.som pos=1558 len=18	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	16409
+Towers.som pos=1429 len=11	>=	BasicPrimitiveOperation OpComparison StatementTag	int	16153
+Towers.som pos=1429 len=11	>=	BasicPrimitiveOperation OpComparison StatementTag	TOTAL	16153
+Towers.som pos=1558 len=18	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	16409
+Towers.som pos=1558 len=18	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	16409
 Towers.som pos=1663 len=8	at:	ArrayRead BasicPrimitiveOperation	ref	16381
 Towers.som pos=1663 len=8	at:	ArrayRead BasicPrimitiveOperation	TOTAL	16381
-Towers.som pos=1800 len=22	at:put:	ArrayWrite BasicPrimitiveOperation	ref	252
-Towers.som pos=1800 len=22	at:put:	ArrayWrite BasicPrimitiveOperation	ref	16129
-Towers.som pos=1800 len=22	at:put:	ArrayWrite BasicPrimitiveOperation	TOTAL	16381
+Towers.som pos=1800 len=22	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	252
+Towers.som pos=1800 len=22	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	ref	16129
+Towers.som pos=1800 len=22	at:put:	ArrayWrite BasicPrimitiveOperation StatementTag	TOTAL	16381
 Towers.som pos=2016 len=3	+	BasicPrimitiveOperation OpArithmetic	int	16381
 Towers.som pos=2016 len=3	+	BasicPrimitiveOperation OpArithmetic	TOTAL	16381
 Towers.som pos=2253 len=3	=	BasicPrimitiveOperation ControlFlowCondition OpComparison	int	8189


### PR DESCRIPTION
Before this change, all expressions were tagged as statements, while they should not be tagged as such. The tagging causes problems with stepping strategies.

Statements are meant to be only the directly contained elements of method bodies or blocks, etc. So, essentially all sequences of expressions from the Newspeak grammar. Especially nested expressions are not tagged as statements anymore.

This required a few small extensions in Truffle to be able to have breakpoints on things that are not statements.

The main goal is to make stepping in the debugger more 'usual'. Especially necessary for the VS code debugger.