### PR TITLE
Added method for graphical representation of Truffle Methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
  - Optimize processing of common single messages by avoiding allocation and
    use of object buffer ([issue #90](https://github.com/smarr/SOMns/pull/90))
 
+ - Added option to show methods after parsing in IGV with
+   `-im`/`--igv-parsed-methods` ([issue #110](https://github.com/smarr/SOMns/pull/110))
+
 ## 0.1.0 - 2016-12-15
 
 This is the first tagged version. For previous changes, please refer to the

--- a/som
+++ b/som
@@ -31,6 +31,8 @@ parser.add_argument('-dnu', '--stack-trace-on-dnu', help='Print a stack trace on
 explore = parser.add_argument_group('Explore', 'Investigate Execution')
 explore.add_argument('-i', '--igv', help='dump compilation details to IGV',
                     dest='igv', action='store_true', default=False)
+explore.add_argument('-im', '--igv-parsed-methods', help='dump methods after parsing to IGV',
+                    dest='igv_methods', action='store_true', default=False)
 explore.add_argument('-if', '--igv-to-file', help='dump compilation details to file to be loaded by IGV',
                     dest='igv_to_file', action='store_true', default=False)
 explore.add_argument('-io', '--igv-only', help='only dump named method, use of * allowed. Uses Invokable.toString()',
@@ -190,7 +192,7 @@ if sys.argv[0].endswith('debug'):
     args.perf_warnings = True
     args.background_compilation = False
 
-if args.only_igv:
+if args.only_igv or args.igv_methods:
     args.igv = True
 
 if not args.interpreter:

--- a/som
+++ b/som
@@ -208,6 +208,8 @@ if  not args.interpreter and args.only_igv:
     flags += ['-Dgraal.MethodFilter=' + args.only_igv]
 if not args.interpreter and args.igv_to_file:
     flags += ['-Dgraal.PrintIdealGraphFile=true']
+if args.igv_methods:
+    flags += ['-Dsom.igvDumpAfterParsing=true']
 if args.low_level:
     flags += ['-XX:+UnlockDiagnosticVMOptions', '-XX:+LogCompilation',
               '-XX:+TraceDeoptimization']

--- a/src/som/vm/VmSettings.java
+++ b/src/som/vm/VmSettings.java
@@ -23,6 +23,8 @@ public class VmSettings {
 
   public static final boolean TRUFFLE_DEBUGGER_ENABLED;
 
+  public static final boolean IGV_DUMP_AFTER_PARSING;
+
   public static final String INSTRUMENTATION_PROP = "som.instrumentation";
 
   static {
@@ -56,6 +58,8 @@ public class VmSettings {
 
     DNU_PRINT_STACK_TRACE = getBool("som.printStackTraceOnDNU", false);
     TRUFFLE_DEBUGGER_ENABLED = getBool("som.truffleDebugger", false);
+
+    IGV_DUMP_AFTER_PARSING = getBool("som.igvDumpAfterParsing", false);
   }
 
   private static boolean getBool(final String prop, final boolean defaultVal) {


### PR DESCRIPTION
This change adds support to show methods directly after parsing in IGV.

This can be used with the `-im`/`--igv-parsed-methods` options on the `som` script.