### PR TITLE
Implemented trace replay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,14 @@ env:
   global:
     - secure: PrFbSr/qjhVXrpiOzrcEMUZrnjEWJmvx5DC9QdaAmnUKpG9/7mJBQVgNziVj+GWfW84WJpkOsQf+I2lx7/cQsWQKad/t8wtypl30wGesSTpAgl5fCiKLOBAbOghKXir+WIaxtcATPPffur9OLh3ogEcmIQbVi682YUKmA5zF11JZdpCR4QONc/u+DqB29FuHru/cFiesYP0Oz82A+M0UtMcYsurKIxdKMD4YK/uSG892PUrcZU6STXlukhgQuy3PitSWkYV2KGxXMVKzWGM7dJvRggN05r/S871pscuRwZ+Doxqr9b17B3umCHi3i4KXmNH+Esb0p1mvegs0iS/b7RyA5SENre+H24n3SOeXTa3wSpTnF90XxQrDEBbY5wV7lN7MJG+pHxkOvoZt6pS3f7x2VYR8Joa4J+Gf6IDvxZMiCd1v3N1kc9ygyvJmHf5wDmLMdupk0/frojApDXfJT6bqiVL3S0FqZpXSPGAsKYf8wfn30Xz/YUBsnfUQ/a21Zz52+OTqPbt32Hf1FGYIEJSkZJUN90Q8rHVJt9zPg37xKCDuf6bxlvT040KSzuuXtizLkOnHq2rhg4Oad/JTw3d4NzPoRVzUI9qDKPrA7RdUAjmrB04Z1f3g/I6w3h2B9JTSFAzBcMZ5NYZhIqE31GQukgStaqC98y32/zo9xFs=
   matrix:
-    - TASK=tests
+    - TASK=core-tests
     - TASK=checkstyle
-    - TASK=kompos
+    - TASK=kompos-tests
+    - TASK=replay1-tests
+    - TASK=replay2-tests
 script:
