### PR TITLE
Added  actor tracing configuration flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 
+
 ## [Unreleased]
 
  - Added basic support for shared-memory multithreading and fork/join
@@ -9,6 +10,9 @@
  - Turn writes to method arguments into errors. Before it was leading to 
    confusing setter sends and 'message not understood' errors.
  - Added Lee and Vacation benchmarks ([PR #78](https://github.com/smarr/SOMns/pull/78))
+
+ - Configuration flag for actor tracing, -atcfg=<config>
+   example: -atcfg=mt:mp:pc turns off message timestamps, message parameters and promises
 
 ## 0.1.0 - 2016-12-15
 

--- a/som
+++ b/som
@@ -69,6 +69,8 @@ tools.add_argument('-dm', '--dynamic-metrics', help='Capture Dynamic Metrics',
                     dest='dynamic_metrics', action='store_true', default=False)
 tools.add_argument('-at', '--actor-tracing', help='enable tracing of actor operations',
                     dest='actor_tracing', action='store_true', default=False)
+tools.add_argument('-atcfg', '--actor-tracing-cfg', help='Configuration string for actor tracing',
+                    dest='actor_tracing_cfg', default='')
 tools.add_argument('-mt', '--memory-tracing', help='enable tracing of memory usage and GC',
                     dest='memory_tracing', action='store_true', default=False)
 tools.add_argument('-tf', '--trace-file', help='Trace file destination, default: traces/trace',
@@ -239,6 +241,8 @@ if args.dynamic_metrics:
 
 if args.actor_tracing:
     flags += ['-Dsom.actorTracing=true']
+if args.actor_tracing_cfg:
+    flags += ['-Dsom.actorTracingCfg=%s' % args.actor_tracing_cfg ]
 if args.trace_file:
     flags += ['-Dsom.traceFile=%s' % args.trace_file ]
 if args.memory_tracing:

--- a/src/som/VmSettings.java
+++ b/src/som/VmSettings.java
@@ -1,5 +1,7 @@
 package som;
 
+import java.util.Arrays;
+import java.util.List;
 
 public class VmSettings {
   public static final int NUM_THREADS;
@@ -13,6 +15,11 @@ public class VmSettings {
   public static final boolean INSTRUMENTATION;
   public static final boolean DYNAMIC_METRICS;
   public static final boolean DNU_PRINT_STACK_TRACE;
+  public static final boolean MESSAGE_TIMESTAMPS;
+  public static final boolean MESSAGE_PARAMETERS;
+  public static final boolean PROMISE_CREATION;
+  public static final boolean PROMISE_RESOLUTION;
+  public static final boolean PROMISE_RESOLVED_WITH;
 
   public static final boolean TRUFFLE_DEBUGGER_ENABLED;
 
@@ -28,10 +35,20 @@ public class VmSettings {
 
     FAIL_ON_MISSING_OPTIMIZATIONS = getBool("som.failOnMissingOptimization", false);
     DEBUG_MODE      = getBool("som.debugMode",      false);
-    ACTOR_TRACING   = getBool("som.actorTracing",   false);
     TRACE_FILE      = System.getProperty("som.traceFile", System.getProperty("user.dir") + "/traces/trace");
     MEMORY_TRACING = getBool("som.memoryTracing",   false);
     DISABLE_TRACE_FILE = getBool("som.disableTraceFile", false);
+
+    String atConfig = System.getProperty("som.actorTracingCfg", "");
+    List<String> al = Arrays.asList(atConfig.split(":"));
+    boolean filter = al.size() > 0 && !atConfig.isEmpty();
+
+    MESSAGE_TIMESTAMPS    =  !al.contains("mt") && filter;
+    MESSAGE_PARAMETERS    = !al.contains("mp") && filter;
+    PROMISE_CREATION      = !al.contains("pc") && filter;
+    PROMISE_RESOLUTION    = PROMISE_CREATION && (!al.contains("pr")) && filter;
+    PROMISE_RESOLVED_WITH = !al.contains("prw") && filter;
+    ACTOR_TRACING   = getBool("som.actorTracing",   false) || MESSAGE_TIMESTAMPS || MESSAGE_PARAMETERS || PROMISE_CREATION;
 
     boolean dm = getBool("som.dynamicMetrics", false);
     DYNAMIC_METRICS = dm;

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -147,7 +147,7 @@ public class Actor {
   @TruffleBoundary
   public synchronized void send(final EventualMessage msg) {
     assert msg.getTarget() == this;
-    if (VmSettings.ACTOR_TRACING) {
+    if (VmSettings.MESSAGE_TIMESTAMPS) {
       mailbox.addMessageSendTime();
     }
     mailbox.append(msg);
@@ -215,7 +215,7 @@ public class Actor {
             dbg.prepareSteppingUntilNextRootNode();
           }
         }
-        if (VmSettings.ACTOR_TRACING) {
+        if (VmSettings.MESSAGE_TIMESTAMPS) {
           current.addMessageExecutionStart();
         }
         msg.execute();

--- a/src/som/interpreter/actors/SPromise.java
+++ b/src/som/interpreter/actors/SPromise.java
@@ -1,7 +1,6 @@
 package som.interpreter.actors;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
@@ -33,7 +32,7 @@ public class SPromise extends SObjectWithClass {
   public static SPromise createPromise(final Actor owner) {
     if (VmSettings.DEBUG_MODE) {
       return new SDebugPromise(owner);
-    } else if (VmSettings.ACTOR_TRACING) {
+    } else if (VmSettings.PROMISE_CREATION) {
       return new STracingPromise(owner);
     } else {
       return new SPromise(owner);
@@ -88,7 +87,6 @@ public class SPromise extends SObjectWithClass {
   }
 
   public long getPromiseId() { return 0; }
-  public List<Long> getPromiseMessages() { return null; }
 
   public final Actor getOwner() {
     return owner;
@@ -206,7 +204,7 @@ public class SPromise extends SObjectWithClass {
   public final synchronized void addChainedPromise(@NotNull final SPromise remote) {
     assert remote != null;
     remote.resolutionState = Resolution.CHAINED;
-    if (VmSettings.ACTOR_TRACING) {
+    if (VmSettings.PROMISE_RESOLUTION) {
       ActorExecutionTrace.promiseChained(this.getPromiseId(), remote.getPromiseId());
     }
 
@@ -273,7 +271,6 @@ public class SPromise extends SObjectWithClass {
 
   protected static final class STracingPromise extends SPromise {
     protected final long promiseId;
-    protected final List<Long> promiseMessages = new ArrayList<>();
 
     protected STracingPromise(final Actor owner) {
       super(owner);
@@ -285,11 +282,6 @@ public class SPromise extends SObjectWithClass {
     @Override
     public long getPromiseId() {
       return promiseId;
-    }
-
-    @Override
-    public List<Long> getPromiseMessages() {
-      return promiseMessages;
     }
   }
 
@@ -387,7 +379,7 @@ public class SPromise extends SObjectWithClass {
         final Object wrapped, final SPromise p, final Actor current, final boolean isBreakpointOnPromiseResolution) {
       assert !(result instanceof SPromise);
 
-      if (VmSettings.ACTOR_TRACING) {
+      if (VmSettings.PROMISE_RESOLUTION) {
         if (p.resolutionState != Resolution.CHAINED) {
           ActorExecutionTrace.promiseResolution(p.getPromiseId(), result);
         }


### PR DESCRIPTION
use -atcfg=<config> to turn off tracing for some things, for example -atcfg=mt:mp:pc to disable message timestamps, message parameters and promises.