### PR TITLE
Implemented array literals

### DIFF
--- a/src/som/compiler/Lexer.java
+++ b/src/som/compiler/Lexer.java
@@ -164,6 +164,10 @@ public final class Lexer {
       match(Symbol.NewBlock);
     } else if (currentChar() == ']') {
       match(Symbol.EndBlock);
+    } else if (currentChar() == '{') {
+      match(Symbol.NewLiteralArray);
+    } else if (currentChar() == '}') {
+      match(Symbol.EndLiteralArray);
     } else if (currentChar() == ':') {
       if (nextChar() == '=') {
         state.incPtr(2);

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -1456,22 +1456,20 @@ public class Parser {
 
     expect(NewLiteralArray, DelimiterOpeningTag.class);
 
-    boolean sawPeriod = true;
-
+    boolean needsSeparator = false;
     while (true) {
       comments();
-
       if (sym == EndLiteralArray) {
         expect(EndLiteralArray, DelimiterClosingTag.class);
         return createLiteralArray(expressions, getSource(coord));
       }
-
-      if (!sawPeriod) {
-        expect(Period, null);
+      if (needsSeparator) {
+        expect(Period,
+            "Could not parse statement. Expected a '.' but got '" + text + "'",
+            StatementSeparatorTag.class);
       }
-
       expressions.add(expression(builder));
-      sawPeriod = accept(Period, StatementSeparatorTag.class);
+      needsSeparator = !accept(Period, StatementSeparatorTag.class);
     }
   }
 

--- a/src/som/compiler/Symbol.java
+++ b/src/som/compiler/Symbol.java
@@ -26,7 +26,7 @@ package som.compiler;
 
 enum Symbol {
   NONE, Integer, Double, Not, And, Or, Star, Div, Mod, Plus, Minus, Equal, More, Less,
-  Comma, At, Per, NewBlock, EndBlock, Colon, Period, Exit, Assign, NewTerm,
+  Comma, At, Per, NewBlock, EndBlock, NewLiteralArray, EndLiteralArray, Colon, Period, Exit, Assign, NewTerm,
   EndTerm, Pound, STString,
   BeginComment, EndComment, SlotMutableAssign, EventualSend, MixinOperator,
   Identifier, Keyword,

--- a/src/som/interpreter/SNodeFactory.java
+++ b/src/som/interpreter/SNodeFactory.java
@@ -17,8 +17,10 @@ import som.interpreter.nodes.ResolvingImplicitReceiverSend;
 import som.interpreter.nodes.ReturnNonLocalNode;
 import som.interpreter.nodes.ReturnNonLocalNode.CatchNonLocalReturnNode;
 import som.interpreter.nodes.SequenceNode;
+import som.interpreter.nodes.literals.ArrayLiteralNode;
 import som.interpreter.nodes.literals.BlockNode;
 import som.interpreter.nodes.literals.BlockNode.BlockNodeWithContext;
+import som.interpreter.nodes.literals.LiteralNode;
 import som.interpreter.nodes.literals.NilLiteralNode;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
 import som.interpreter.objectstorage.InitializerFieldWrite;
@@ -52,6 +54,15 @@ public final class SNodeFactory {
       return expressions.get(0);
     }
     return new SequenceNode(expressions.toArray(new ExpressionNode[0]), source);
+  }
+
+  public static LiteralNode createLiteralArray(
+      final List<ExpressionNode> expressions, final SourceSection source) {
+    for (ExpressionNode statement : expressions) {
+      statement.markAsStatement();
+    }
+
+    return new ArrayLiteralNode(expressions.toArray(new ExpressionNode[0]), source);
   }
 
   public static BlockNode createBlockNode(final SInvokable blockMethod,

--- a/src/som/interpreter/nodes/literals/ArrayLiteralNode.java
+++ b/src/som/interpreter/nodes/literals/ArrayLiteralNode.java
@@ -1,0 +1,35 @@
+package som.interpreter.nodes.literals;
+
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.api.source.SourceSection;
+
+import som.interpreter.nodes.ExpressionNode;
+import som.vm.constants.Classes;
+import som.vmobjects.SArray.SMutableArray;
+
+public final class ArrayLiteralNode extends LiteralNode {
+  @Children private final ExpressionNode[] expressions;
+
+  public ArrayLiteralNode(final ExpressionNode[] expressions, final SourceSection source) {
+    super(source);
+    assert source != null;
+    this.expressions = expressions;
+  }
+
+  @ExplodeLoop
+  private SMutableArray evaluatedExpressions(final VirtualFrame frame) {
+    Object[] arr = new Object[expressions.length];
+    for (int i = 0; i < expressions.length; i++) {
+      arr[i] = expressions[i].executeGeneric(frame);
+    }
+
+    return new SMutableArray(arr, Classes.arrayClass);
+  }
+
+  @Override
+  public Object executeGeneric(final VirtualFrame frame) {
+    return evaluatedExpressions(frame);
+  }
+}


### PR DESCRIPTION
Add support for literal arrays, based on issue #83

In the Parser, I've added a new primary expression. When the literal array opening symbol `{` is found, a new method `literalArray(builder) ` is called. This method parses each expression uses a while loop, much like is done in `blockBody(builder)`. The method also eats the braces and the periods between expressions. Once collected, the list of expressions is sent to a new method in the node factory, which marks each expression as a statement and then returns an instance of the new Array Literal node. When executed, the Array Literal node instantiates an SMutableArray by evaluating each expressions.

Some things I'd like to do next are:

- [ ] optimization the Array Literal node using Truffle specializations
- [ ] write appropriate tests to validate that the implementation works as expect
- [ ] implement support for value arrays (as noted in the issue linked above)