-  - if [ "$TASK" = "tests" ];      then ant tests; fi
-  - if [ "$TASK" = "checkstyle" ]; then ant checkstyle   && cd tools/kompos && nvm install 7 && npm install && npm run lint; fi
-  - if [ "$TASK" = "kompos" ]; then nvm install 7 && ant && cd tools/kompos && npm install && npm test; fi
+  - if [ "$TASK" = "core-tests" ]; then ant core-tests; fi
+  - if [ "$TASK" = "checkstyle" ]; then ant checkstyle && cd tools/kompos && nvm install 7 && npm install && npm run lint; fi
+  - if [ "$TASK" = "kompos-tests" ]; then nvm install 7 && ant && cd tools/kompos && npm install && npm test; fi
+  - if [ "$TASK" = "replay1-tests" ]; then ant compile && ./tests/replay/test.sh 1; fi
+  - if [ "$TASK" = "replay2-tests" ]; then ant compile && ./tests/replay/test.sh 2; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
  - Added trace replay functionality ([PR #109](https://github.com/smarr/SOMns/pull/109))
+   - Added `-r` flag to enable replay
+
+ - Added `-vmd` flag to enable debug output
+ - Added `-J` flag for JVM flags, e.g. `-JXmx2g`
 
 ## [0.2.0] - 2017-03-07 Extended Concurrency Support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+ - Added trace replay functionality ([PR #109](https://github.com/smarr/SOMns/pull/109))
+
 ## [0.2.0] - 2017-03-07 Extended Concurrency Support
 
 ### Concurrency Support

--- a/build.xml
+++ b/build.xml
@@ -162,7 +162,12 @@
       <exec executable="tests/dym/test.sh" failonerror="true"></exec>
     </target>
 
-    <target name="tests" depends="unit-tests,som-tests,dynamic-metrics-tests">
+    <target name="replay-tests" depends="compile">
+      <exec executable="echo" failonerror="true"></exec>
+      <exec executable="tests/replay/test.sh" failonerror="true"></exec>
+    </target>
+
+    <target name="tests" depends="unit-tests,som-tests,dynamic-metrics-tests,replay-tests">
       <!-- submit coverage data -->
       <java classname="coveralls.Report" fork="true" failonerror="true">
           <classpath refid="project.classpath" />

--- a/build.xml
+++ b/build.xml
@@ -158,16 +158,22 @@
     </target>
 
     <target name="dynamic-metrics-tests" depends="compile">
-      <exec executable="echo" failonerror="true"></exec>
       <exec executable="tests/dym/test.sh" failonerror="true"></exec>
     </target>
 
     <target name="replay-tests" depends="compile">
-      <exec executable="echo" failonerror="true"></exec>
-      <exec executable="tests/replay/test.sh" failonerror="true"></exec>
+      <exec executable="tests/replay/test.sh" failonerror="true">
+          <arg value="1" />
+      </exec>
+      <exec executable="tests/replay/test.sh" failonerror="true">
+          <arg value="2" />
+      </exec>
+    </target>
+    
+    <target name="core-tests" depends="unit-tests,som-tests,dynamic-metrics-tests">
     </target>
 
-    <target name="tests" depends="unit-tests,som-tests,dynamic-metrics-tests,replay-tests">
+    <target name="tests" depends="core-tests,replay-tests">
       <!-- submit coverage data -->
       <java classname="coveralls.Report" fork="true" failonerror="true">
           <classpath refid="project.classpath" />

--- a/core-lib/Benchmarks/Validation.som
+++ b/core-lib/Benchmarks/Validation.som
@@ -349,10 +349,9 @@ class Validation usingPlatform: platform andHarness: harness = Value (
   )
 
 
-  public class Philosophers new: numPhil rounds: numRounds = Benchmark (
+  public class Philosophers new: numPhil rounds: numRounds = Benchmark <: Value (
   | private numPhil   = numPhil.
     private numRounds = numRounds.
-    private rand = Random new.
   |)(
     private class Counter = (
     | private value ::= 0. |
@@ -398,6 +397,7 @@ class Validation usingPlatform: platform andHarness: harness = Value (
       private resolver = resolver.
       private abortion ::= false.
       private resolved ::= false.
+      private rand = Random new.
     |)(
       public hungry: philosopher id: leftForkId = (
         | rightForkId |

--- a/som
+++ b/som
@@ -27,6 +27,8 @@ parser.add_argument('-k', '--kernel', help='SOM Kernel file, default: core-lib/K
                     dest='som_kernel', default=BASE_DIR + '/core-lib/Kernel.som')
 parser.add_argument('-dnu', '--stack-trace-on-dnu', help='Print a stack trace on #doesNotUnderstand:',
                     dest='som_dnu', action='store_true', default=False)
+parser.add_argument('-vmd', '--vmdebug', help='enables debug mode (additional output)',
+                    dest='vmdebug', action='store_true', default=False)
 
 explore = parser.add_argument_group('Explore', 'Investigate Execution')
 explore.add_argument('-i', '--igv', help='dump compilation details to IGV',
@@ -109,7 +111,8 @@ parser.add_argument('-vv', '--verbose', action='store_true', default=False,
 parser.add_argument('--print-graal-options', action='store_true', default=False,
                     dest='print_graal_options', help="print all Graal options")
 
-
+parser.add_argument('-J', help="Java VM Argument prefix",
+                    dest="java_args", action='append')
 parser.add_argument('-D', help="define a Java property",
                     dest="java_properties", action='append')
 
@@ -244,6 +247,8 @@ if args.web_debugger:
 if args.dynamic_metrics:
     SOM_ARGS += ['--dynamic-metrics']
     flags += ['-Dsom.dynamicMetrics=true']
+if args.vmdebug:
+    flags += ['-Dsom.debugMode=true']
 
 if args.actor_tracing:
     flags += ['-Dsom.actorTracing=true']
@@ -301,6 +306,9 @@ if args.print_graal_options:
 
 if args.java_properties:
     flags += ['-D' + property for property in args.java_properties]
+
+if args.java_args:
+    JAVA_ARGS += ['-' + property for property in args.java_args]
 
 flags += ['-Dsom.tools=' + BASE_DIR + '/tools']
 

--- a/som
+++ b/som
@@ -76,9 +76,11 @@ tools.add_argument('-atcfg', '--actor-tracing-cfg', help='Configuration string f
 tools.add_argument('-mt', '--memory-tracing', help='enable tracing of memory usage and GC',
                     dest='memory_tracing', action='store_true', default=False)
 tools.add_argument('-tf', '--trace-file', help='Trace file destination, default: traces/trace',
-                    dest='trace_file', default=BASE_DIR + '/traces/tracea')
+                    dest='trace_file', default=BASE_DIR + '/traces/trace')
 tools.add_argument('-TF', '--disable-trace-file', help='trace file wont be written to disk',
                     dest='disable_trace_file', action='store_true', default=False)
+tools.add_argument('-r', '--replay', help='execution of the programm is guided by an exisiting trace file',
+                    dest='replay', action='store_true', default=False)
 tools.add_argument('--coverage', help='determine code coverage and store in given file',
                    dest='coverage', default=None)
 
@@ -253,6 +255,8 @@ if args.memory_tracing:
     flags += ['-Dsom.memoryTracing=true']
 if args.disable_trace_file:
     flags += ['-Dsom.disableTraceFile=true']
+if args.replay:
+    flags += ['-Dsom.replay=true']
 
 if (args.truffle_profile or args.truffle_debugger or args.web_debugger or
     args.dynamic_metrics or args.coverage):

--- a/src/som/VM.java
+++ b/src/som/VM.java
@@ -193,14 +193,18 @@ public final class VM {
       truffleProfiler.printHistograms(System.err);
     }
 
+    int code = errorCode;
+
     Actor.shutDownActorPool();
     ActorExecutionTrace.waitForTrace();
-    Actor.printMissingMessages();
+    if (Actor.printMissingMessages() && errorCode == 0) {
+      code = 1;
+    }
     engine.dispose();
     if (VmSettings.MEMORY_TRACING) {
       ActorExecutionTrace.reportPeakMemoryUsage();
     }
-    System.exit(errorCode);
+    System.exit(code);
   }
 
   /**

--- a/src/som/VM.java
+++ b/src/som/VM.java
@@ -41,6 +41,7 @@ import som.vm.VmSettings;
 import som.vm.constants.KernelObj;
 import som.vmobjects.SObjectWithClass.SObjectWithoutFields;
 import tools.concurrency.ActorExecutionTrace;
+import tools.concurrency.TracingActors;
 import tools.debugger.Tags;
 import tools.debugger.WebDebugger;
 import tools.dym.DynamicMetrics;
@@ -197,7 +198,7 @@ public final class VM {
 
     Actor.shutDownActorPool();
     ActorExecutionTrace.waitForTrace();
-    if (Actor.printMissingMessages() && errorCode == 0) {
+    if (TracingActors.ReplayActor.printMissingMessages() && errorCode == 0) {
       code = 1;
     }
     engine.dispose();

--- a/src/som/VM.java
+++ b/src/som/VM.java
@@ -192,7 +192,10 @@ public final class VM {
     if (truffleProfiler != null) {
       truffleProfiler.printHistograms(System.err);
     }
+
     Actor.shutDownActorPool();
+    ActorExecutionTrace.waitForTrace();
+    Actor.printMissingMessages();
     engine.dispose();
     if (VmSettings.MEMORY_TRACING) {
       ActorExecutionTrace.reportPeakMemoryUsage();

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -340,9 +340,11 @@ public class Actor implements Activity {
     protected long nextActorId = 1;
     protected long nextMessageId;
     protected long nextPromiseId;
+    protected ByteBuffer tracingDataBuffer;
+
+    // Used for tracing, accessed by the ExecAllMessages classes
     public long createdMessages;
     public long currentMessageId;
-    protected ByteBuffer tracingDataBuffer;
     public long resolvedPromises;
 
     protected ActorProcessingThread(final ForkJoinPool pool) {

--- a/src/som/interpreter/actors/EventualMessage.java
+++ b/src/som/interpreter/actors/EventualMessage.java
@@ -284,7 +284,7 @@ public abstract class EventualMessage {
     }
   }
 
-  protected final void execute() {
+  public final void execute() {
     try {
       executeMessage();
     } catch (ThreadDeath t) {

--- a/src/som/interpreter/actors/SPromise.java
+++ b/src/som/interpreter/actors/SPromise.java
@@ -1,7 +1,6 @@
 package som.interpreter.actors;
 
 import java.util.ArrayList;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
@@ -30,9 +29,7 @@ public class SPromise extends SObjectWithClass {
   private boolean triggerResolutionBreakpointOnUnresolvedChainedPromise;
 
   public static SPromise createPromise(final Actor owner) {
-    if (VmSettings.DEBUG_MODE) {
-      return new SDebugPromise(owner);
-    } else if (VmSettings.REPLAY) {
+    if (VmSettings.REPLAY) {
       return new SReplayPromise(owner);
     } else if (VmSettings.PROMISE_CREATION) {
       return new STracingPromise(owner);
@@ -252,24 +249,6 @@ public class SPromise extends SObjectWithClass {
   /** Internal Helper, only to be used properly synchronized. */
   final Object getValueUnsync() {
     return value;
-  }
-
-  protected static final class SDebugPromise extends SPromise {
-    private static final AtomicInteger idGenerator = new AtomicInteger(0);
-
-    private final int id;
-
-    protected SDebugPromise(final Actor owner) {
-      super(owner);
-      id = idGenerator.getAndIncrement();
-    }
-
-    @Override
-    public String toString() {
-      String r = "Promise[" + owner.toString();
-      r += ", " + resolutionState.name();
-      return r + (value == null ? "" : ", " + value.toString()) + ", id:" + id + "]";
-    }
   }
 
   protected static class STracingPromise extends SPromise {

--- a/src/som/interpreter/actors/SPromise.java
+++ b/src/som/interpreter/actors/SPromise.java
@@ -17,6 +17,7 @@ import som.vmobjects.SBlock;
 import som.vmobjects.SClass;
 import som.vmobjects.SObjectWithClass;
 import tools.concurrency.ActorExecutionTrace;
+import tools.concurrency.TracingActors.ReplayActor;
 
 
 public class SPromise extends SObjectWithClass {
@@ -272,7 +273,7 @@ public class SPromise extends SObjectWithClass {
 
     protected SReplayPromise(final Actor owner) {
       super(owner);
-      Actor creator = EventualMessage.getActorCurrentMessageIsExecutionOn();
+      ReplayActor creator = (ReplayActor) EventualMessage.getActorCurrentMessageIsExecutionOn();
 
       assert creator.getReplayPromiseIds() != null && creator.getReplayPromiseIds().size() > 0;
       replayId = creator.getReplayPromiseIds().remove();

--- a/src/som/vm/ObjectSystem.java
+++ b/src/som/vm/ObjectSystem.java
@@ -339,7 +339,7 @@ Classes.transferClass.getSOMClass().setClassGroup(Classes.metaclassClass.getInst
     }
 
     assert !VM.shouldExit();
-
+    Actor.printMissingMessages();
     VM.errorExit("VM seems to have exited prematurely. But the actor pool has been idle for " + emptyFJPool + " checks in a row.");
     VM.getVM().shutdownAndExit(1); // just in case it was disable for VM.errorExit
   }

--- a/src/som/vm/ObjectSystem.java
+++ b/src/som/vm/ObjectSystem.java
@@ -339,6 +339,8 @@ Classes.transferClass.getSOMClass().setClassGroup(Classes.metaclassClass.getInst
     }
 
     assert !VM.shouldExit();
+
+    Actor.printMissingMessages();
     VM.errorExit("VM seems to have exited prematurely. But the actor pool has been idle for " + emptyFJPool + " checks in a row.");
     VM.getVM().shutdownAndExit(1); // just in case it was disable for VM.errorExit
   }

--- a/src/som/vm/ObjectSystem.java
+++ b/src/som/vm/ObjectSystem.java
@@ -340,7 +340,6 @@ Classes.transferClass.getSOMClass().setClassGroup(Classes.metaclassClass.getInst
 
     assert !VM.shouldExit();
 
-    Actor.printMissingMessages();
     VM.errorExit("VM seems to have exited prematurely. But the actor pool has been idle for " + emptyFJPool + " checks in a row.");
     VM.getVM().shutdownAndExit(1); // just in case it was disable for VM.errorExit
   }

--- a/src/som/vm/ObjectSystem.java
+++ b/src/som/vm/ObjectSystem.java
@@ -36,6 +36,7 @@ import som.vmobjects.SInvokable;
 import som.vmobjects.SObject;
 import som.vmobjects.SObjectWithClass.SObjectWithoutFields;
 import som.vmobjects.SSymbol;
+import tools.concurrency.TracingActors;
 import tools.language.StructuralProbe;
 
 
@@ -339,7 +340,7 @@ Classes.transferClass.getSOMClass().setClassGroup(Classes.metaclassClass.getInst
     }
 
     assert !VM.shouldExit();
-    Actor.printMissingMessages();
+    TracingActors.ReplayActor.printMissingMessages();
     VM.errorExit("VM seems to have exited prematurely. But the actor pool has been idle for " + emptyFJPool + " checks in a row.");
     VM.getVM().shutdownAndExit(1); // just in case it was disable for VM.errorExit
   }

--- a/src/som/vm/VmSettings.java
+++ b/src/som/vm/VmSettings.java
@@ -20,6 +20,7 @@ public class VmSettings {
   public static final boolean PROMISE_CREATION;
   public static final boolean PROMISE_RESOLUTION;
   public static final boolean PROMISE_RESOLVED_WITH;
+  public static final boolean REPLAY;
 
   public static final boolean TRUFFLE_DEBUGGER_ENABLED;
 
@@ -39,18 +40,19 @@ public class VmSettings {
     DEBUG_MODE      = getBool("som.debugMode",      false);
     TRACE_FILE      = System.getProperty("som.traceFile", System.getProperty("user.dir") + "/traces/trace");
     MEMORY_TRACING = getBool("som.memoryTracing",   false);
-    DISABLE_TRACE_FILE = getBool("som.disableTraceFile", false);
+    REPLAY = getBool("som.replay", false);
+    DISABLE_TRACE_FILE = getBool("som.disableTraceFile", false) || REPLAY;
 
     String atConfig = System.getProperty("som.actorTracingCfg", "");
     List<String> al = Arrays.asList(atConfig.split(":"));
     boolean filter = (al.size() > 0 && !atConfig.isEmpty()) || getBool("som.actorTracing",   false);
 
-    MESSAGE_TIMESTAMPS    = !al.contains("mt") && filter;
+    MESSAGE_TIMESTAMPS    = !al.contains("mt") && filter && !REPLAY;
     MESSAGE_PARAMETERS    = !al.contains("mp") && filter;
     PROMISE_CREATION      = !al.contains("pc") && filter;
     PROMISE_RESOLUTION    = PROMISE_CREATION && (!al.contains("pr")) && filter;
     PROMISE_RESOLVED_WITH = !al.contains("prw") && filter;
-    ACTOR_TRACING   = getBool("som.actorTracing",   false) || MESSAGE_TIMESTAMPS || MESSAGE_PARAMETERS || PROMISE_CREATION;
+    ACTOR_TRACING   = getBool("som.actorTracing",   false) || REPLAY || MESSAGE_TIMESTAMPS || MESSAGE_PARAMETERS || PROMISE_CREATION;
 
     boolean dm = getBool("som.dynamicMetrics", false);
     DYNAMIC_METRICS = dm;

--- a/src/tools/TraceData.java
+++ b/src/tools/TraceData.java
@@ -1,0 +1,9 @@
+package tools;
+
+
+public class TraceData {
+  public static final byte MESSAGE_BASE = (byte) 0x80;
+  public static final byte PROMISE_BIT = 0x40;
+  public static final byte TIMESTAMP_BIT = 0x20;
+  public static final byte PARAMETER_BIT = 0x10;
+}

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -16,7 +16,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import javax.management.Notification;
 import javax.management.NotificationEmitter;
@@ -31,7 +33,6 @@ import som.interpreter.actors.Actor;
 import som.interpreter.actors.Actor.ActorProcessingThread;
 import som.interpreter.actors.EventualMessage;
 import som.interpreter.actors.EventualMessage.PromiseMessage;
-import som.interpreter.actors.EventualMessage.PromiseSendMessage;
 import som.interpreter.actors.SFarReference;
 import som.interpreter.actors.SPromise;
 import som.interpreter.actors.SPromise.SResolver;
@@ -46,13 +47,15 @@ import tools.debugger.FrontendConnector;
 public class ActorExecutionTrace {
 
   private static final int BUFFER_POOL_SIZE = Runtime.getRuntime().availableProcessors() * 4;
-  private static final int BUFFER_SIZE = 4096 * 1024;
+  static final int BUFFER_SIZE = 4096 * 1024;
   private static final byte MESSAGE_BASE = (byte) 0x80;
   private static final byte PROMISE_BIT = 0x40;
   private static final byte TIMESTAMP_BIT = 0x20;
   private static final byte PARAMETER_BIT = 0x10;
-  private static final int MESSAGE_SIZE = 45;
+  private static final int MESSAGE_SIZE = 45 + 16;
   private static final int PARAM_SIZE = 9;
+  private static final int TRACE_TIMEOUT = 500;
+  private static final int POLL_TIMEOUT = 10;
 
   private static final List<java.lang.management.GarbageCollectorMXBean> gcbeans = ManagementFactory.getGarbageCollectorMXBeans();
 
@@ -66,8 +69,7 @@ public class ActorExecutionTrace {
   private static FrontendConnector front = null;
 
   private static long collectedMemory = 0;
-
-  private static Thread workerThread = new TraceWorkerThread();
+  private static TraceWorkerThread workerThread = new TraceWorkerThread();
   private static final byte messageEventId;
 
   static {
@@ -173,7 +175,7 @@ public class ActorExecutionTrace {
     PromiseCreation((byte) 2, 17),
     PromiseResolution((byte) 3, 28),
     PromiseChained((byte) 4, 17),
-    Mailbox((byte) 5, 17),
+    Mailbox((byte) 5, 21),
 
     // at the beginning of buffer, allows to track what was created/executed
     // on which thread, really cheap solution, timestamp?
@@ -181,7 +183,7 @@ public class ActorExecutionTrace {
 
     // for memory events another buffer is needed
     // (the gc callback is on Thread[Service Thread,9,system])
-    MailboxContd((byte) 7, 19),
+    MailboxContd((byte) 7, 23),
     BasicMessage((byte) 8, 7),
     PromiseMessage((byte) 9, 7);
 
@@ -273,7 +275,6 @@ public class ActorExecutionTrace {
       b.put(Events.PromiseResolution.id);
       b.putLong(promiseId); // id of the promise
       b.putLong(t.getCurrentMessageId()); // resolving message
-
       writeParameter(value, b);
 
       t.resolvedPromises++;
@@ -303,7 +304,7 @@ public class ActorExecutionTrace {
   }
 
   public static void mailboxExecuted(final EventualMessage m,
-      final ObjectBuffer<EventualMessage> moreCurrent, final long baseMessageId, final long sendTS,
+      final ObjectBuffer<EventualMessage> moreCurrent, final long baseMessageId, final int mailboxNo, final long sendTS,
       final ObjectBuffer<Long> moreSendTS, final long[] execTS, final Actor actor) {
     if (!VmSettings.ACTOR_TRACING) {
       return;
@@ -321,6 +322,7 @@ public class ActorExecutionTrace {
       ByteBuffer b = t.getThreadLocalBuffer();
       b.put(Events.Mailbox.id);
       b.putLong(baseMessageId); // base id for messages
+      b.putInt(mailboxNo);
       b.putLong(actor.getActorId());   // receiver of the messages
 
       int idx = 0;
@@ -330,8 +332,9 @@ public class ActorExecutionTrace {
         b = t.getThreadLocalBuffer();
         b.put(Events.MailboxContd.id);
         b.putLong(baseMessageId);
+        b.putInt(mailboxNo);
         b.putLong(actor.getActorId()); // receiver of the messages
-        b.putShort((short) idx);
+        b.putInt(idx);
       }
 
       writeBasicMessage(m, b);
@@ -358,8 +361,9 @@ public class ActorExecutionTrace {
             b = t.getThreadLocalBuffer();
             b.put(Events.MailboxContd.id);
             b.putLong(baseMessageId);
+            b.putInt(mailboxNo);
             b.putLong(actor.getActorId()); // receiver of the messages
-            b.putShort((short) idx);
+            b.putInt(idx);
           }
 
           writeBasicMessage(em, b);
@@ -379,7 +383,7 @@ public class ActorExecutionTrace {
   }
 
   private static void writeBasicMessage(final EventualMessage em, final ByteBuffer b) {
-    if (em instanceof PromiseSendMessage && VmSettings.PROMISE_CREATION) {
+    if (em instanceof PromiseMessage && VmSettings.PROMISE_CREATION) {
       b.put((byte) (messageEventId | PROMISE_BIT));
       b.putLong(((PromiseMessage) em).getPromise().getPromiseId());
     } else {
@@ -388,6 +392,7 @@ public class ActorExecutionTrace {
 
     b.putLong(em.getSender().getActorId()); // sender
     b.putLong(em.getCausalMessageId());
+
     b.putShort(em.getSelector().getSymbolId());
   }
 
@@ -447,58 +452,145 @@ public class ActorExecutionTrace {
     front = fc;
   }
 
-  public static synchronized void logSymbol(final SSymbol symbol) {
-    symbolsToWrite.add(symbol);
+  public static void logSymbol(final SSymbol symbol) {
+    synchronized (symbolsToWrite) {
+      symbolsToWrite.add(symbol);
+    }
+  }
+
+  public static void waitForTrace() {
+    workerThread.cont = false;
+    try {
+      workerThread.join(TRACE_TIMEOUT);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private static class TraceWorkerThread extends Thread{
+    protected boolean cont = true;
+
     @Override
     public void run() {
+
       File f = new File(VmSettings.TRACE_FILE + ".trace");
       File sf = new File(VmSettings.TRACE_FILE + ".sym");
       f.getParentFile().mkdirs();
 
-      try (FileOutputStream fos = new FileOutputStream(f);
-          FileOutputStream sfos = new FileOutputStream(sf);
-          BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(sfos))) {
+      if (!VmSettings.DISABLE_TRACE_FILE) {
+        try (FileOutputStream fos = new FileOutputStream(f);
+            FileOutputStream sfos = new FileOutputStream(sf);
+            BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(sfos))) {
 
+          while (cont || ActorExecutionTrace.fullBuffers.size() > 0) {
+            ByteBuffer b;
 
-        while (true) {
-          ByteBuffer b = ActorExecutionTrace.fullBuffers.take();
+            try {
+              b = ActorExecutionTrace.fullBuffers.poll(POLL_TIMEOUT, TimeUnit.MILLISECONDS);
+              if (b == null) {
+                continue;
+              }
+            } catch (InterruptedException e) {
+              continue;
+            }
 
-          if (!VmSettings.DISABLE_TRACE_FILE) {
+            synchronized (symbolsToWrite) {
+              if (front != null) {
+                front.sendSymbols(ActorExecutionTrace.symbolsToWrite);
+              }
+
+              for (SSymbol s : symbolsToWrite) {
+                bw.write(s.getSymbolId() + ":" + s.getString());
+                bw.newLine();
+              }
+              bw.flush();
+              ActorExecutionTrace.symbolsToWrite.clear();
+            }
+
             fos.getChannel().write(b);
+            fos.flush();
             b.rewind();
-          }
 
-          if (front != null) {
-            front.sendTracingData(b);
+            if (front != null) {
+              front.sendTracingData(b);
+            }
+
+            b.clear();
+            ActorExecutionTrace.emptyBuffers.add(b);
+          }
+        } catch (FileNotFoundException e) {
+          throw new RuntimeException(e);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      } else {
+        while (cont || ActorExecutionTrace.fullBuffers.size() > 0) {
+          ByteBuffer b;
+
+          try {
+            b = ActorExecutionTrace.fullBuffers.poll(POLL_TIMEOUT, TimeUnit.MILLISECONDS);
+            if (b == null) {
+              continue;
+            }
+          } catch (InterruptedException e) {
+            continue;
           }
 
           synchronized (symbolsToWrite) {
             if (front != null) {
               front.sendSymbols(ActorExecutionTrace.symbolsToWrite);
             }
-
-            if (!VmSettings.DISABLE_TRACE_FILE) {
-              for (SSymbol s : symbolsToWrite) {
-                bw.write(s.getSymbolId() + ":" + s.getString());
-                bw.newLine();
-              }
-            }
-
             ActorExecutionTrace.symbolsToWrite.clear();
+          }
+
+          if (front != null) {
+            front.sendTracingData(b);
           }
 
           b.clear();
           ActorExecutionTrace.emptyBuffers.add(b);
         }
-      } catch (FileNotFoundException e) {
-        throw new RuntimeException(e);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      } catch (InterruptedException e) {
-        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  public static void mailboxExecutedReplay(final Queue<EventualMessage> todo,
+      final long baseMessageId, final int mailboxNo, final Actor actor) {
+    Thread current = Thread.currentThread();
+
+    if (current instanceof ActorProcessingThread) {
+      ActorProcessingThread t = (ActorProcessingThread) current;
+
+      if (t.getThreadLocalBuffer().remaining() < Events.Mailbox.size + 100 * 50) {
+        swapBuffer(t);
+      }
+
+      ByteBuffer b = t.getThreadLocalBuffer();
+      b.put(Events.Mailbox.id);
+      b.putLong(baseMessageId); // base id for messages
+      b.putInt(mailboxNo);
+      b.putLong(actor.getActorId());   // receiver of the messages
+
+      int idx = 0;
+
+      if (todo != null) {
+        for (EventualMessage em : todo) {
+          if (b.remaining() < (MESSAGE_SIZE + em.getArgs().length * PARAM_SIZE)) {
+            swapBuffer(t);
+            b = t.getThreadLocalBuffer();
+            b.put(Events.MailboxContd.id);
+            b.putLong(baseMessageId);
+            b.putLong(actor.getActorId()); // receiver of the messages
+            b.putInt(idx);
+          }
+
+          writeBasicMessage(em, b);
+
+          if (VmSettings.MESSAGE_PARAMETERS) {
+            writeParameters(em.getArgs(), b);
+          }
+          idx++;
+        }
       }
     }
   }

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -170,21 +170,21 @@ public class ActorExecutionTrace {
 
 
   protected enum Events {
-    ActorCreation((byte) 1, 19),
-    PromiseCreation((byte) 2, 17),
-    PromiseResolution((byte) 3, 28),
-    PromiseChained((byte) 4, 17),
-    Mailbox((byte) 5, 21),
+    ActorCreation(TraceParser.ACTOR_CREATION,         19),
+    PromiseCreation(TraceParser.PROMISE_CREATION,     17),
+    PromiseResolution(TraceParser.PROMISE_RESOLUTION, 28),
+    PromiseChained(TraceParser.PROMISE_CHAINED,       17),
+    Mailbox(TraceParser.MAILBOX,                      21),
 
     // at the beginning of buffer, allows to track what was created/executed
     // on which thread, really cheap solution, timestamp?
-    Thread((byte) 6, 9),
+    Thread(TraceParser.THREAD, 9),
 
     // for memory events another buffer is needed
     // (the gc callback is on Thread[Service Thread,9,system])
-    MailboxContd((byte) 7, 23),
-    BasicMessage((byte) 8, 7),
-    PromiseMessage((byte) 9, 7);
+    MailboxContd(TraceParser.MAILBOX_CONTD,     23),
+    BasicMessage(TraceParser.BASIC_MESSAGE,      7),
+    PromiseMessage(TraceParser.PROMISE_MESSAGE,  7);
 
     private final byte id;
     private final int size;

--- a/src/tools/concurrency/TraceParser.java
+++ b/src/tools/concurrency/TraceParser.java
@@ -24,13 +24,16 @@ import tools.TraceData;
 
 
 public final class TraceParser {
-  private static final byte ACTOR_CREATION = 1;
-  private static final byte PROMISE_CREATION = 2;
-  private static final byte PROMISE_RESOLUTION = 3;
-  private static final byte PROMISE_CHAINED = 4;
-  private static final byte MAILBOX = 5;
-  private static final byte THREAD = 6;
-  private static final byte MAILBOX_CONTD = 7;
+  public static final byte ACTOR_CREATION     = 1;
+  public static final byte PROMISE_CREATION   = 2;
+  public static final byte PROMISE_RESOLUTION = 3;
+  public static final byte PROMISE_CHAINED    = 4;
+  public static final byte MAILBOX            = 5;
+  public static final byte THREAD             = 6;
+  public static final byte MAILBOX_CONTD      = 7;
+
+  public static final byte BASIC_MESSAGE      = 8;
+  public static final byte PROMISE_MESSAGE    = 9;
 
   private final HashMap<Short, SSymbol> symbolMapping = new HashMap<>();
   private ByteBuffer b = ByteBuffer.allocate(ActorExecutionTrace.BUFFER_SIZE);

--- a/src/tools/concurrency/TraceParser.java
+++ b/src/tools/concurrency/TraceParser.java
@@ -1,0 +1,339 @@
+package tools.concurrency;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+import som.VM;
+import som.vm.Symbols;
+import som.vm.VmSettings;
+import som.vmobjects.SSymbol;
+
+
+
+public final class TraceParser {
+  private static final byte ACTOR_CREATION = 1;
+  private static final byte PROMISE_CREATION = 2;
+  private static final byte PROMISE_RESOLUTION = 3;
+  private static final byte PROMISE_CHAINED = 4;
+  private static final byte MAILBOX = 5;
+  private static final byte THREAD = 6;
+  private static final byte MAILBOX_CONTD = 7;
+
+  private static final byte MESSAGE_BIT = (byte) 0x80;
+  private static final byte PROMISE_BIT = 0x40;
+  private static final byte TIMESTAMP_BIT = 0x20;
+  private static final byte PARAMETER_BIT = 0x10;
+
+
+  private final HashMap<Short, SSymbol> symbolMapping = new HashMap<>();
+  private ByteBuffer b = ByteBuffer.allocate(ActorExecutionTrace.BUFFER_SIZE);
+  private final HashMap<ActorNode, Long> mappedActors = new HashMap<>();
+  private final HashMap<Long, Queue<Message>> expectedMessages = new HashMap<>();
+  private long currentReceiver;
+  private long currentMessage;
+  private int currentMailbox;
+  private int msgNo;
+  private long parsedMessages = 0;
+  private long parsedActors = 0;
+
+  private static TraceParser parser;
+
+  public static Queue<Message> getExpectedMessages(final long replayId) {
+    if (parser == null) {
+      parser = new TraceParser();
+      parser.parseTrace();
+    }
+    return parser.expectedMessages.remove(replayId);
+  }
+
+  public static long getReplayId(final long parentId, final int childNo) {
+    if (parser == null) {
+      parser = new TraceParser();
+      parser.parseTrace();
+    }
+    return parser.mappedActors.get(new TraceParser.ActorNode(parentId, childNo));
+  }
+
+  public static boolean isActorInTrace(final long parentId, final int childNo) {
+    if (parser == null) {
+      parser = new TraceParser();
+      parser.parseTrace();
+    }
+    return parser.mappedActors.containsKey(new TraceParser.ActorNode(parentId, childNo));
+  }
+
+  private TraceParser() {
+    assert VmSettings.REPLAY;
+  }
+
+  private void parseTrace() {
+    File f = new File(VmSettings.TRACE_FILE + ".trace");
+    File sf = new File(VmSettings.TRACE_FILE + ".sym");
+    HashMap<Long, List<Long>> unmappedActors = new HashMap<>(); // maps message to created actors
+    HashMap<Long, Queue<Long>> unmappedPromises = new HashMap<>(); // maps message to created promises
+    HashMap<Long, Integer> numChildren = new HashMap<>(); // maps actor id to #foundchildren
+
+    VM.println("Parsing Trace ...");
+
+    // create mapping from old to new symbol ids
+    try (FileInputStream sfos = new FileInputStream(sf);
+        BufferedReader br = new BufferedReader(new InputStreamReader(sfos))) {
+      br.lines().forEach((l) -> {
+
+        String[] a = l.split(":", 2);
+        symbolMapping.put(Short.parseShort(a[0]), Symbols.symbolFor(a[1]));
+      });
+    } catch (FileNotFoundException e) {
+      throw new RuntimeException(e);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    // parsing trace-file
+    try (FileInputStream fos = new FileInputStream(f); FileChannel channel = fos.getChannel()) {
+      channel.read(b);
+      b.flip();
+      while (channel.position() < channel.size() || b.remaining() > 0) {
+        if (!b.hasRemaining()) {
+          b.clear();
+          channel.read(b);
+          b.flip();
+        }
+        byte type = b.get();
+
+        long cause;
+        switch (type) {
+          case ACTOR_CREATION:
+            long id = b.getLong(); // actor id
+            cause = b.getLong(); // causal
+            if (!unmappedActors.containsKey(cause)) {
+              unmappedActors.put(cause, new ArrayList<>());
+            }
+            unmappedActors.get(cause).add(id);
+            b.getShort(); // type
+            parsedActors++;
+            break;
+          case MAILBOX:
+            currentMessage = b.getLong(); // base msg id
+            currentMailbox = b.getInt(); // mailboxno
+            currentReceiver = b.getLong(); // receiver
+            msgNo = 0;
+            break;
+          case MAILBOX_CONTD:
+
+            currentMessage = b.getLong(); // base msg id
+            currentMailbox = b.getInt(); // mailboxno
+            currentReceiver = b.getLong(); // receiver
+            int offset = b.getInt(); // offset
+            currentMessage += offset;
+            msgNo = offset;
+            break;
+          case PROMISE_CHAINED:
+            b.getLong(); // parent
+            b.getLong(); // child
+            break;
+          case PROMISE_CREATION:
+            long pid  = b.getLong(); // promise id
+            cause = b.getLong(); // causal message
+            if (!unmappedPromises.containsKey(cause)) {
+              unmappedPromises.put(cause, new LinkedList<>());
+            }
+            unmappedPromises.get(cause).add(pid);
+            break;
+          case PROMISE_RESOLUTION:
+            b.getLong(); // promise id
+            b.getLong(); // resolving msg
+            parseParameter(); // param
+            break;
+          case THREAD:
+            b.compact();
+            channel.read(b);
+            b.flip();
+            b.get(); // thread id
+            b.getLong(); // time millis
+            break;
+          default:
+            parsedMessages++;
+            assert (type & MESSAGE_BIT) != 0;
+            if (unmappedActors.containsKey(currentMessage)) {
+              for (long l : unmappedActors.remove(currentMessage)) {
+                if (!numChildren.containsKey(currentReceiver)) {
+                  numChildren.put(currentReceiver, 0);
+                }
+                mappedActors.put(new ActorNode(currentReceiver, numChildren.get(currentReceiver)), l);
+                numChildren.put(currentReceiver, numChildren.get(currentReceiver) + 1);
+              }
+            }
+            parseMessage(type, unmappedPromises.remove(currentMessage)); // messages
+            break;
+        }
+      }
+
+    } catch (FileNotFoundException e) {
+      throw new RuntimeException(e);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    assert unmappedActors.isEmpty();
+    assert unmappedPromises.isEmpty();
+
+    VM.println("Trace with " + parsedMessages + " Messages and " + parsedActors + " Actors sucessfully parsed!");
+  }
+
+  private void parseMessage(final byte type, final Queue<Long> createdPromises) {
+    long promid = 0;
+    // promise msg
+    if ((type & PROMISE_BIT) > 0) {
+      promid = b.getLong(); // promise
+    }
+
+    long sender = b.getLong(); // sender
+    b.getLong(); // causal message
+    short sym = b.getShort(); // selector
+
+    if (!expectedMessages.containsKey(currentReceiver)) {
+      expectedMessages.put(currentReceiver, new PriorityQueue<>());
+    }
+
+    if ((type & PROMISE_BIT) > 0) {
+      expectedMessages.get(currentReceiver).add(new PromiseMessage(sender, symbolMapping.get(sym), promid, currentMailbox, msgNo, createdPromises));
+    } else {
+      expectedMessages.get(currentReceiver).add(new Message(sender, symbolMapping.get(sym), currentMailbox, msgNo, createdPromises));
+    }
+
+    // timestamp
+    if ((type & TIMESTAMP_BIT) > 0) {
+      b.getLong();
+      b.getLong();
+    }
+
+    // params
+    if ((type & PARAMETER_BIT) > 0) {
+      byte numParam = b.get();
+
+      for (int i = 0; i < numParam; i++) {
+        parseParameter();
+      }
+    }
+    currentMessage++;
+    msgNo++;
+
+  }
+
+  private void parseParameter() {
+    byte type = b.get();
+    switch (ActorExecutionTrace.ParamTypes.values()[type]) {
+      case False:
+        break;
+      case True:
+        break;
+      case Long:
+        b.getLong();
+        break;
+      case Double:
+        b.getDouble();
+        break;
+      case Promise:
+        b.getLong();
+        break;
+      case Resolver:
+        b.getLong();
+        break;
+      case Object:
+        b.getShort();
+        break;
+      case String:
+        break;
+      default:
+        break;
+    }
+  }
+
+  private static class ActorNode implements Comparable<ActorNode> {
+    final long actorId;
+    final int childNo;
+
+    ActorNode(final long actorId, final int childNo) {
+      super();
+      this.actorId = actorId;
+      this.childNo = childNo;
+    }
+
+    @Override
+    public int compareTo(final ActorNode o) {
+      int i = Long.compare(actorId, o.actorId);
+      if (i != 0) {
+        i = Long.compare(childNo, o.childNo);
+      }
+
+      return i;
+    }
+
+    @Override
+    public int hashCode() {
+      return (int) (actorId ^ childNo);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+      if (obj instanceof ActorNode) {
+        ActorNode an = (ActorNode) obj;
+        return (this.actorId == an.actorId && this.childNo == an.childNo);
+      }
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      return "" + actorId + ":" + childNo;
+    }
+  }
+
+  public static class Message implements Comparable<Message> {
+    public final long sender;
+    public final SSymbol symbol;
+    public final int mailboxNo;
+    public final int messageNo;
+    public final Queue<Long> createdPromises;
+
+    public Message(final long sender, final SSymbol symbol, final int mb, final int no, final Queue<Long> createdPromises) {
+      super();
+      this.sender = sender;
+      this.symbol = symbol;
+      this.mailboxNo = mb;
+      this.messageNo = no;
+      this.createdPromises = createdPromises;
+    }
+
+    @Override
+    public int compareTo(final Message o) {
+      if (mailboxNo == o.mailboxNo) {
+        return messageNo - o.messageNo;
+      }
+
+      return mailboxNo - o.mailboxNo;
+    }
+  }
+
+  public static class PromiseMessage extends Message{
+    public final long pId;
+
+    public PromiseMessage(final long sender, final SSymbol symbol, final long pId, final int mb, final int no, final Queue<Long> createdPromises) {
+      super(sender, symbol, mb, no, createdPromises);
+      this.pId = pId;
+    }
+  }
+}

--- a/src/tools/concurrency/TraceParser.java
+++ b/src/tools/concurrency/TraceParser.java
@@ -19,6 +19,7 @@ import som.VM;
 import som.vm.Symbols;
 import som.vm.VmSettings;
 import som.vmobjects.SSymbol;
+import tools.TraceData;
 
 
 
@@ -31,16 +32,10 @@ public final class TraceParser {
   private static final byte THREAD = 6;
   private static final byte MAILBOX_CONTD = 7;
 
-  private static final byte MESSAGE_BIT = (byte) 0x80;
-  private static final byte PROMISE_BIT = 0x40;
-  private static final byte TIMESTAMP_BIT = 0x20;
-  private static final byte PARAMETER_BIT = 0x10;
-
-
   private final HashMap<Short, SSymbol> symbolMapping = new HashMap<>();
   private ByteBuffer b = ByteBuffer.allocate(ActorExecutionTrace.BUFFER_SIZE);
   private final HashMap<Long, ActorNode> mappedActors = new HashMap<>();
-  private final HashMap<Long, Queue<Message>> expectedMessages = new HashMap<>();
+  private final HashMap<Long, Queue<MessageRecord>> expectedMessages = new HashMap<>();
   private long currentReceiver;
   private long currentMessage;
   private int currentMailbox;
@@ -50,7 +45,7 @@ public final class TraceParser {
 
   private static TraceParser parser;
 
-  public static synchronized Queue<Message> getExpectedMessages(final long replayId) {
+  public static synchronized Queue<MessageRecord> getExpectedMessages(final long replayId) {
     if (parser == null) {
       parser = new TraceParser();
       parser.parseTrace();
@@ -71,19 +66,12 @@ public final class TraceParser {
     assert VmSettings.REPLAY;
   }
 
-  private void parseTrace() {
-    File f = new File(VmSettings.TRACE_FILE + ".trace");
-    File sf = new File(VmSettings.TRACE_FILE + ".sym");
-    HashMap<Long, List<Long>> unmappedActors = new HashMap<>(); // maps message to created actors
-    HashMap<Long, Queue<Long>> unmappedPromises = new HashMap<>(); // maps message to created promises
-
-    VM.println("Parsing Trace ...");
-
+  private void parseSymbols() {
+    File symbolFile = new File(VmSettings.TRACE_FILE + ".sym");
     // create mapping from old to new symbol ids
-    try (FileInputStream sfos = new FileInputStream(sf);
-        BufferedReader br = new BufferedReader(new InputStreamReader(sfos))) {
+    try (FileInputStream fis = new FileInputStream(symbolFile);
+        BufferedReader br = new BufferedReader(new InputStreamReader(fis))) {
       br.lines().forEach((l) -> {
-
         String[] a = l.split(":", 2);
         symbolMapping.put(Short.parseShort(a[0]), Symbols.symbolFor(a[1]));
       });
@@ -92,12 +80,22 @@ public final class TraceParser {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
 
-    // parsing trace-file
-    try (FileInputStream fos = new FileInputStream(f); FileChannel channel = fos.getChannel()) {
+  private void parseTrace() {
+    File traceFile = new File(VmSettings.TRACE_FILE + ".trace");
+
+    HashMap<Long, List<Long>> unmappedActors = new HashMap<>(); // maps message to created actors
+    HashMap<Long, Queue<Long>> unmappedPromises = new HashMap<>(); // maps message to created promises
+
+    VM.println("Parsing Trace ...");
+    parseSymbols();
+
+    try (FileInputStream fis = new FileInputStream(traceFile); FileChannel channel = fis.getChannel()) {
       channel.read(b);
-      b.flip();
+      b.flip(); // prepare for reading from buffer
       while (channel.position() < channel.size() || b.remaining() > 0) {
+        // read from file if buffer is empty
         if (!b.hasRemaining()) {
           b.clear();
           channel.read(b);
@@ -124,7 +122,6 @@ public final class TraceParser {
             msgNo = 0;
             break;
           case MAILBOX_CONTD:
-
             currentMessage = b.getLong(); // base msg id
             currentMailbox = b.getInt(); // mailboxno
             currentReceiver = b.getLong(); // receiver
@@ -158,7 +155,7 @@ public final class TraceParser {
             break;
           default:
             parsedMessages++;
-            assert (type & MESSAGE_BIT) != 0;
+            assert (type & TraceData.MESSAGE_BASE) != 0;
             if (unmappedActors.containsKey(currentMessage)) {
               // necessary as the receivers creation event hasn't been parsed yet
               if (!mappedActors.containsKey(currentReceiver)) {
@@ -185,7 +182,6 @@ public final class TraceParser {
     }
 
     assert unmappedActors.isEmpty();
-    assert unmappedPromises.isEmpty();
 
     VM.println("Trace with " + parsedMessages + " Messages and " + parsedActors + " Actors sucessfully parsed!");
   }
@@ -193,7 +189,7 @@ public final class TraceParser {
   private void parseMessage(final byte type, final Queue<Long> createdPromises) {
     long promid = 0;
     // promise msg
-    if ((type & PROMISE_BIT) > 0) {
+    if ((type & TraceData.PROMISE_BIT) > 0) {
       promid = b.getLong(); // promise
     }
 
@@ -205,20 +201,20 @@ public final class TraceParser {
       expectedMessages.put(currentReceiver, new PriorityQueue<>());
     }
 
-    if ((type & PROMISE_BIT) > 0) {
-      expectedMessages.get(currentReceiver).add(new PromiseMessage(sender, symbolMapping.get(sym), promid, currentMailbox, msgNo, createdPromises));
+    if ((type & TraceData.PROMISE_BIT) > 0) {
+      expectedMessages.get(currentReceiver).add(new PromiseMessageRecord(sender, symbolMapping.get(sym), promid, currentMailbox, msgNo, createdPromises));
     } else {
-      expectedMessages.get(currentReceiver).add(new Message(sender, symbolMapping.get(sym), currentMailbox, msgNo, createdPromises));
+      expectedMessages.get(currentReceiver).add(new MessageRecord(sender, symbolMapping.get(sym), currentMailbox, msgNo, createdPromises));
     }
 
     // timestamp
-    if ((type & TIMESTAMP_BIT) > 0) {
+    if ((type & TraceData.TIMESTAMP_BIT) > 0) {
       b.getLong();
       b.getLong();
     }
 
     // params
-    if ((type & PARAMETER_BIT) > 0) {
+    if ((type & TraceData.PARAMETER_BIT) > 0) {
       byte numParam = b.get();
 
       for (int i = 0; i < numParam; i++) {
@@ -305,14 +301,14 @@ public final class TraceParser {
     }
   }
 
-  public static class Message implements Comparable<Message> {
+  public static class MessageRecord implements Comparable<MessageRecord> {
     public final long sender;
     public final SSymbol symbol;
     public final int mailboxNo;
     public final int messageNo;
     public final Queue<Long> createdPromises;
 
-    public Message(final long sender, final SSymbol symbol, final int mb, final int no, final Queue<Long> createdPromises) {
+    public MessageRecord(final long sender, final SSymbol symbol, final int mb, final int no, final Queue<Long> createdPromises) {
       super();
       this.sender = sender;
       this.symbol = symbol;
@@ -322,7 +318,7 @@ public final class TraceParser {
     }
 
     @Override
-    public int compareTo(final Message o) {
+    public int compareTo(final MessageRecord o) {
       if (mailboxNo == o.mailboxNo) {
         return messageNo - o.messageNo;
       }
@@ -331,10 +327,10 @@ public final class TraceParser {
     }
   }
 
-  public static class PromiseMessage extends Message{
+  public static class PromiseMessageRecord extends MessageRecord{
     public final long pId;
 
-    public PromiseMessage(final long sender, final SSymbol symbol, final long pId, final int mb, final int no, final Queue<Long> createdPromises) {
+    public PromiseMessageRecord(final long sender, final SSymbol symbol, final long pId, final int mb, final int no, final Queue<Long> createdPromises) {
       super(sender, symbol, mb, no, createdPromises);
       this.pId = pId;
     }

--- a/src/tools/concurrency/TracingActors.java
+++ b/src/tools/concurrency/TracingActors.java
@@ -1,0 +1,255 @@
+package tools.concurrency;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+
+import som.VM;
+import som.interpreter.actors.Actor;
+import som.interpreter.actors.EventualMessage;
+import som.interpreter.actors.EventualMessage.PromiseMessage;
+import som.vm.VmSettings;
+import tools.concurrency.TraceParser.MessageRecord;
+import tools.debugger.WebDebugger;
+
+public class TracingActors {
+  public static class TracingActor extends Actor {
+    protected final long actorId;
+    protected int mailboxNumber;
+
+    public TracingActor() {
+      super();
+      if (Thread.currentThread() instanceof ActorProcessingThread) {
+        ActorProcessingThread t = (ActorProcessingThread) Thread.currentThread();
+        this.actorId = t.generateActorId();
+      } else {
+        actorId = 0; // main actor
+      }
+    }
+
+    public int getAndIncrementMailboxNumber() {
+      return mailboxNumber++;
+    }
+
+    public long getActorId() {
+      return actorId;
+    }
+  }
+
+  public static final class ReplayActor extends TracingActor{
+    protected int children;
+    protected final long replayId;
+    protected final Queue<MessageRecord> expectedMessages;
+    protected final ArrayList<EventualMessage> leftovers = new ArrayList<>();
+    protected final Queue<Long> replayPromiseIds;
+    private static List<ReplayActor> actorList;
+
+    static {
+      if (VmSettings.DEBUG_MODE) {
+        actorList = new ArrayList<>();
+      }
+    }
+
+    @TruffleBoundary
+    public ReplayActor() {
+      isExecuting = false;
+      this.executor = new ExecAllMessagesReplay(this);
+      if (Thread.currentThread() instanceof ActorProcessingThread) {
+        ActorProcessingThread t = (ActorProcessingThread) Thread.currentThread();
+        ReplayActor parent = (ReplayActor) t.currentMessage.getTarget();
+        long parentId = parent.getReplayActorId();
+        int childNo = parent.addChild();
+
+        replayId = TraceParser.getReplayId(parentId, childNo);
+        expectedMessages = TraceParser.getExpectedMessages(replayId);
+
+      } else {
+        replayId = 0;
+        expectedMessages = TraceParser.getExpectedMessages(0L);
+
+      }
+      replayPromiseIds = new LinkedList<>();
+
+      if (VmSettings.DEBUG_MODE) {
+        synchronized (actorList) { actorList.add(this); }
+      }
+    }
+
+    @Override
+    @TruffleBoundary
+    public synchronized void send(final EventualMessage msg) {
+      assert msg.getTarget() == this;
+
+      if (this.firstMessage == null) {
+        firstMessage = msg;
+      } else {
+        this.appendToMailbox(msg);
+      }
+
+      // actor remains dormant until the expected message arrives
+      if ((!this.isExecuting) && this.replayCanProcess(msg)) {
+        this.isExecuting = true;
+        this.executeOnPool();
+      }
+    }
+
+    /**
+     * Prints a list of expected Messages and remaining mailbox content.
+     * @return true if there are actors expecting messages, false otherwise.
+     */
+    public static boolean printMissingMessages() {
+      if (!(VmSettings.REPLAY && VmSettings.DEBUG_MODE)) {
+        return false;
+      }
+
+      boolean result = false;
+      for (ReplayActor a : actorList) {
+        ReplayActor ra = a;
+        if (ra.getReplayExpectedMessages() != null && ra.getReplayExpectedMessages().peek() != null) {
+          result = true; // program did not execute all messages
+          if (ra.getReplayExpectedMessages().peek() instanceof TraceParser.PromiseMessageRecord) {
+            VM.println(a.getName() + " [" + ra.getReplayActorId() + "] expecting PromiseMessage " + ra.getReplayExpectedMessages().peek().symbol + " from " + ra.getReplayExpectedMessages().peek().sender + " PID " + ((TraceParser.PromiseMessageRecord) ra.getReplayExpectedMessages().peek()).pId);
+          } else {
+            VM.println(a.getName() + " [" + ra.getReplayActorId() + "] expecting Message" + ra.getReplayExpectedMessages().peek().symbol + " from " + ra.getReplayExpectedMessages().peek().sender);
+          }
+
+          if (a.firstMessage != null) {
+            printMsg(a.firstMessage);
+            if (a.mailboxExtension != null) {
+              for (EventualMessage em : a.mailboxExtension) {
+                printMsg(em);
+              }
+            }
+          }
+
+          for (EventualMessage em : a.leftovers) {
+            printMsg(em);
+          }
+        } else if (a.firstMessage != null || a.mailboxExtension != null) {
+
+          int n = a.firstMessage != null ?  1 : 0;
+          n += a.mailboxExtension != null ? a.mailboxExtension.size() : 0;
+
+          VM.println(a.getName() + " [" + a.getReplayActorId() + "] has " + n + " unexpected messages");
+        }
+      }
+      return result;
+    }
+
+    private static void printMsg(final EventualMessage msg) {
+      if (msg instanceof PromiseMessage) {
+        VM.println("\t" + "PromiseMessage " + msg.getSelector() + " from " + ((ReplayActor) msg.getSender()).getReplayActorId() + " PID " + ((PromiseMessage) msg).getPromise().getReplayPromiseId());
+      } else {
+        VM.println("\t" + "Message" + msg.getSelector() + " from " + ((ReplayActor) msg.getSender()).getReplayActorId());
+      }
+    }
+
+    protected boolean replayCanProcess(final EventualMessage msg) {
+      if (!VmSettings.REPLAY) {
+        return true;
+      }
+
+      assert getReplayExpectedMessages() != null;
+
+      if (getReplayExpectedMessages().size() == 0) {
+        // actor no longer executes messages
+        return false;
+      }
+
+      MessageRecord other = getReplayExpectedMessages().peek();
+
+      // handle promise messages
+      if (other instanceof TraceParser.PromiseMessageRecord) {
+        if (msg instanceof PromiseMessage) {
+          return ((PromiseMessage) msg).getPromise().getReplayPromiseId() == ((TraceParser.PromiseMessageRecord) other).pId;
+        } else {
+          return false;
+        }
+      }
+
+      return msg.getSelector().equals(other.symbol) && ((ReplayActor) msg.getSender()).getReplayActorId() == other.sender;
+    }
+
+    public long getReplayActorId() {
+      return replayId;
+    }
+
+    protected int addChild() {
+      return children++;
+    }
+
+    protected Queue<MessageRecord> getReplayExpectedMessages() {
+      return expectedMessages;
+    }
+
+    public Queue<Long> getReplayPromiseIds() {
+      return replayPromiseIds;
+    }
+
+    private static class ExecAllMessagesReplay extends ExecAllMessages {
+      ExecAllMessagesReplay(final Actor actor) {
+        super(actor);
+      }
+
+      @Override
+      protected void processCurrentMessages(final ActorProcessingThread currentThread, final WebDebugger dbg) {
+        assert actor instanceof ReplayActor;
+        assert (size > 0);
+
+        ReplayActor a = (ReplayActor) actor;
+
+        boolean cont = true;
+        Queue<EventualMessage> todo = new LinkedList<>();
+        List<EventualMessage> rem = ((ReplayActor) actor).leftovers;
+
+          if (a.replayCanProcess(firstMessage)) {
+            todo.add(firstMessage);
+            if (a.getReplayExpectedMessages().peek().createdPromises != null) {
+              a.getReplayPromiseIds().addAll(a.getReplayExpectedMessages().peek().createdPromises);
+            }
+            a.getReplayExpectedMessages().remove();
+          } else {
+            rem.add(firstMessage);
+          }
+
+          if (mailboxExtension != null) {
+            for (EventualMessage msg: mailboxExtension) {
+              rem.add(msg);
+            }
+          }
+
+          while (cont) {
+            cont = false;
+            for (EventualMessage msg: rem) {
+              if (a.replayCanProcess(msg)) {
+                todo.add(msg);
+                if (a.getReplayExpectedMessages().peek().createdPromises != null) {
+                  a.getReplayPromiseIds().addAll(a.getReplayExpectedMessages().peek().createdPromises);
+                }
+                a.getReplayExpectedMessages().remove();
+                rem.remove(msg);
+                cont = true;
+                break;
+              }
+            }
+          }
+
+          baseMessageId = currentThread.generateMessageBaseId(todo.size());
+          currentThread.currentMessageId = baseMessageId;
+
+          for (EventualMessage msg : todo) {
+            currentThread.currentMessage = msg;
+            handleBreakPoints(firstMessage, dbg);
+            msg.execute();
+            currentThread.currentMessageId += 1;
+          }
+
+          currentThread.createdMessages += todo.size();
+          ActorExecutionTrace.mailboxExecutedReplay(todo, baseMessageId, currentMailboxNo, actor);
+      }
+    }
+  }
+}

--- a/src/tools/debugger/session/BreakpointActor.java
+++ b/src/tools/debugger/session/BreakpointActor.java
@@ -241,10 +241,8 @@ public class BreakpointActor extends Actor {
   public void updateInbox(final EventualMessage msg, final boolean addition) {
     if (addition) {
       // messageAddedToActorEvent
-      logMessageAddedToMailbox(msg);
     } else {
       // messageRemovedFromActorEvent
-      logMessageBeingExecuted(msg);
     }
   }
 }

--- a/tests/replay/test.sh
+++ b/tests/replay/test.sh
@@ -2,54 +2,44 @@
 # quit on first error
 set -e
 
-declare -a Savina=("PingPong 1 0 40000"
-"Counting 1 0 200000"
-"ForkJoinThroughput 1 0 3000:60"
-"ForkJoinActorCreation 1 0 40000"
-"ThreadRing 1 0 100:100000"
-"Chameneos 1 0 100:100000"
-"BigContention 1 0 2000:120"
-"ConcurrentDictionary 1 0 20:1000:20"
-"ConcurrentSortedLinkedList 1 0 10:1500:10:1"
-"ProducerConsumerBoundedBuffer 1 0 40:10:10:60"
-"Philosophers 1 0 20:5000"
-"SleepingBarber 1 0 2500:1000:1000:1000"
-"CigaretteSmokers 1 0 10000:200"
-"LogisticsMapSeries 1 0 25000:10:346"
-"BankTransaction 1 0 1000:100000"
-"RadixSort 1 0 50000:65536:74755"
-"UnbalancedCobwebbedTree 1 0 100000:10:500:100"
-"TrapezoidalApproximation 1 0 100:1000000:1:5"
-"AStarSearch 1 0 100:20"
-"NQueens 1 0 20:10:4") 
+if [ "$1" = "1" ]
+then
+  declare -a Savina=(
+    "PingPong 1 0 40000"
+    "Counting 1 0 200000"
+    "ForkJoinThroughput 1 0 3000:60"
+    "ForkJoinActorCreation 1 0 40000"
+    "ThreadRing 1 0 100:100000"
+    "Chameneos 1 0 100:100000"
+    "BigContention 1 0 2000:120"
+    "ConcurrentDictionary 1 0 20:1000:20"
+    "ConcurrentSortedLinkedList 1 0 10:1500:10:1"
+    "ProducerConsumerBoundedBuffer 1 0 40:10:10:60"
+    "Philosophers 1 0 20:5000"
+    "SleepingBarber 1 0 2500:1000:1000:1000"
+    "CigaretteSmokers 1 0 10000:200"
+    "LogisticsMapSeries 1 0 25000:10:346"
+  ) 
 
-declare -a Savina=("PingPong 1 0 40000"
-"Counting 1 0 200000"
-"ForkJoinThroughput 1 0 3000:60"
-"ForkJoinActorCreation 1 0 40000"
-"ThreadRing 1 0 100:100000"
-"Chameneos 1 0 100:100000"
-"BigContention 1 0 2000:120"
-"ConcurrentDictionary 1 0 20:1000:20"
-"ConcurrentSortedLinkedList 1 0 10:1500:10:1"
-"ProducerConsumerBoundedBuffer 1 0 40:10:10:60"
-"Philosophers 1 0 20:5000"
-"SleepingBarber 1 0 2500:1000:1000:1000"
-"CigaretteSmokers 1 0 10000:200"
-"LogisticsMapSeries 1 0 25000:10:346"
-"BankTransaction 1 0 1000:100000"
-"RadixSort 1 0 50000:65536:74755"
-"UnbalancedCobwebbedTree 1 0 100000:10:500:100"
-"TrapezoidalApproximation 1 0 100:1000000:1:5"
-"AStarSearch 1 0 100:20"
-"NQueens 1 0 20:10:4")
+  declare -a Validation=()
+else
+  declare -a Savina=(
+    "BankTransaction 1 0 1000:100000"
+    "RadixSort 1 0 50000:65536:74755"
+    "UnbalancedCobwebbedTree 1 0 100000:10:500:100"
+    "TrapezoidalApproximation 1 0 100:1000000:1:5"
+    "AStarSearch 1 0 100:20"
+    "NQueens 1 0 20:10:4"
+  ) 
 
-declare -a Validation=("Counting 100 0 1000"
-"Philosophers 100 0 5:5 25"
-"DeadLock 100 0 4:2:3"
-"Messages 100 0 1000"
-"Sequence 100 0 100"
-) 
+  declare -a Validation=(
+    "Counting 100 0 1000"
+    "Philosophers 100 0 5:5 25"
+    "DeadLock 100 0 4:2:3"
+    "Messages 100 0 1000"
+    "Sequence 100 0 100"
+  )
+fi
 
 ## Determine absolute path of script
 pushd `dirname $0` > /dev/null

--- a/tests/replay/test.sh
+++ b/tests/replay/test.sh
@@ -2,7 +2,7 @@
 # quit on first error
 set -e
 
-declare -a arr=("PingPong 1 0 40000"
+declare -a Savina=("PingPong 1 0 40000"
 "Counting 1 0 200000"
 "ForkJoinThroughput 1 0 3000:60"
 "ForkJoinActorCreation 1 0 40000"
@@ -23,6 +23,34 @@ declare -a arr=("PingPong 1 0 40000"
 "AStarSearch 1 0 100:20"
 "NQueens 1 0 20:10:4") 
 
+declare -a Savina=("PingPong 1 0 40000"
+"Counting 1 0 200000"
+"ForkJoinThroughput 1 0 3000:60"
+"ForkJoinActorCreation 1 0 40000"
+"ThreadRing 1 0 100:100000"
+"Chameneos 1 0 100:100000"
+"BigContention 1 0 2000:120"
+"ConcurrentDictionary 1 0 20:1000:20"
+"ConcurrentSortedLinkedList 1 0 10:1500:10:1"
+"ProducerConsumerBoundedBuffer 1 0 40:10:10:60"
+"Philosophers 1 0 20:5000"
+"SleepingBarber 1 0 2500:1000:1000:1000"
+"CigaretteSmokers 1 0 10000:200"
+"LogisticsMapSeries 1 0 25000:10:346"
+"BankTransaction 1 0 1000:100000"
+"RadixSort 1 0 50000:65536:74755"
+"UnbalancedCobwebbedTree 1 0 100000:10:500:100"
+"TrapezoidalApproximation 1 0 100:1000000:1:5"
+"AStarSearch 1 0 100:20"
+"NQueens 1 0 20:10:4")
+
+declare -a Validation=("Counting 100 0 1000"
+"Philosophers 100 0 5:5 25"
+"DeadLock 100 0 4:2:3"
+"Messages 100 0 1000"
+"Sequence 100 0 100"
+) 
+
 ## Determine absolute path of script
 pushd `dirname $0` > /dev/null
 SCRIPT_PATH=`pwd`
@@ -30,16 +58,29 @@ popd > /dev/null
 
 SOM_DIR=$SCRIPT_PATH/../..
 
-for args in "${arr[@]}"  
-do 
-	echo "$args"
-	echo "Tracing:"
-	$SOM_DIR/som -G -JXmx1500m -vmd -at core-lib/Benchmarks/AsyncHarness.som Savina.$args
-	echo ""
-        echo "Replay:"
-	$SOM_DIR/som -G -JXmx1500m -vmd -at -r core-lib/Benchmarks/AsyncHarness.som Savina.$args
-	echo ""
-	echo "========================================================"
-	echo ""
-done
+for args in "${Savina[@]}"   
+do  
+  echo "$args" 
+  echo "Tracing:" 
+  $SOM_DIR/som -G -JXmx1500m -vmd -at core-lib/Benchmarks/AsyncHarness.som Savina.$args 
+  echo "" 
+  echo "Replay:" 
+  $SOM_DIR/som -G -JXmx1500m -vmd -at -r core-lib/Benchmarks/AsyncHarness.som Savina.$args 
+  echo "" 
+  echo "========================================================" 
+  echo "" 
+done 
 
+for args in "${Validation[@]}"  
+do 
+  echo "$args"
+  echo "Tracing:"
+  $SOM_DIR/som -G -JXmx1500m -vmd -at core-lib/Benchmarks/ImpactHarness.som Validation.$args | grep -o 'success: .*' > $SCRIPT_PATH/orig.txt
+  echo ""
+  echo "Replay:"
+  $SOM_DIR/som -G -JXmx1500m -vmd -at -r core-lib/Benchmarks/ImpactHarness.som Validation.$args | grep -o 'success: .*' > $SCRIPT_PATH/repl.txt
+  diff $SCRIPT_PATH/orig.txt $SCRIPT_PATH/repl.txt
+  echo ""
+  echo "========================================================"
+  echo ""
+done

--- a/tests/replay/test.sh
+++ b/tests/replay/test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# quit on first error
+set -e
+
+declare -a arr=("PingPong 1 0 40000"
+"Counting 1 0 200000"
+"ForkJoinThroughput 1 0 3000:60"
+"ForkJoinActorCreation 1 0 40000"
+"ThreadRing 1 0 100:100000"
+"Chameneos 1 0 100:100000"
+"BigContention 1 0 2000:120"
+"ConcurrentDictionary 1 0 20:1000:20"
+"ConcurrentSortedLinkedList 1 0 10:1500:10:1"
+"ProducerConsumerBoundedBuffer 1 0 40:10:10:60"
+"Philosophers 1 0 20:5000"
+"SleepingBarber 1 0 2500:1000:1000:1000"
+"CigaretteSmokers 1 0 10000:200"
+"LogisticsMapSeries 1 0 25000:10:346"
+"BankTransaction 1 0 1000:100000"
+"RadixSort 1 0 50000:65536:74755"
+"UnbalancedCobwebbedTree 1 0 100000:10:500:100"
+"TrapezoidalApproximation 1 0 100:1000000:1:5"
+"AStarSearch 1 0 100:20"
+"NQueens 1 0 20:10:4") 
+
+## Determine absolute path of script
+pushd `dirname $0` > /dev/null
+SCRIPT_PATH=`pwd`
+popd > /dev/null
+
+SOM_DIR=$SCRIPT_PATH/../..
+
+for args in "${arr[@]}"  
+do 
+	echo "$args"
+	echo "Tracing:"
+	$SOM_DIR/som -G -JXmx1500m -vmd -at core-lib/Benchmarks/AsyncHarness.som Savina.$args
+	echo ""
+        echo "Replay:"
+	$SOM_DIR/som -G -JXmx1500m -vmd -at -r core-lib/Benchmarks/AsyncHarness.som Savina.$args
+	echo ""
+	echo "========================================================"
+	echo ""
+done
+

--- a/tools/kompos/src/history-data.ts
+++ b/tools/kompos/src/history-data.ts
@@ -110,8 +110,9 @@ export class HistoryData {
           break;
         case 5:
           // 8 byte message base id
-          this.currentReceiver = (data.getInt32(i + 12) + ":" + data.getInt32(i + 8)); // receiver id
-          i += 16;
+          // 4 byte mailboxno
+          this.currentReceiver = (data.getInt32(i + 16) + ":" + data.getInt32(i + 12)); // receiver id
+          i += 20;
           break;
         case 6:
           data.getInt8(i); // Thread
@@ -120,9 +121,10 @@ export class HistoryData {
           break;
         case 7:
           // 8 byte message base id
-          this.currentReceiver = (data.getInt32(i + 12) + ":" + data.getInt32(i + 8)); // receiver id
-          data.getInt16(i + 16); // id offset
-          i += 18;
+          // 4 byte mailboxno
+          this.currentReceiver = (data.getInt32(i + 16) + ":" + data.getInt32(i + 12)); // receiver id
+          data.getInt32(i + 20); // id offset
+          i += 24;
           break;
 
         default:


### PR DESCRIPTION
Replay feature enforces the message order recorded in the trace file. Messages that don't fit the next expected message of an actor are put into a leftover queue. After a fitting message was received, leftovers and remaining mailbox are checked for other messages that can be executed. The leftovers have a higher priority. Extra messages that are not present in the trace will not be processed (e.g. weren't processed due to shutdown in original run).

Actors that didn't exist in the trace cause an assertion exception.

Replay requires the program parameters to be equal to those of the execution recorded in the trace.
The easiest way to replay, is to use the same command and adding the replay flag `-r`.

- fixed tracefile bugs
- added a mailbox number to the mailbox-events to allow ordering.
- added `-vmd` flag to enable debug output.
- added `-r` flag to enable replay.
- added `-J` flag for JVM flags, e.g. `-JXmx2g`
- removed `DebugActor`, tracing provides the same and more functionality