### PR TITLE
Introduce TracingActivityThread base class

### DIFF
--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -430,16 +430,16 @@ public class Actor implements Activity {
       new UncaughtExceptions(), true);
 
   public static final void shutDownActorPool() {
-      actorPool.shutdown();
-      try {
-        actorPool.awaitTermination(10, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        throw new RuntimeException(e);
-      }
-      if (VmSettings.ACTOR_TRACING) {
-        VM.printConcurrencyEntitiesReport("[Total]\tA#" + numCreatedActors + "\t\tM#" + numCreatedMessages + "\t\tP#" + numCreatedPromises);
-        VM.printConcurrencyEntitiesReport("[Unresolved] " + (numCreatedPromises - numResolvedPromises));
-      }
+    actorPool.shutdown();
+    try {
+      actorPool.awaitTermination(10, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    if (VmSettings.ACTOR_TRACING) {
+      VM.printConcurrencyEntitiesReport("[Total]\tA#" + numCreatedActors + "\t\tM#" + numCreatedMessages + "\t\tP#" + numCreatedPromises);
+      VM.printConcurrencyEntitiesReport("[Unresolved] " + (numCreatedPromises - numResolvedPromises));
+    }
   }
 
   public static final void forceSwapBuffers() {

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -1,7 +1,6 @@
 package som.interpreter.actors;
 
 import java.lang.Thread.UncaughtExceptionHandler;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
@@ -9,7 +8,6 @@ import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory;
 import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
@@ -25,7 +23,9 @@ import som.vmobjects.SArray.STransferArray;
 import som.vmobjects.SObject;
 import som.vmobjects.SObjectWithClass.SObjectWithoutFields;
 import tools.ObjectBuffer;
+import tools.TraceData;
 import tools.concurrency.ActorExecutionTrace;
+import tools.concurrency.TracingActivityThread;
 import tools.concurrency.TracingActors.ReplayActor;
 import tools.concurrency.TracingActors.TracingActor;
 import tools.debugger.WebDebugger;
@@ -60,8 +60,6 @@ public class Actor implements Activity {
     }
   }
 
-  /** Used to shift the thread id to the 8 most significant bits. */
-  private static final int THREAD_ID_SHIFT = 56;
   private static final int MAILBOX_EXTENSION_SIZE = 8;
 
   /**
@@ -143,6 +141,9 @@ public class Actor implements Activity {
     }
     return o;
   }
+
+  @Override
+  public long getId() { return 0; }
 
   /**
    * Send the give message to the actor.
@@ -332,39 +333,22 @@ public class Actor implements Activity {
     }
   }
 
-  public static final class ActorProcessingThread extends ForkJoinWorkerThread implements ActivityThread {
+  public static final class ActorProcessingThread extends TracingActivityThread
+      implements ActivityThread {
     public EventualMessage currentMessage;
-    private static AtomicInteger threadIdGen = new AtomicInteger(0);
+
     protected Actor currentlyExecutingActor;
-    protected final long threadId;
-    protected long nextActorId = 1;
-    protected long nextMessageId;
-    protected long nextPromiseId;
-    protected ByteBuffer tracingDataBuffer;
 
     // Used for tracing, accessed by the ExecAllMessages classes
-    public long createdMessages;
     public long currentMessageId;
-    public long resolvedPromises;
 
     protected ActorProcessingThread(final ForkJoinPool pool) {
       super(pool);
-      threadId = threadIdGen.getAndIncrement();
-      if (VmSettings.ACTOR_TRACING) {
-        ActorExecutionTrace.swapBuffer(this);
-        nextActorId = (threadId << THREAD_ID_SHIFT) + 1;
-        nextMessageId = (threadId << THREAD_ID_SHIFT);
-        nextPromiseId = (threadId << THREAD_ID_SHIFT);
-      }
     }
 
     @Override
     public Activity getActivity() {
       return currentMessage.getTarget();
-    }
-
-    public long generateActorId() {
-      return nextActorId++;
     }
 
     public long generateMessageBaseId(final int numMessages) {
@@ -373,18 +357,8 @@ public class Actor implements Activity {
       return result;
     }
 
-    protected long generatePromiseId() {
-      return nextPromiseId++;
-    }
 
-    public ByteBuffer getThreadLocalBuffer() {
-      return tracingDataBuffer;
-    }
-
-    public void setThreadLocalBuffer(final ByteBuffer threadLocalBuffer) {
-      this.tracingDataBuffer = threadLocalBuffer;
-    }
-
+    @Override
     public long getCurrentMessageId() {
       return currentMessageId;
     }
@@ -392,8 +366,8 @@ public class Actor implements Activity {
     @Override
     protected void onTermination(final Throwable exception) {
       if (VmSettings.ACTOR_TRACING) {
-        long createdActors = nextActorId - 1 - (threadId << THREAD_ID_SHIFT);
-        long createdPromises = nextPromiseId - (threadId << THREAD_ID_SHIFT);
+        long createdActors   = nextActivityId - 1 - (threadId << TraceData.ACTIVITY_ID_BITS);
+        long createdPromises = nextPromiseId - (threadId << TraceData.ACTIVITY_ID_BITS);
 
         ActorExecutionTrace.returnBuffer(this.tracingDataBuffer);
         this.tracingDataBuffer = null;

--- a/src/som/interpreter/actors/SPromise.java
+++ b/src/som/interpreter/actors/SPromise.java
@@ -7,7 +7,6 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.RootCallTarget;
 import com.sun.istack.internal.NotNull;
 
-import som.interpreter.actors.Actor.ActorProcessingThread;
 import som.interpreter.actors.EventualMessage.PromiseCallbackMessage;
 import som.interpreter.actors.EventualMessage.PromiseMessage;
 import som.vm.NotYetImplementedException;
@@ -17,6 +16,7 @@ import som.vmobjects.SBlock;
 import som.vmobjects.SClass;
 import som.vmobjects.SObjectWithClass;
 import tools.concurrency.ActorExecutionTrace;
+import tools.concurrency.TracingActivityThread;
 import tools.concurrency.TracingActors.ReplayActor;
 
 
@@ -257,7 +257,7 @@ public class SPromise extends SObjectWithClass {
 
     protected STracingPromise(final Actor owner) {
       super(owner);
-      ActorProcessingThread t = (ActorProcessingThread) Thread.currentThread();
+      TracingActivityThread t = (TracingActivityThread) Thread.currentThread();
       promiseId = t.generatePromiseId();
       ActorExecutionTrace.promiseCreation(promiseId);
     }

--- a/src/som/primitives/TimerPrim.java
+++ b/src/som/primitives/TimerPrim.java
@@ -18,19 +18,19 @@ import som.interpreter.nodes.nary.BinaryComplexOperation;
 @GenerateNodeFactory
 @Primitive(primitive = "actorResolveProm:after:")
 public abstract class TimerPrim extends BinaryComplexOperation{
+  @CompilationFinal private static Timer timer;
+
   protected TimerPrim(final BinaryComplexOperation node) { super(node); }
   protected TimerPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
   @Child protected WrapReferenceNode wrapper = WrapReferenceNodeGen.create();
 
-  @CompilationFinal private static Timer timerThread;
-
   @Specialization
   public final Object doResolveAfter(final VirtualFrame frame, final SResolver resolver, final long timeout) {
-    if (timerThread == null) {
-      timerThread = new Timer();
+    if (timer == null) {
+      timer = new Timer();
     }
-    timerThread.schedule(new TimerTask() {
+    timer.schedule(new TimerTask() {
       @Override
       public void run() {
         ResolvePromiseNode.resolve(wrapper, resolver.getPromise(), true,
@@ -38,5 +38,11 @@ public abstract class TimerPrim extends BinaryComplexOperation{
       }
     }, timeout);
     return true;
+  }
+
+  public static boolean isTimerThread(final Thread t) {
+    // Checkstyle: stop
+    return t.getClass().getName() == "java.util.TimerThread";
+    // Checkstyle: resume
   }
 }

--- a/src/som/primitives/processes/ChannelPrimitives.java
+++ b/src/som/primitives/processes/ChannelPrimitives.java
@@ -44,6 +44,7 @@ import tools.SourceCoordinate.FullSourceCoordinate;
 import tools.concurrency.Tags.ChannelRead;
 import tools.concurrency.Tags.ChannelWrite;
 import tools.concurrency.Tags.ExpressionBreakpoint;
+import tools.concurrency.TracingActivityThread;
 import tools.debugger.nodes.AbstractBreakpointNode;
 import tools.debugger.nodes.BreakpointNodeGen;
 import tools.debugger.nodes.DisabledBreakpointNode;
@@ -79,7 +80,7 @@ public abstract class ChannelPrimitives {
     }
   }
 
-  public static final class ProcessThread extends ForkJoinWorkerThread
+  public static final class ProcessThread extends TracingActivityThread
       implements ActivityThread {
     private Process current;
 
@@ -88,6 +89,11 @@ public abstract class ChannelPrimitives {
     @Override
     public Activity getActivity() {
       return current;
+    }
+
+    @Override
+    public long getCurrentMessageId() {
+      return -1;
     }
   }
 
@@ -118,6 +124,9 @@ public abstract class ChannelPrimitives {
         }
       }
     }
+
+    @Override
+    public long getId() { return 0; }
 
     @Override
     public String getName() {

--- a/src/som/vm/Activity.java
+++ b/src/som/vm/Activity.java
@@ -3,4 +3,5 @@ package som.vm;
 
 public interface Activity {
   String getName();
+  long getId();
 }

--- a/src/tools/TraceData.java
+++ b/src/tools/TraceData.java
@@ -6,4 +6,7 @@ public class TraceData {
   public static final byte PROMISE_BIT = 0x40;
   public static final byte TIMESTAMP_BIT = 0x20;
   public static final byte PARAMETER_BIT = 0x10;
+
+  /** Used to shift the thread id to the 8 most significant bits. */
+  public static final int ACTIVITY_ID_BITS = 56;
 }

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -35,6 +35,7 @@ import som.interpreter.actors.EventualMessage.PromiseMessage;
 import som.interpreter.actors.SFarReference;
 import som.interpreter.actors.SPromise;
 import som.interpreter.actors.SPromise.SResolver;
+import som.primitives.TimerPrim;
 import som.vm.ObjectSystem;
 import som.vm.VmSettings;
 import som.vmobjects.SAbstractObject;
@@ -258,6 +259,10 @@ public class ActorExecutionTrace {
     }
 
     Thread current = Thread.currentThread();
+    if (TimerPrim.isTimerThread(current)) {
+      return;
+    }
+
     assert current instanceof TracingActivityThread;
     TracingActivityThread t = (TracingActivityThread) current;
 

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -30,7 +30,6 @@ import com.sun.management.GarbageCollectionNotificationInfo;
 
 import som.VM;
 import som.interpreter.actors.Actor;
-import som.interpreter.actors.Actor.ActorProcessingThread;
 import som.interpreter.actors.EventualMessage;
 import som.interpreter.actors.EventualMessage.PromiseMessage;
 import som.interpreter.actors.SFarReference;
@@ -146,7 +145,7 @@ public class ActorExecutionTrace {
   }
 
   @TruffleBoundary
-  public static synchronized void swapBuffer(final ActorProcessingThread t) throws IllegalStateException {
+  public static synchronized void swapBuffer(final TracingActivityThread t) throws IllegalStateException {
     returnBuffer(t.getThreadLocalBuffer());
 
     try {
@@ -195,7 +194,7 @@ public class ActorExecutionTrace {
     }
   };
 
-  protected enum ParamTypes{
+  protected enum ParamTypes {
     False,
     True,
     Long,
@@ -216,23 +215,22 @@ public class ActorExecutionTrace {
     }
 
     Thread current = Thread.currentThread();
+    assert current instanceof TracingActivityThread;
 
-    if (current instanceof ActorProcessingThread) {
-      ActorProcessingThread t = (ActorProcessingThread) current;
-      if (t.getThreadLocalBuffer().remaining() < Events.ActorCreation.size) {
-        swapBuffer(t);
-      }
-
-      Object value = actor.getValue();
-      assert value instanceof SClass;
-      SClass actorClass = (SClass) value;
-
-      ByteBuffer b = t.getThreadLocalBuffer();
-      b.put(Events.ActorCreation.id);
-      b.putLong(((TracingActor) actor.getActor()).getActorId()); // id of the created actor
-      b.putLong(t.getCurrentMessageId()); // causal message
-      b.putShort(actorClass.getName().getSymbolId());
+    TracingActivityThread t = (TracingActivityThread) current;
+    if (t.getThreadLocalBuffer().remaining() < Events.ActorCreation.size) {
+      swapBuffer(t);
     }
+
+    Object value = actor.getValue();
+    assert value instanceof SClass;
+    SClass actorClass = (SClass) value;
+
+    ByteBuffer b = t.getThreadLocalBuffer();
+    b.put(Events.ActorCreation.id);
+    b.putLong(actor.getActor().getId()); // id of the created actor
+    b.putLong(t.getCurrentMessageId()); // causal message
+    b.putShort(actorClass.getName().getSymbolId());
   }
 
   public static void promiseCreation(final long promiseId) {
@@ -241,19 +239,17 @@ public class ActorExecutionTrace {
     }
 
     Thread current = Thread.currentThread();
+    assert current instanceof TracingActivityThread;
+    TracingActivityThread t = (TracingActivityThread) current;
 
-    if (current instanceof ActorProcessingThread) {
-      ActorProcessingThread t = (ActorProcessingThread) current;
-
-      if (t.getThreadLocalBuffer().remaining() < Events.PromiseCreation.size) {
-        swapBuffer(t);
-      }
-
-      ByteBuffer b = t.getThreadLocalBuffer();
-      b.put(Events.PromiseCreation.id);
-      b.putLong(promiseId); // id of the created promise
-      b.putLong(t.getCurrentMessageId()); // causal message
+    if (t.getThreadLocalBuffer().remaining() < Events.PromiseCreation.size) {
+      swapBuffer(t);
     }
+
+    ByteBuffer b = t.getThreadLocalBuffer();
+    b.put(Events.PromiseCreation.id);
+    b.putLong(promiseId); // id of the created promise
+    b.putLong(t.getCurrentMessageId()); // causal message
   }
 
   public static void promiseResolution(final long promiseId, final Object value) {
@@ -262,22 +258,20 @@ public class ActorExecutionTrace {
     }
 
     Thread current = Thread.currentThread();
+    assert current instanceof TracingActivityThread;
+    TracingActivityThread t = (TracingActivityThread) current;
 
-    if (current instanceof ActorProcessingThread) {
-      ActorProcessingThread t = (ActorProcessingThread) current;
-
-      if (t.getThreadLocalBuffer().remaining() < Events.PromiseResolution.size) {
-        swapBuffer(t);
-      }
-
-      ByteBuffer b = t.getThreadLocalBuffer();
-      b.put(Events.PromiseResolution.id);
-      b.putLong(promiseId); // id of the promise
-      b.putLong(t.getCurrentMessageId()); // resolving message
-      writeParameter(value, b);
-
-      t.resolvedPromises++;
+    if (t.getThreadLocalBuffer().remaining() < Events.PromiseResolution.size) {
+      swapBuffer(t);
     }
+
+    ByteBuffer b = t.getThreadLocalBuffer();
+    b.put(Events.PromiseResolution.id);
+    b.putLong(promiseId); // id of the promise
+    b.putLong(t.getCurrentMessageId()); // resolving message
+    writeParameter(value, b);
+
+    t.resolvedPromises++;
   }
 
   public static void promiseChained(final long parent, final long child) {
@@ -286,20 +280,18 @@ public class ActorExecutionTrace {
     }
 
     Thread current = Thread.currentThread();
+    assert current instanceof TracingActivityThread;
+    TracingActivityThread t = (TracingActivityThread) current;
 
-    if (current instanceof ActorProcessingThread) {
-      ActorProcessingThread t = (ActorProcessingThread) current;
-
-      if (t.getThreadLocalBuffer().remaining() < Events.PromiseChained.size) {
-        swapBuffer(t);
-      }
-
-      ByteBuffer b = t.getThreadLocalBuffer();
-      b.put(Events.PromiseChained.id);
-      b.putLong(parent); // id of the parent
-      b.putLong(child); // id of the chained promise
-      t.resolvedPromises++;
+    if (t.getThreadLocalBuffer().remaining() < Events.PromiseChained.size) {
+      swapBuffer(t);
     }
+
+    ByteBuffer b = t.getThreadLocalBuffer();
+    b.put(Events.PromiseChained.id);
+    b.putLong(parent); // id of the parent
+    b.putLong(child); // id of the chained promise
+    t.resolvedPromises++;
   }
 
   public static void mailboxExecuted(final EventualMessage m,
@@ -311,73 +303,71 @@ public class ActorExecutionTrace {
 
     TracingActor ta = (TracingActor) actor;
     Thread current = Thread.currentThread();
+    assert current instanceof TracingActivityThread;
+    TracingActivityThread t = (TracingActivityThread) current;
 
-    if (current instanceof ActorProcessingThread) {
-      ActorProcessingThread t = (ActorProcessingThread) current;
+    if (t.getThreadLocalBuffer().remaining() < Events.Mailbox.size + 100 * 50) {
+      swapBuffer(t);
+    }
 
-      if (t.getThreadLocalBuffer().remaining() < Events.Mailbox.size + 100 * 50) {
-        swapBuffer(t);
-      }
+    ByteBuffer b = t.getThreadLocalBuffer();
+    b.put(Events.Mailbox.id);
+    b.putLong(baseMessageId); // base id for messages
+    b.putInt(mailboxNo);
+    b.putLong(ta.getId());   // receiver of the messages
 
-      ByteBuffer b = t.getThreadLocalBuffer();
-      b.put(Events.Mailbox.id);
-      b.putLong(baseMessageId); // base id for messages
+    int idx = 0;
+
+    if (b.remaining() < (MESSAGE_SIZE + m.getArgs().length * PARAM_SIZE)) {
+      swapBuffer(t);
+      b = t.getThreadLocalBuffer();
+      b.put(Events.MailboxContd.id);
+      b.putLong(baseMessageId);
       b.putInt(mailboxNo);
-      b.putLong(ta.getActorId());   // receiver of the messages
+      b.putLong(ta.getId()); // receiver of the messages
+      b.putInt(idx);
+    }
 
-      int idx = 0;
+    writeBasicMessage(m, b);
 
-      if (b.remaining() < (MESSAGE_SIZE + m.getArgs().length * PARAM_SIZE)) {
-        swapBuffer(t);
-        b = t.getThreadLocalBuffer();
-        b.put(Events.MailboxContd.id);
-        b.putLong(baseMessageId);
-        b.putInt(mailboxNo);
-        b.putLong(ta.getActorId()); // receiver of the messages
-        b.putInt(idx);
-      }
+    if (VmSettings.MESSAGE_TIMESTAMPS) {
+      b.putLong(execTS[0]);
+      b.putLong(sendTS);
+    }
 
-      writeBasicMessage(m, b);
+    if (VmSettings.MESSAGE_PARAMETERS) {
+      writeParameters(m.getArgs(), b);
+    }
+    idx++;
 
+    if (moreCurrent != null) {
+      Iterator<Long> it = null;
       if (VmSettings.MESSAGE_TIMESTAMPS) {
-        b.putLong(execTS[0]);
-        b.putLong(sendTS);
+        assert moreSendTS != null && moreCurrent.size() == moreSendTS.size();
+        it = moreSendTS.iterator();
       }
+      for (EventualMessage em : moreCurrent) {
+        if (b.remaining() < (MESSAGE_SIZE + em.getArgs().length * PARAM_SIZE)) {
+          swapBuffer(t);
+          b = t.getThreadLocalBuffer();
+          b.put(Events.MailboxContd.id);
+          b.putLong(baseMessageId);
+          b.putInt(mailboxNo);
+          b.putLong(ta.getId()); // receiver of the messages
+          b.putInt(idx);
+        }
 
-      if (VmSettings.MESSAGE_PARAMETERS) {
-        writeParameters(m.getArgs(), b);
-      }
-      idx++;
+        writeBasicMessage(em, b);
 
-      if (moreCurrent != null) {
-        Iterator<Long> it = null;
         if (VmSettings.MESSAGE_TIMESTAMPS) {
-          assert moreSendTS != null && moreCurrent.size() == moreSendTS.size();
-          it = moreSendTS.iterator();
+          b.putLong(execTS[idx]);
+          b.putLong(it.next());
         }
-        for (EventualMessage em : moreCurrent) {
-          if (b.remaining() < (MESSAGE_SIZE + em.getArgs().length * PARAM_SIZE)) {
-            swapBuffer(t);
-            b = t.getThreadLocalBuffer();
-            b.put(Events.MailboxContd.id);
-            b.putLong(baseMessageId);
-            b.putInt(mailboxNo);
-            b.putLong(ta.getActorId()); // receiver of the messages
-            b.putInt(idx);
-          }
 
-          writeBasicMessage(em, b);
-
-          if (VmSettings.MESSAGE_TIMESTAMPS) {
-            b.putLong(execTS[idx]);
-            b.putLong(it.next());
-          }
-
-          if (VmSettings.MESSAGE_PARAMETERS) {
-            writeParameters(em.getArgs(), b);
-          }
-          idx++;
+        if (VmSettings.MESSAGE_PARAMETERS) {
+          writeParameters(em.getArgs(), b);
         }
+        idx++;
       }
     }
   }
@@ -390,7 +380,7 @@ public class ActorExecutionTrace {
       b.put(messageEventId);
     }
 
-    b.putLong(((TracingActor) em.getSender()).getActorId()); // sender
+    b.putLong(em.getSender().getId()); // sender
     b.putLong(em.getCausalMessageId());
 
     b.putShort(em.getSelector().getSymbolId());
@@ -559,39 +549,38 @@ public class ActorExecutionTrace {
     Thread current = Thread.currentThread();
     TracingActor ta = (TracingActor) actor;
 
-    if (current instanceof ActorProcessingThread) {
-      ActorProcessingThread t = (ActorProcessingThread) current;
+    assert current instanceof TracingActivityThread;
+    TracingActivityThread t = (TracingActivityThread) current;
 
-      if (t.getThreadLocalBuffer().remaining() < Events.Mailbox.size + 100 * 50) {
-        swapBuffer(t);
-      }
+    if (t.getThreadLocalBuffer().remaining() < Events.Mailbox.size + 100 * 50) {
+      swapBuffer(t);
+    }
 
-      ByteBuffer b = t.getThreadLocalBuffer();
-      b.put(Events.Mailbox.id);
-      b.putLong(baseMessageId); // base id for messages
-      b.putInt(mailboxNo);
-      b.putLong(ta.getActorId());   // receiver of the messages
+    ByteBuffer b = t.getThreadLocalBuffer();
+    b.put(Events.Mailbox.id);
+    b.putLong(baseMessageId); // base id for messages
+    b.putInt(mailboxNo);
+    b.putLong(ta.getId());    // receiver of the messages
 
-      int idx = 0;
+    int idx = 0;
 
-      if (todo != null) {
-        for (EventualMessage em : todo) {
-          if (b.remaining() < (MESSAGE_SIZE + em.getArgs().length * PARAM_SIZE)) {
-            swapBuffer(t);
-            b = t.getThreadLocalBuffer();
-            b.put(Events.MailboxContd.id);
-            b.putLong(baseMessageId);
-            b.putLong(ta.getActorId()); // receiver of the messages
-            b.putInt(idx);
-          }
-
-          writeBasicMessage(em, b);
-
-          if (VmSettings.MESSAGE_PARAMETERS) {
-            writeParameters(em.getArgs(), b);
-          }
-          idx++;
+    if (todo != null) {
+      for (EventualMessage em : todo) {
+        if (b.remaining() < (MESSAGE_SIZE + em.getArgs().length * PARAM_SIZE)) {
+          swapBuffer(t);
+          b = t.getThreadLocalBuffer();
+          b.put(Events.MailboxContd.id);
+          b.putLong(baseMessageId);
+          b.putLong(ta.getId()); // receiver of the messages
+          b.putInt(idx);
         }
+
+        writeBasicMessage(em, b);
+
+        if (VmSettings.MESSAGE_PARAMETERS) {
+          writeParameters(em.getArgs(), b);
+        }
+        idx++;
       }
     }
   }

--- a/src/tools/concurrency/TracingActivityThread.java
+++ b/src/tools/concurrency/TracingActivityThread.java
@@ -1,0 +1,67 @@
+package tools.concurrency;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import som.vm.VmSettings;
+import tools.TraceData;
+
+
+public abstract class TracingActivityThread extends ForkJoinWorkerThread {
+  private static AtomicInteger threadIdGen = new AtomicInteger(0);
+  protected final long threadId;
+
+  protected long nextActivityId = 1;
+
+  protected long nextMessageId;
+  protected long nextPromiseId;
+
+  // Used for tracing, accessed by the ExecAllMessages classes
+  public long createdMessages;
+  public long resolvedPromises;
+
+  protected ByteBuffer tracingDataBuffer;
+
+  public TracingActivityThread(final ForkJoinPool pool) {
+    super(pool);
+    if (VmSettings.ACTOR_TRACING) {
+      ActorExecutionTrace.swapBuffer(this);
+      threadId = threadIdGen.getAndIncrement();
+      nextMessageId = (threadId << TraceData.ACTIVITY_ID_BITS);
+      nextPromiseId = (threadId << TraceData.ACTIVITY_ID_BITS);
+    } else {
+      threadId = 0;
+    }
+  }
+
+  public long generateActivityId() {
+    long result = (threadId << TraceData.ACTIVITY_ID_BITS) | nextActivityId;
+    nextActivityId++;
+    return result;
+  }
+
+  public long generatePromiseId() {
+    return nextPromiseId++;
+  }
+
+  public final ByteBuffer getThreadLocalBuffer() {
+    return tracingDataBuffer;
+  }
+
+  public void setThreadLocalBuffer(final ByteBuffer threadLocalBuffer) {
+    this.tracingDataBuffer = threadLocalBuffer;
+  }
+
+  public abstract long getCurrentMessageId();
+
+  @Override
+  protected void onTermination(final Throwable exception) {
+    if (VmSettings.ACTOR_TRACING) {
+      ActorExecutionTrace.returnBuffer(this.tracingDataBuffer);
+      this.tracingDataBuffer = null;
+    }
+    super.onTermination(exception);
+  }
+}

--- a/src/tools/concurrency/TracingActors.java
+++ b/src/tools/concurrency/TracingActors.java
@@ -24,7 +24,7 @@ public class TracingActors {
       super();
       if (Thread.currentThread() instanceof ActorProcessingThread) {
         ActorProcessingThread t = (ActorProcessingThread) Thread.currentThread();
-        this.actorId = t.generateActorId();
+        this.actorId = t.generateActivityId();
       } else {
         actorId = 0; // main actor
       }
@@ -34,9 +34,8 @@ public class TracingActors {
       return mailboxNumber++;
     }
 
-    public long getActorId() {
-      return actorId;
-    }
+    @Override
+    public long getId() { return actorId; }
   }
 
   public static final class ReplayActor extends TracingActor{


### PR DESCRIPTION
Move thread state relevant for tracing of different kinds of activities (actors, processes,…) into common base class.

Use TracingActivityThread where possible, especially in ActorExecutionTrace.

- rely on `assert` instead of `if` to test for thread
- ignore `java.util.TimeThread` for recording promises, doesn't seem to be necessary

@daumayr please have a brief look at this, that's a change I originally introduced in my huge Kompos PR #106 and now extracted, because I had issues getting replay to work again. Seems to work now.