### PR TITLE
Make instrumentation of primitives more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
  - Simplified AST inlining and use objects to represent variable info to improve
    details displayed in debugger ([PR #80](https://github.com/smarr/SOMns/pull/80)).
 
+ - Make instrumentation more robust by defining number of arguments of an
+   operation explicitly.
+
 ## 0.1.0 - 2016-12-15
 
 This is the first tagged version. For previous changes, please refer to the

--- a/src/som/VM.java
+++ b/src/som/VM.java
@@ -115,11 +115,7 @@ public final class VM {
     // TODO: can I assert that it is locked?? helper on Node??
     if (VmSettings.INSTRUMENTATION) {
       assert node.getSourceSection() != null || (node instanceof WrapperNode) : "Node needs source section, or needs to be wrapper";
-      // TODO: a way to check whether the node needs actually wrapping?
-//      String[] tags = node.getSourceSection().getTags();
-//      if (tags != null && tags.length > 0) {
-        InstrumentationHandler.insertInstrumentationWrapper(node);
-//      }
+      InstrumentationHandler.insertInstrumentationWrapper(node);
     }
   }
 

--- a/src/som/interpreter/nodes/OperationNode.java
+++ b/src/som/interpreter/nodes/OperationNode.java
@@ -3,4 +3,5 @@ package som.interpreter.nodes;
 
 public interface OperationNode {
   String getOperation();
+  int getNumArguments();
 }

--- a/src/som/interpreter/nodes/nary/EagerBinaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerBinaryPrimitiveNode.java
@@ -83,6 +83,11 @@ public final class EagerBinaryPrimitiveNode extends EagerPrimitive {
   }
 
   @Override
+  public int getNumArguments() {
+    return 2;
+  }
+
+  @Override
   public Object executeGeneric(final VirtualFrame frame) {
     Object rcvr = receiver.executeGeneric(frame);
     Object arg  = argument.executeGeneric(frame);

--- a/src/som/interpreter/nodes/nary/EagerTernaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerTernaryPrimitiveNode.java
@@ -88,6 +88,11 @@ public final class EagerTernaryPrimitiveNode extends EagerPrimitive {
   }
 
   @Override
+  public int getNumArguments() {
+    return 3;
+  }
+
+  @Override
   public Object executeGeneric(final VirtualFrame frame) {
     Object rcvr = receiver.executeGeneric(frame);
     Object arg1 = argument1.executeGeneric(frame);

--- a/src/som/interpreter/nodes/nary/EagerUnaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerUnaryPrimitiveNode.java
@@ -78,6 +78,11 @@ public final class EagerUnaryPrimitiveNode extends EagerPrimitive {
   }
 
   @Override
+  public int getNumArguments() {
+    return 1;
+  }
+
+  @Override
   public Object executeGeneric(final VirtualFrame frame) {
     Object rcvr = receiver.executeGeneric(frame);
     return executeEvaluated(frame, rcvr);

--- a/src/som/interpreter/nodes/specialized/AndMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/AndMessageNode.java
@@ -9,6 +9,7 @@ import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.OperationNode;
 import som.interpreter.nodes.literals.BlockNode;
 import som.interpreter.nodes.nary.BinaryBasicOperation;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
@@ -104,7 +105,7 @@ public abstract class AndMessageNode extends BinaryComplexOperation {
   }
 
   @GenerateNodeFactory
-  public abstract static class AndBoolMessageNode extends BinaryBasicOperation {
+  public abstract static class AndBoolMessageNode extends BinaryBasicOperation implements OperationNode {
     public AndBoolMessageNode(final SourceSection source) { super(false, source); }
 
     @Override
@@ -119,6 +120,16 @@ public abstract class AndMessageNode extends BinaryComplexOperation {
     @Specialization
     public final boolean doAnd(final VirtualFrame frame, final boolean receiver, final boolean argument) {
       return receiver && argument;
+    }
+
+    @Override
+    public String getOperation() {
+      return "&&";
+    }
+
+    @Override
+    public int getNumArguments() {
+      return 2;
     }
   }
 }

--- a/src/som/interpreter/nodes/specialized/OrMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/OrMessageNode.java
@@ -8,6 +8,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.source.SourceSection;
 
+import som.interpreter.nodes.OperationNode;
 import som.interpreter.nodes.nary.BinaryBasicOperation;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
 import som.interpreter.nodes.nary.BinaryExpressionNode;
@@ -74,7 +75,7 @@ public abstract class OrMessageNode extends BinaryComplexOperation {
   }
 
   @GenerateNodeFactory
-  public abstract static class OrBoolMessageNode extends BinaryBasicOperation {
+  public abstract static class OrBoolMessageNode extends BinaryBasicOperation implements OperationNode {
     public OrBoolMessageNode(final SourceSection source) { super(false, source); }
 
     @Override
@@ -90,6 +91,16 @@ public abstract class OrMessageNode extends BinaryComplexOperation {
     public final boolean doOr(final VirtualFrame frame, final boolean receiver,
         final boolean argument) {
       return receiver || argument;
+    }
+
+    @Override
+    public String getOperation() {
+      return "||";
+    }
+
+    @Override
+    public int getNumArguments() {
+      return 2;
     }
   }
 }

--- a/src/som/primitives/ObjectPrims.java
+++ b/src/som/primitives/ObjectPrims.java
@@ -15,6 +15,7 @@ import som.interpreter.Types;
 import som.interpreter.actors.SFarReference;
 import som.interpreter.actors.SPromise;
 import som.interpreter.actors.SPromise.SResolver;
+import som.interpreter.nodes.OperationNode;
 import som.interpreter.nodes.nary.UnaryBasicOperation;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
 import som.primitives.ObjectPrimsFactory.IsValueFactory;
@@ -84,7 +85,7 @@ public final class ObjectPrims {
 
   @GenerateNodeFactory
   @Primitive(selector = "isNil", noWrapper = true)
-  public abstract static class IsNilNode extends UnaryBasicOperation {
+  public abstract static class IsNilNode extends UnaryBasicOperation implements OperationNode {
     public IsNilNode(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Override
@@ -100,11 +101,21 @@ public final class ObjectPrims {
     public final boolean isNil(final Object receiver) {
       return receiver == Nil.nilObject;
     }
+
+    @Override
+    public String getOperation() {
+      return "isNil";
+    }
+
+    @Override
+    public int getNumArguments() {
+      return 1;
+    }
   }
 
   @GenerateNodeFactory
   @Primitive(selector = "notNil", noWrapper = true)
-  public abstract static class NotNilNode extends UnaryBasicOperation {
+  public abstract static class NotNilNode extends UnaryBasicOperation implements OperationNode {
     public NotNilNode(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Override
@@ -119,6 +130,16 @@ public final class ObjectPrims {
     @Specialization
     public final boolean isNotNil(final Object receiver) {
       return receiver != Nil.nilObject;
+    }
+
+    @Override
+    public String getOperation() {
+      return "notNil";
+    }
+
+    @Override
+    public int getNumArguments() {
+      return 1;
     }
   }
 

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -32,6 +32,7 @@ import som.interop.ValueConversionFactory.ToSomConversionNodeGen;
 import som.interpreter.Invokable;
 import som.interpreter.SomLanguage;
 import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.OperationNode;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
 import som.interpreter.nodes.nary.UnaryBasicOperation;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
@@ -256,12 +257,22 @@ public final class SystemPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "systemTicks:", selector = "ticks",
              specializer = IsSystemModule.class, noWrapper = true)
-  public abstract static class TicksPrim extends UnaryBasicOperation {
+  public abstract static class TicksPrim extends UnaryBasicOperation implements OperationNode {
     public TicksPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
     public final long doSObject(final Object receiver) {
       return System.nanoTime() / 1000L - startMicroTime;
+    }
+
+    @Override
+    public String getOperation() {
+      return "ticks";
+    }
+
+    @Override
+    public int getNumArguments() {
+      return 1;
     }
   }
 

--- a/src/som/primitives/arrays/AtPrim.java
+++ b/src/som/primitives/arrays/AtPrim.java
@@ -8,7 +8,7 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.SArguments;
 import som.interpreter.nodes.MessageSendNode;
-import som.interpreter.nodes.MessageSendNode.GenericMessageSendNode;
+import som.interpreter.nodes.MessageSendNode.AbstractMessageSendNode;
 import som.interpreter.nodes.nary.BinaryBasicOperation;
 import som.primitives.Primitive;
 import som.vm.Symbols;
@@ -23,7 +23,7 @@ import tools.dym.Tags.ArrayRead;
 public abstract class AtPrim extends BinaryBasicOperation {
   private final ValueProfile storageType = ValueProfile.createClassProfile();
 
-  @Child protected GenericMessageSendNode exception;
+  @Child protected AbstractMessageSendNode exception;
 
   protected AtPrim(final boolean eagWrap, final SourceSection source) {
     super(eagWrap, source);

--- a/src/som/primitives/arrays/AtPutPrim.java
+++ b/src/som/primitives/arrays/AtPutPrim.java
@@ -11,7 +11,7 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.SArguments;
 import som.interpreter.nodes.MessageSendNode;
-import som.interpreter.nodes.MessageSendNode.GenericMessageSendNode;
+import som.interpreter.nodes.MessageSendNode.AbstractMessageSendNode;
 import som.interpreter.nodes.nary.TernaryExpressionNode;
 import som.primitives.Primitive;
 import som.vm.Symbols;
@@ -31,7 +31,7 @@ import tools.dym.Tags.BasicPrimitiveOperation;
 public abstract class AtPutPrim extends TernaryExpressionNode {
   private final ValueProfile storageType = ValueProfile.createClassProfile();
 
-  @Child protected GenericMessageSendNode exception;
+  @Child protected AbstractMessageSendNode exception;
 
   protected AtPutPrim(final boolean eagWrap, final SourceSection source) {
     super(eagWrap, source);

--- a/src/tools/dym/DynamicMetrics.java
+++ b/src/tools/dym/DynamicMetrics.java
@@ -204,17 +204,16 @@ public class DynamicMetrics extends TruffleInstrument {
     });
   }
 
-  private static int numberOfChildren(final Node node) {
-    int i = 0;
-    for (@SuppressWarnings("unused") Node child : node.getChildren()) {
-      i += 1;
-    }
-    return i;
-  }
-
   private static String getOperation(final Node node) {
     if (node instanceof OperationNode) {
       return ((OperationNode) node).getOperation();
+    }
+    throw new NotYetImplementedException();
+  }
+
+  private static int getNumArguments(final Node node) {
+    if (node instanceof OperationNode) {
+      return ((OperationNode) node).getNumArguments();
     }
     throw new NotYetImplementedException();
   }
@@ -225,14 +224,14 @@ public class DynamicMetrics extends TruffleInstrument {
     filters.tagIs(ComplexPrimitiveOperation.class, BasicPrimitiveOperation.class);
 
     ExecutionEventNodeFactory primExpFactory = (final EventContext ctx) -> {
-      int numSubExpr = numberOfChildren(ctx.getInstrumentedNode());
+      int numArgsAndResult = getNumArguments(ctx.getInstrumentedNode()) + 1;
       String operation = getOperation(ctx.getInstrumentedNode());
       Set<Class<?>> tags = instrumenter.queryTags(ctx.getInstrumentedNode());
 
       OperationProfile p = operationProfiles.computeIfAbsent(
         ctx.getInstrumentedSourceSection(),
         (final SourceSection src) -> new OperationProfile(
-            src, operation, tags, numSubExpr));
+            src, operation, tags, numArgsAndResult));
       return new OperationProfilingNode(p, ctx);
     };
 

--- a/src/tools/dym/MetricsCsvWriter.java
+++ b/src/tools/dym/MetricsCsvWriter.java
@@ -236,6 +236,10 @@ public final class MetricsCsvWriter {
       }
       throw new NotYetImplementedException();
     } else if (tags.contains(OpComparison.class)) {
+      if (p.getNumArgsAndResult() == 2) {
+        return typeCategory(a.getArgType(1));
+      }
+
       String left  = typeCategory(a.getArgType(1));
       String right = typeCategory(a.getArgType(2));
       if (left.equals(right)) {
@@ -250,7 +254,7 @@ public final class MetricsCsvWriter {
       }
       throw new NotYetImplementedException();
     } else if (tags.contains(ArrayRead.class) || tags.contains(ArrayWrite.class)) {
-      assert a.argTypeIs(1, "Array");
+      assert a.argTypeIs(1, "Array") || a.argTypeIs(1, "ValueArray");
       assert a.argTypeIs(2, "Integer");
       if (tags.contains(ArrayRead.class)) {
         return typeCategory(a.getArgType(0));
@@ -263,6 +267,8 @@ public final class MetricsCsvWriter {
       return typeCategory(a.getArgType(1));
     } else if (tags.contains(StringAccess.class)) {
       return "str";
+    } else if (p.getOperation().equals("ticks")) {
+      return "int";
     }
     throw new NotYetImplementedException();
   }

--- a/src/tools/dym/profiles/OperationProfile.java
+++ b/src/tools/dym/profiles/OperationProfile.java
@@ -16,13 +16,14 @@ public final class OperationProfile extends Counter {
   private final String operation;
   private final Set<Class<?>> tags;
   private final Deque<Object[]> argumentsForExecutions;
-  protected final int numSubexpressions;
+  protected final int numArgsAndResult;
   protected final Map<Arguments, Integer> argumentTypes;
 
   public OperationProfile(final SourceSection source,
-      @NotNull final String operation, final Set<Class<?>> tags, final int numSubexpressions) {
+      @NotNull final String operation, final Set<Class<?>> tags,
+      final int numArgsAndResult) {
     super(source);
-    this.numSubexpressions = numSubexpressions;
+    this.numArgsAndResult  = numArgsAndResult;
     this.operation         = operation;
     this.tags              = tags;
     argumentsForExecutions = new ArrayDeque<>();
@@ -36,7 +37,7 @@ public final class OperationProfile extends Counter {
   }
 
   public void enterMainNode() {
-    argumentsForExecutions.push(new Object[numSubexpressions]);
+    argumentsForExecutions.push(new Object[numArgsAndResult]);
   }
 
   public String getOperation() {
@@ -45,6 +46,10 @@ public final class OperationProfile extends Counter {
 
   public Set<Class<?>> getTags() {
     return tags;
+  }
+
+  public int getNumArgsAndResult() {
+    return numArgsAndResult;
   }
 
   public Map<Arguments, Integer> getArgumentTypes() {


### PR DESCRIPTION
Currently, we were essentially guessing the correct number of arguments based on the number of child nodes. But since we can have child nodes for a various number of other purposes.