### PR TITLE
Added Peak Memory Report

### DIFF
--- a/src/som/VM.java
+++ b/src/som/VM.java
@@ -180,6 +180,9 @@ public final class VM {
     }
     Actor.shutDownActorPool();
     engine.dispose();
+    if (VmSettings.MEMORY_TRACING) {
+      ActorExecutionTrace.reportPeakMemoryUsage();
+    }
     System.exit(errorCode);
   }
 


### PR DESCRIPTION
running som with "-mt" flag reports peak memory usage for heap and non heap memory, additionally  the time spent on GC is provided.
Data is collected from MXBeans just before the VM shuts down.

example:
[Memstat] Heap: 209142184B	NonHeap: 44378016B	Collected: 518722336B	GC-Time: 67ms