### PR TITLE
Catch exceptions for implicit promises

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ newspeak
 tools/kompos/node_modules
 tools/kompos/out
 traces
+/npm-debug.log

--- a/src/som/interpreter/actors/ReceivedMessage.java
+++ b/src/som/interpreter/actors/ReceivedMessage.java
@@ -9,6 +9,7 @@ import com.oracle.truffle.api.nodes.DirectCallNode;
 
 import som.VmSettings;
 import som.interpreter.SArguments;
+import som.interpreter.SomException;
 import som.interpreter.SomLanguage;
 import som.interpreter.nodes.MessageSendNode.AbstractMessageSendNode;
 import som.vmobjects.SSymbol;
@@ -35,9 +36,12 @@ public class ReceivedMessage extends ReceivedRootNode {
       dbg.prepareSteppingAfterNextRootNode();
     }
 
-    Object result = onReceive.doPreEvaluated(frame, msg.args);
-
-    resolvePromise(frame, msg.resolver, result, msg.triggerPromiseResolutionBreakpoint);
+    try {
+      Object result = onReceive.doPreEvaluated(frame, msg.args);
+      resolvePromise(frame, msg.resolver, result, msg.triggerPromiseResolutionBreakpoint);
+    } catch (SomException exception) {
+      msg.getResolver().onError(exception);
+    }
     return null;
   }
 
@@ -85,9 +89,12 @@ public class ReceivedMessage extends ReceivedRootNode {
         dbg.prepareSteppingAfterNextRootNode();
       }
 
-      Object result = onReceive.call(frame, msg.args);
-
-      resolvePromise(frame, msg.resolver, result, msg.triggerPromiseResolutionBreakpoint);
+      try {
+        Object result = onReceive.call(frame, msg.args);
+        resolvePromise(frame, msg.resolver, result, msg.triggerPromiseResolutionBreakpoint);
+      } catch (SomException exception) {
+        msg.getResolver().onError(exception);
+      }
       return null;
     }
   }

--- a/src/som/interpreter/actors/SPromise.java
+++ b/src/som/interpreter/actors/SPromise.java
@@ -10,10 +10,10 @@ import com.oracle.truffle.api.RootCallTarget;
 import com.sun.istack.internal.NotNull;
 
 import som.VmSettings;
+import som.interpreter.SomException;
 import som.interpreter.actors.Actor.ActorProcessingThread;
 import som.interpreter.actors.EventualMessage.PromiseCallbackMessage;
 import som.interpreter.actors.EventualMessage.PromiseMessage;
-import som.vm.NotYetImplementedException;
 import som.vmobjects.SAbstractObject;
 import som.vmobjects.SBlock;
 import som.vmobjects.SClass;
@@ -141,9 +141,6 @@ public class SPromise extends SObjectWithClass {
 
   public synchronized void registerOnError(final PromiseMessage msg,
       final Actor current) {
-    if (resolutionState == Resolution.ERRORNOUS) {
-      scheduleCallbacksOnResolution(value, msg, current, false);
-    } else {
       if (resolutionState == Resolution.SUCCESSFUL) {
         // short cut on resolved, this promise will never error, so,
         // just return promise, don't use isSomehowResolved(), because the other
@@ -154,6 +151,14 @@ public class SPromise extends SObjectWithClass {
         onError = new ArrayList<>(1);
       }
       onError.add(msg);
+  }
+
+  public void scheduleOnErrorCallbacks(final Actor current, final SomException exception) {
+    if (onError != null) {
+      for (int i = 0; i < onError.size(); i++) {
+        PromiseMessage callbackOrMsg =  onError.get(i);
+        scheduleCallbacksOnResolution(exception.getSomObject(), callbackOrMsg, current, false);
+      }
     }
   }
 
@@ -336,8 +341,9 @@ public class SPromise extends SObjectWithClass {
       resolverClass = cls;
     }
 
-    public final void onError() {
-      throw new NotYetImplementedException(); // TODO: implement
+    public final void onError(final SomException exception) {
+      promise.resolutionState = Resolution.ERRORNOUS;
+      promise.scheduleOnErrorCallbacks(EventualMessage.getActorCurrentMessageIsExecutionOn(), exception);
     }
 
     public final boolean assertNotCompleted() {


### PR DESCRIPTION
- change resolution of the promise to ERRORNOUS when occurs an exception
- set the value of the SomException as the returned value of the promise message.
- TODO: implement resolver error for explicit promises

In the program TestExceptionPromises of small-experiments it is captured an exception thrown by an implicit promise.
In this branch is needed still to consider the cases when an exception is thrown for promises that are declared explicitly. 

There are two more TODO but related to the branch explicit-promise-breakpoints (check pull request https://github.com/smarr/SOMns/pull/69)
1.  Solve issue of double wrapping of the primitive whenResolved, it causes assertion error in method isTaggedWith of EagerBinaryPrimitiveNode class.
2. There is an issue related to the the tests of breakpoints. This happen after the  changes of the promise breakpoint flags. All tests in basic-protocol.ts passed except for SOMns stack trace test.