### PR TITLE
Optimize outer sends to self-sends where possible

### DIFF
--- a/src/som/compiler/MethodBuilder.java
+++ b/src/som/compiler/MethodBuilder.java
@@ -49,7 +49,6 @@ import som.interpreter.Method;
 import som.interpreter.SNodeFactory;
 import som.interpreter.SplitterForLexicallyEmbeddedCode;
 import som.interpreter.nodes.ExpressionNode;
-import som.interpreter.nodes.OuterObjectRead;
 import som.interpreter.nodes.OuterObjectReadNodeGen;
 import som.interpreter.nodes.ReturnNonLocalNode;
 import som.vm.constants.Nil;
@@ -455,7 +454,7 @@ public final class MethodBuilder {
     }
   }
 
-  public OuterObjectRead getOuterRead(final String outerName,
+  public ExpressionNode getOuterRead(final String outerName,
       final SourceSection source) throws MixinDefinitionError {
     MixinBuilder enclosing = getEnclosingMixinBuilder();
     MixinDefinitionId lexicalSelfMixinId = enclosing.getMixinId();
@@ -469,8 +468,12 @@ public final class MethodBuilder {
       }
     }
 
-    return OuterObjectReadNodeGen.create(ctxLevel, lexicalSelfMixinId,
-        enclosing.getMixinId(), source, getSelfRead(source));
+    if (ctxLevel == 0) {
+      return getSelfRead(source);
+    } else {
+      return OuterObjectReadNodeGen.create(ctxLevel, lexicalSelfMixinId,
+          enclosing.getMixinId(), source, getSelfRead(source));
+    }
   }
 
   /**

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -85,7 +85,6 @@ import som.interpreter.SNodeFactory;
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.MessageSendNode;
 import som.interpreter.nodes.MessageSendNode.AbstractUninitializedMessageSendNode;
-import som.interpreter.nodes.OuterObjectRead;
 import som.interpreter.nodes.literals.BlockNode;
 import som.interpreter.nodes.literals.BlockNode.BlockNodeWithContext;
 import som.interpreter.nodes.literals.BooleanLiteralNode.FalseLiteralNode;
@@ -444,7 +443,7 @@ public class Parser {
 
     if (acceptIdentifier("outer", KeywordTag.class)) {
       String outer = identifier();
-      OuterObjectRead self = meth.getOuterRead(outer, getSource(coord));
+      ExpressionNode self = meth.getOuterRead(outer, getSource(coord));
       if (sym == Identifier) {
         return unaryMessage(self, false, null);
       } else {

--- a/src/som/interpreter/nodes/OuterObjectRead.java
+++ b/src/som/interpreter/nodes/OuterObjectRead.java
@@ -86,6 +86,7 @@ public abstract class OuterObjectRead
 
   @Specialization(guards = "contextLevel == 0")
   public final Object doForOuterIsDirectClass(final SObjectWithClass receiver) {
+    assert false;
     return enclosingObj.profile(receiver);
   }
 
@@ -159,6 +160,7 @@ public abstract class OuterObjectRead
    */
   @Specialization(guards = {"contextLevel == 0"})
   public SFarReference doFarReferenceDirect(final SFarReference receiver) {
+    assert false;
     return receiver;
   }
 
@@ -187,26 +189,26 @@ public abstract class OuterObjectRead
   public Object doSBlock(final SBlock receiver) { return KernelObj.kernel; }
 
   @Specialization(guards = "contextLevel == 0")
-  public boolean doBoolDirect(final boolean receiver) { return receiver; }
+  public boolean doBoolDirect(final boolean receiver) { assert false; return receiver; }
 
   @Specialization(guards = "contextLevel == 0")
-  public long doLongDirect(final long receiver) { return receiver; }
+  public long doLongDirect(final long receiver) { assert false; return receiver; }
 
   @Specialization(guards = "contextLevel == 0")
-  public String doStringDirect(final String receiver) { return receiver; }
+  public String doStringDirect(final String receiver) { assert false; return receiver; }
 
   @Specialization(guards = "contextLevel == 0")
-  public BigInteger doBigIntegerDirect(final BigInteger receiver) { return receiver; }
+  public BigInteger doBigIntegerDirect(final BigInteger receiver) { assert false; return receiver; }
 
   @Specialization(guards = "contextLevel == 0")
-  public Double doDoubleDirect(final double receiver) { return receiver; }
+  public Double doDoubleDirect(final double receiver) { assert false; return receiver; }
 
   @Specialization(guards = "contextLevel == 0")
-  public SSymbol doSSymbolDirect(final SSymbol receiver) { return receiver; }
+  public SSymbol doSSymbolDirect(final SSymbol receiver) { assert false; return receiver; }
 
   @Specialization(guards = "contextLevel == 0")
-  public SArray doSArrayDirect(final SArray receiver) { return receiver; }
+  public SArray doSArrayDirect(final SArray receiver) { assert false; return receiver; }
 
   @Specialization(guards = "contextLevel == 0")
-  public SBlock doSBlockDirect(final SBlock receiver) { return receiver; }
+  public SBlock doSBlockDirect(final SBlock receiver) { assert false; return receiver; }
 }


### PR DESCRIPTION
Outer sends with a context level of 0, i.e., if the outer context corresponds to the holder of a method, are self sends.
Instead of using the complex `OuterObjectRead`, optimize these sends to simple self sends, i.e., use a normal `[Non]LocalSelfReadNode`.

This also allows us to simplify the `OuterObjectRead` node because it does not need to deal with `contextLevel == 0` anymore.