### PR TITLE
Add button to unfold code pane 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
  - Updated to Truffle 0.24+patches, from pre-0.22+patches
  - Visualize all types of activities in system view ([PR #116](https://github.com/smarr/SOMns/pull/116))
  - Block methods are named based on outer method's name
+ - Enable display of code for unsuspended activities, i.e., activities not
+   hitting a breakpoint
 
 ## [0.2.0] - 2017-03-07 Extended Concurrency Support
 

--- a/src/som/primitives/actors/CreateActorPrim.java
+++ b/src/som/primitives/actors/CreateActorPrim.java
@@ -33,11 +33,7 @@ public abstract class CreateActorPrim extends BinaryComplexOperation {
     SFarReference ref = new SFarReference(actor, argument);
 
     if (VmSettings.ACTOR_TRACING) {
-      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
-        ActorExecutionTrace.actorCreationWithOrigin(ref, sourceSection);
-      } else {
-        ActorExecutionTrace.actorCreation(ref);
-      }
+      ActorExecutionTrace.actorCreation(ref, sourceSection);
     }
     return ref;
   }

--- a/src/som/primitives/actors/CreateActorPrim.java
+++ b/src/som/primitives/actors/CreateActorPrim.java
@@ -33,7 +33,11 @@ public abstract class CreateActorPrim extends BinaryComplexOperation {
     SFarReference ref = new SFarReference(actor, argument);
 
     if (VmSettings.ACTOR_TRACING) {
-      ActorExecutionTrace.actorCreation(ref);
+      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
+        ActorExecutionTrace.actorCreationWithOrigin(ref, sourceSection);
+      } else {
+        ActorExecutionTrace.actorCreation(ref);
+      }
     }
     return ref;
   }

--- a/src/som/primitives/processes/ChannelPrimitives.java
+++ b/src/som/primitives/processes/ChannelPrimitives.java
@@ -98,10 +98,15 @@ public abstract class ChannelPrimitives {
     }
   }
 
-  private static Process create(final SObjectWithClass obj) {
+  private static Process create(final SObjectWithClass obj, final SourceSection origin) {
     if (VmSettings.ACTOR_TRACING) {
       TracingProcess result = new TracingProcess(obj);
-      ActorExecutionTrace.processCreation(result);
+
+      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
+        ActorExecutionTrace.processCreationWithOrigin(result, origin);
+      } else {
+        ActorExecutionTrace.processCreation(result);
+      }
       return result;
     } else {
       return new Process(obj);
@@ -210,7 +215,7 @@ public abstract class ChannelPrimitives {
       SInvokable disp = procCls.getMixinDefinition().getFactoryMethods().get(sel);
       SObjectWithClass obj = (SObjectWithClass) disp.invoke(toArgs.executedEvaluated(args, procCls));
 
-      processesPool.submit(create(obj));
+      processesPool.submit(create(obj, sourceSection));
       return Nil.nilObject;
     }
   }

--- a/src/som/primitives/processes/ChannelPrimitives.java
+++ b/src/som/primitives/processes/ChannelPrimitives.java
@@ -101,12 +101,7 @@ public abstract class ChannelPrimitives {
   private static Process create(final SObjectWithClass obj, final SourceSection origin) {
     if (VmSettings.ACTOR_TRACING) {
       TracingProcess result = new TracingProcess(obj);
-
-      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
-        ActorExecutionTrace.processCreationWithOrigin(result, origin);
-      } else {
-        ActorExecutionTrace.processCreation(result);
-      }
+      ActorExecutionTrace.processCreation(result, origin);
       return result;
     } else {
       return new Process(obj);

--- a/src/som/primitives/threading/TaskPrimitives.java
+++ b/src/som/primitives/threading/TaskPrimitives.java
@@ -121,7 +121,11 @@ public final class TaskPrimitives {
       forkJoinPool.execute(task);
 
       if (VmSettings.ACTOR_TRACING) {
-        ActorExecutionTrace.taskSpawn(block.getMethod(), task.getId());
+        if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
+          ActorExecutionTrace.taskSpawnWithOrigin(block.getMethod(), task.getId(), sourceSection);
+        } else {
+          ActorExecutionTrace.taskSpawn(block.getMethod(), task.getId());
+        }
       }
       return task;
     }
@@ -141,7 +145,11 @@ public final class TaskPrimitives {
       forkJoinPool.execute(task);
 
       if (VmSettings.ACTOR_TRACING) {
-        ActorExecutionTrace.taskSpawn(block.getMethod(), task.getId());
+        if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
+          ActorExecutionTrace.taskSpawnWithOrigin(block.getMethod(), task.getId(), sourceSection);
+        } else {
+          ActorExecutionTrace.taskSpawn(block.getMethod(), task.getId());
+        }
       }
       return task;
     }

--- a/src/som/primitives/threading/TaskPrimitives.java
+++ b/src/som/primitives/threading/TaskPrimitives.java
@@ -121,11 +121,7 @@ public final class TaskPrimitives {
       forkJoinPool.execute(task);
 
       if (VmSettings.ACTOR_TRACING) {
-        if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
-          ActorExecutionTrace.taskSpawnWithOrigin(block.getMethod(), task.getId(), sourceSection);
-        } else {
-          ActorExecutionTrace.taskSpawn(block.getMethod(), task.getId());
-        }
+        ActorExecutionTrace.taskSpawn(block.getMethod(), task.getId(), sourceSection);
       }
       return task;
     }
@@ -145,11 +141,7 @@ public final class TaskPrimitives {
       forkJoinPool.execute(task);
 
       if (VmSettings.ACTOR_TRACING) {
-        if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
-          ActorExecutionTrace.taskSpawnWithOrigin(block.getMethod(), task.getId(), sourceSection);
-        } else {
-          ActorExecutionTrace.taskSpawn(block.getMethod(), task.getId());
-        }
+        ActorExecutionTrace.taskSpawn(block.getMethod(), task.getId(), sourceSection);
       }
       return task;
     }

--- a/src/tools/TraceData.java
+++ b/src/tools/TraceData.java
@@ -16,6 +16,8 @@ public class TraceData {
   public static final byte THREAD             = 6;
   public static final byte MAILBOX_CONTD      = 7;
 
+  public static final byte ACTOR_CREATION_ORIGIN     = 8;
+
   public static final byte PROCESS_CREATION   = 10;
   public static final byte PROCESS_COMPLETION = 11;
 
@@ -23,6 +25,9 @@ public class TraceData {
   public static final byte TASK_JOIN  = 13;
 
   public static final byte PROMISE_ERROR = 14;
+
+  public static final byte PROCESS_CREATION_ORIGIN   = 14;
+  public static final byte TASK_SPAWN_ORIGIN = 15;
 
   /**
    * Messages use a different EventId system, the most significant bit is 1 to clearly distinguish it from custom Events.

--- a/src/tools/TraceData.java
+++ b/src/tools/TraceData.java
@@ -16,7 +16,7 @@ public class TraceData {
   public static final byte THREAD             = 6;
   public static final byte MAILBOX_CONTD      = 7;
 
-  public static final byte ACTOR_CREATION_ORIGIN     = 8;
+  public static final byte ACTIVITY_ORIGIN    = 8;
 
   public static final byte PROCESS_CREATION   = 10;
   public static final byte PROCESS_COMPLETION = 11;
@@ -26,9 +26,6 @@ public class TraceData {
 
   public static final byte PROMISE_ERROR = 14;
 
-  public static final byte PROCESS_CREATION_ORIGIN   = 14;
-  public static final byte TASK_SPAWN_ORIGIN = 15;
-
   /**
    * Messages use a different EventId system, the most significant bit is 1 to clearly distinguish it from custom Events.
    * The other bits are used to encode what information is contained in that event.
@@ -37,7 +34,6 @@ public class TraceData {
   public static final byte PROMISE_BIT   = 0x40;
   public static final byte TIMESTAMP_BIT = 0x20;
   public static final byte PARAMETER_BIT = 0x10;
-
 
   public static final long ACTIVITY_ID_BITS = 30;
   public static final long THREAD_ID_BITS   = 10;

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -26,6 +26,7 @@ import javax.management.NotificationListener;
 import javax.management.openmbean.CompositeData;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.source.SourceSection;
 import com.sun.management.GarbageCollectionNotificationInfo;
 
 import som.VM;
@@ -210,6 +211,7 @@ public class ActorExecutionTrace {
 
   protected enum Events {
     ActorCreation(TraceData.ACTOR_CREATION,         19),
+    ActorCreationWithOrigin(TraceData.ACTOR_CREATION_ORIGIN,         27),
     PromiseCreation(TraceData.PROMISE_CREATION,     17),
     PromiseResolution(TraceData.PROMISE_RESOLUTION, 28),
     PromiseChained(TraceData.PROMISE_CHAINED,       17),
@@ -229,7 +231,10 @@ public class ActorExecutionTrace {
     TaskSpawn(TraceData.TASK_SPAWN, 19),
     TaskJoin(TraceData.TASK_JOIN,   11),
 
-    PromiseError(TraceData.PROMISE_ERROR, 28);
+    PromiseError(TraceData.PROMISE_ERROR, 28),
+
+    TaskSpawnOrigin(TraceData.TASK_SPAWN_ORIGIN, 27),
+    ProcessCreationOrigin(TraceData.PROCESS_CREATION_ORIGIN, 27);
 
     final byte id;
     final int size;
@@ -273,9 +278,19 @@ public class ActorExecutionTrace {
     t.getBuffer().recordActorCreation(actor, t.getCurrentMessageId());
   }
 
+  public static void actorCreationWithOrigin(final SFarReference actor, final SourceSection origin) {
+    TracingActivityThread t = getThread();
+    t.getBuffer().recordActorCreationWithOrigin(actor, t.getCurrentMessageId(), origin);
+  }
+
   public static void processCreation(final TracingProcess proc) {
     TracingActivityThread t = getThread();
     t.getBuffer().recordProcessCreation(proc, t.getCurrentMessageId());
+  }
+
+  public static void processCreationWithOrigin(final TracingProcess proc, final SourceSection origin) {
+    TracingActivityThread t = getThread();
+    t.getBuffer().recordProcessCreationWithOrigin(proc, t.getCurrentMessageId(), origin);
   }
 
   public static void processCompletion(final TracingProcess proc) {
@@ -286,6 +301,11 @@ public class ActorExecutionTrace {
   public static void taskSpawn(final SInvokable method, final long activityId) {
     TracingActivityThread t = getThread();
     t.getBuffer().recordTaskSpawn(method, activityId, t.getCurrentMessageId());
+  }
+
+  public static void taskSpawnWithOrigin(final SInvokable method, final long activityId, final SourceSection origin) {
+    TracingActivityThread t = getThread();
+    t.getBuffer().recordTaskSpawnWithOrigin(method, activityId, t.getCurrentMessageId(), origin);
   }
 
   public static void taskJoin(final SInvokable method, final long activityId) {

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -211,7 +211,7 @@ public class ActorExecutionTrace {
 
   protected enum Events {
     ActorCreation(TraceData.ACTOR_CREATION,         19),
-    ActorCreationWithOrigin(TraceData.ACTOR_CREATION_ORIGIN,         27),
+    ActivityOrigin(TraceData.ACTIVITY_ORIGIN,        9),
     PromiseCreation(TraceData.PROMISE_CREATION,     17),
     PromiseResolution(TraceData.PROMISE_RESOLUTION, 28),
     PromiseChained(TraceData.PROMISE_CHAINED,       17),
@@ -231,10 +231,7 @@ public class ActorExecutionTrace {
     TaskSpawn(TraceData.TASK_SPAWN, 19),
     TaskJoin(TraceData.TASK_JOIN,   11),
 
-    PromiseError(TraceData.PROMISE_ERROR, 28),
-
-    TaskSpawnOrigin(TraceData.TASK_SPAWN_ORIGIN, 27),
-    ProcessCreationOrigin(TraceData.PROCESS_CREATION_ORIGIN, 27);
+    PromiseError(TraceData.PROMISE_ERROR, 28);
 
     final byte id;
     final int size;
@@ -273,24 +270,14 @@ public class ActorExecutionTrace {
     workerThread.start();
   }
 
-  public static void actorCreation(final SFarReference actor) {
+  public static void actorCreation(final SFarReference actor, final SourceSection section) {
     TracingActivityThread t = getThread();
-    t.getBuffer().recordActorCreation(actor, t.getCurrentMessageId());
+    t.getBuffer().recordActorCreation(actor, t.getCurrentMessageId(), section);
   }
 
-  public static void actorCreationWithOrigin(final SFarReference actor, final SourceSection origin) {
+  public static void processCreation(final TracingProcess proc, final SourceSection section) {
     TracingActivityThread t = getThread();
-    t.getBuffer().recordActorCreationWithOrigin(actor, t.getCurrentMessageId(), origin);
-  }
-
-  public static void processCreation(final TracingProcess proc) {
-    TracingActivityThread t = getThread();
-    t.getBuffer().recordProcessCreation(proc, t.getCurrentMessageId());
-  }
-
-  public static void processCreationWithOrigin(final TracingProcess proc, final SourceSection origin) {
-    TracingActivityThread t = getThread();
-    t.getBuffer().recordProcessCreationWithOrigin(proc, t.getCurrentMessageId(), origin);
+    t.getBuffer().recordProcessCreation(proc, t.getCurrentMessageId(), section);
   }
 
   public static void processCompletion(final TracingProcess proc) {
@@ -298,14 +285,10 @@ public class ActorExecutionTrace {
     t.getBuffer().recordProcessCompletion(proc);
   }
 
-  public static void taskSpawn(final SInvokable method, final long activityId) {
+  public static void taskSpawn(final SInvokable method, final long activityId,
+      final SourceSection section) {
     TracingActivityThread t = getThread();
-    t.getBuffer().recordTaskSpawn(method, activityId, t.getCurrentMessageId());
-  }
-
-  public static void taskSpawnWithOrigin(final SInvokable method, final long activityId, final SourceSection origin) {
-    TracingActivityThread t = getThread();
-    t.getBuffer().recordTaskSpawnWithOrigin(method, activityId, t.getCurrentMessageId(), origin);
+    t.getBuffer().recordTaskSpawn(method, activityId, t.getCurrentMessageId(), section);
   }
 
   public static void taskJoin(final SInvokable method, final long activityId) {

--- a/src/tools/concurrency/TraceBuffer.java
+++ b/src/tools/concurrency/TraceBuffer.java
@@ -14,6 +14,7 @@ import som.interpreter.actors.EventualMessage.PromiseMessage;
 import som.interpreter.actors.SFarReference;
 import som.interpreter.actors.SPromise;
 import som.interpreter.actors.SPromise.SResolver;
+import som.interpreter.nodes.dispatch.Dispatchable;
 import som.primitives.processes.ChannelPrimitives.TracingProcess;
 import som.vm.ObjectSystem;
 import som.vm.Symbols;
@@ -93,73 +94,72 @@ public class TraceBuffer {
 
   public final void recordMainActor(final Actor mainActor,
       final ObjectSystem objectSystem) {
+    SourceSection section;
+
+    if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
+      Dispatchable disp = objectSystem.getPlatformClass().
+          getDispatchables().get(Symbols.symbolFor("start"));
+      SInvokable method = (SInvokable) disp;
+
+      section = method.getInvokable().getSourceSection();
+    } else {
+      section = null;
+    }
+
     recordActivityCreation(Events.ActorCreation, mainActor.getId(), 0,
-        objectSystem.getPlatformClass().getName().getSymbolId());
+        objectSystem.getPlatformClass().getName().getSymbolId(), section);
   }
 
   public final void recordActorCreation(final SFarReference actor,
-      final long currentMessageId) {
+      final long currentMessageId, final SourceSection sourceSection) {
     final Object value = actor.getValue();
     assert value instanceof SClass;
     final SClass actorClass = (SClass) value;
 
     recordActivityCreation(Events.ActorCreation, actor.getActor().getId(),
-        currentMessageId, actorClass.getName().getSymbolId());
+        currentMessageId, actorClass.getName().getSymbolId(), sourceSection);
   }
 
-  public void recordActorCreationWithOrigin(final SFarReference actor, final long currentMessageId,
-      final SourceSection origin) {
-    final Object value = actor.getValue();
-    assert value instanceof SClass;
-    final SClass actorClass = (SClass) value;
-
-    recordActivityCreationWithOrigin(Events.ActorCreationWithOrigin, actor.getActor().getId(),
-        currentMessageId, actorClass.getName().getSymbolId(), origin);
-  }
-
-  public final void recordProcessCreation(final TracingProcess proc,
-      final long currentMessageId) {
-    recordActivityCreation(Events.ProcessCreation, proc.getId(),
-        currentMessageId,
-        proc.getProcObject().getSOMClass().getName().getSymbolId());
-  }
-
-  public final void recordProcessCreationWithOrigin(final TracingProcess proc,
-      final long currentMessageId, final SourceSection origin) {
-    recordActivityCreationWithOrigin(Events.ProcessCreationOrigin, proc.getId(),
-        currentMessageId, proc.getProcObject().getSOMClass().getName().getSymbolId(), origin);
-  }
-
-  protected void recordActivityCreation(final Events event,
-      final long activityId, final long causalMessageId, final short symbolId) {
-    ensureSufficientSpace(event.size);
+  private void recordActivityOrigin(final SourceSection origin) {
+    assert storage.remaining() >= Events.ActivityOrigin.size :
+      "Sufficient space needs to be required for encoding activity, to ensure continuous encoding in memory.";
 
     final int start = storage.position();
 
-    storage.put(event.id);
-    storage.putLong(activityId);
-    storage.putLong(causalMessageId);
-    storage.putShort(symbolId);
-
-    assert storage.position() == start + event.size;
-  }
-
-  private void recordActivityCreationWithOrigin(final Events event, final long activityId,
-      final long causalMessageId, final short symbolId, final SourceSection origin) {
-    ensureSufficientSpace(event.size);
-
-    final int start = storage.position();
-
-    storage.put(event.id);
-    storage.putLong(activityId);
-    storage.putLong(causalMessageId);
-    storage.putShort(symbolId);
-    VM.println(origin.getSource().getURI().toString());
+    storage.put(Events.ActivityOrigin.id);
     storage.putShort(Symbols.symbolFor(origin.getSource().getURI().toString()).getSymbolId());
     storage.putShort((short) origin.getStartLine());
     storage.putShort((short) origin.getStartColumn());
     storage.putShort((short) origin.getCharLength());
+    assert storage.position() == start + Events.ActivityOrigin.size;
+  }
+
+  public final void recordProcessCreation(final TracingProcess proc,
+      final long currentMessageId, final SourceSection sourceSection) {
+    recordActivityCreation(Events.ProcessCreation, proc.getId(),
+        currentMessageId,
+        proc.getProcObject().getSOMClass().getName().getSymbolId(),
+        sourceSection);
+  }
+
+  protected void recordActivityCreation(final Events event,
+      final long activityId, final long causalMessageId, final short symbolId, final SourceSection sourceSection) {
+    int requiredSpace = event.size +
+        (VmSettings.TRUFFLE_DEBUGGER_ENABLED ? Events.ActivityOrigin.size : 0);
+    ensureSufficientSpace(requiredSpace);
+
+    final int start = storage.position();
+
+    storage.put(event.id);
+    storage.putLong(activityId);
+    storage.putLong(causalMessageId);
+    storage.putShort(symbolId);
+
     assert storage.position() == start + event.size;
+
+    if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
+      recordActivityOrigin(sourceSection);
+    }
   }
 
   public void recordProcessCompletion(final TracingProcess proc) {
@@ -174,15 +174,9 @@ public class TraceBuffer {
   }
 
   public void recordTaskSpawn(final SInvokable method, final long activityId,
-      final long causalMessageId) {
+      final long causalMessageId, final SourceSection section) {
     recordActivityCreation(Events.TaskSpawn, activityId, causalMessageId,
-        method.getSignature().getSymbolId());
-  }
-
-  public void recordTaskSpawnWithOrigin(final SInvokable method, final long activityId,
-      final long causalMessageId, final SourceSection origin) {
-    recordActivityCreationWithOrigin(Events.TaskSpawnOrigin, activityId, causalMessageId,
-        method.getSignature().getSymbolId(), origin);
+        method.getSignature().getSymbolId(), section);
   }
 
   public void recordTaskJoin(final SInvokable method, final long activityId) {
@@ -410,8 +404,9 @@ public class TraceBuffer {
 
     @Override
     protected synchronized void recordActivityCreation(final Events event,
-        final long activityId, final long causalMessageId, final short symbolId) {
-      super.recordActivityCreation(event, activityId, causalMessageId, symbolId);
+        final long activityId, final long causalMessageId, final short symbolId,
+        final SourceSection section) {
+      super.recordActivityCreation(event, activityId, causalMessageId, symbolId, section);
     }
 
     @Override

--- a/src/tools/concurrency/TraceParser.java
+++ b/src/tools/concurrency/TraceParser.java
@@ -118,27 +118,12 @@ public final class TraceParser {
             parsedActors++;
             assert b.position() == start + Events.ActorCreation.size;
             break;
-          case TraceData.ACTOR_CREATION_ORIGIN:
-            id = b.getLong(); // actor id
-            cause = b.getLong(); // causal
-            if (id == 0) {
-              assert !readMainActor : "There should be only one main actor.";
-              readMainActor = true;
-            }
-            if (id != 0) {
-              if (!unmappedActors.containsKey(cause)) {
-                unmappedActors.put(cause, new ArrayList<>());
-              }
-              unmappedActors.get(cause).add(id);
-            }
-            b.getShort(); // type
-
+          case TraceData.ACTIVITY_ORIGIN:
             b.getShort(); // file
             b.getShort(); // startline
             b.getShort(); // startcol
             b.getShort(); // charlen
-            parsedActors++;
-            assert b.position() == start + Events.ActorCreationWithOrigin.size;
+            assert b.position() == start + Events.ActivityOrigin.size;
             break;
           case TraceData.MAILBOX:
             currentMessage = b.getLong(); // base msg id

--- a/src/tools/concurrency/TraceParser.java
+++ b/src/tools/concurrency/TraceParser.java
@@ -118,6 +118,28 @@ public final class TraceParser {
             parsedActors++;
             assert b.position() == start + Events.ActorCreation.size;
             break;
+          case TraceData.ACTOR_CREATION_ORIGIN:
+            id = b.getLong(); // actor id
+            cause = b.getLong(); // causal
+            if (id == 0) {
+              assert !readMainActor : "There should be only one main actor.";
+              readMainActor = true;
+            }
+            if (id != 0) {
+              if (!unmappedActors.containsKey(cause)) {
+                unmappedActors.put(cause, new ArrayList<>());
+              }
+              unmappedActors.get(cause).add(id);
+            }
+            b.getShort(); // type
+
+            b.getShort(); // file
+            b.getShort(); // startline
+            b.getShort(); // startcol
+            b.getShort(); // charlen
+            parsedActors++;
+            assert b.position() == start + Events.ActorCreationWithOrigin.size;
+            break;
           case TraceData.MAILBOX:
             currentMessage = b.getLong(); // base msg id
             currentMailbox = b.getInt(); // mailboxno

--- a/tools/kompos/index.html
+++ b/tools/kompos/index.html
@@ -187,6 +187,12 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
     font-size: 75%;
     padding: 2px 6px 3px;
   }
+  .activity-fold {
+    position: absolute;
+    right: 5%;
+    color: #555;
+  }
+
   .activity-name, .nav-link.card-title.disabled {
     color: #000;
     font-weight: bold;
@@ -235,6 +241,13 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
     padding:0.3em;
     font-size: 75%;
   }
+  .pane-opened .pane-closed {
+    display: none;
+  }
+  .pane-closed .pane-opened {
+    display: none;
+  }
+
   .system-status {
     background-color:rgba(255, 255, 255, 0.5);
     position: absolute;
@@ -356,6 +369,12 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
                     onclick="ctrl.stepOver(getAttribute('data-actid'));"><i class="fa fa-share"></i></button>
             <button class="act-return btn btn-secondary btn-sm disabled" type="button" title="Return from Method"
                     onclick="ctrl.returnFromExecution(getAttribute('data-actid'));"><i class="fa fa-reply" style="transform: scaleY(-1);"></i></button>
+          </div>
+          <div class="activity-fold">
+            <button class="btn btn-secondary pane-closed"
+              onclick="ctrl.toggleCodePane(getAttribute('data-actid'), this);">
+              <span class="pane-opened">&#9660;</span><span class="pane-closed">&#9664;</span>
+            </button>
           </div>
         </div>
 

--- a/tools/kompos/index.html
+++ b/tools/kompos/index.html
@@ -247,6 +247,9 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
   .pane-closed .pane-opened {
     display: none;
   }
+  .activity-source.pane-closed {
+    display: none;
+  }
 
   .system-status {
     background-color:rgba(255, 255, 255, 0.5);
@@ -370,9 +373,9 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
             <button class="act-return btn btn-secondary btn-sm disabled" type="button" title="Return from Method"
                     onclick="ctrl.returnFromExecution(getAttribute('data-actid'));"><i class="fa fa-reply" style="transform: scaleY(-1);"></i></button>
           </div>
-          <div class="activity-fold">
+          <div class="btn-group btn-group-xs activity-fold" role="group" aria-label="Stepping">
             <button class="btn btn-secondary pane-closed"
-              onclick="ctrl.toggleCodePane(getAttribute('data-actid'), this);">
+              onclick="ctrl.toggleCodePane(getAttribute('data-actid'));">
               <span class="pane-opened">&#9660;</span><span class="pane-closed">&#9664;</span>
             </button>
           </div>

--- a/tools/kompos/src/debugger.ts
+++ b/tools/kompos/src/debugger.ts
@@ -148,4 +148,8 @@ export class Debugger {
       }
     }
   }
+
+  public getActivity(actId): Activity {
+    return this.activities[actId];
+  }
 }

--- a/tools/kompos/src/messages.ts
+++ b/tools/kompos/src/messages.ts
@@ -57,6 +57,7 @@ export interface Activity {
   name: string;
   type: ActivityType;
   causalMsg: number;
+  origin?: FullSourceCoordinate;
 }
 
 export interface StoppedMessage {

--- a/tools/kompos/src/ui-controller.ts
+++ b/tools/kompos/src/ui-controller.ts
@@ -68,15 +68,19 @@ export class UiController extends Controller {
     this.dbg.addSource(msg);
   }
 
-  public toggleCodePane(actId: string, btnNode: Element) {
-    const btn = $(btnNode);
-    const isClosed = btn.hasClass("pane-closed");
-    if (isClosed) {
-      btn.removeClass("pane-closed");
-      btn.addClass("pane-opened");
+  public toggleCodePane(actId: string) {
+    const expanded = this.view.isCodePaneExpanded(actId);
+
+    if (expanded) {
+      this.view.markCodePaneClosed(actId);
     } else {
-      btn.addClass("pane-closed");
-      btn.removeClass("pane-opened");
+      const aId      = getActivityIdFromView(actId);
+      const activity = this.dbg.getActivity(aId);
+      const sId      = this.dbg.getSourceId(activity.origin.uri);
+      const source   = this.dbg.getSource(sId);
+
+      console.assert(aId === activity.id);
+      this.view.displaySource(aId, source, sId);
     }
   }
 

--- a/tools/kompos/src/ui-controller.ts
+++ b/tools/kompos/src/ui-controller.ts
@@ -68,6 +68,18 @@ export class UiController extends Controller {
     this.dbg.addSource(msg);
   }
 
+  public toggleCodePane(actId: string, btnNode: Element) {
+    const btn = $(btnNode);
+    const isClosed = btn.hasClass("pane-closed");
+    if (isClosed) {
+      btn.removeClass("pane-closed");
+      btn.addClass("pane-opened");
+    } else {
+      btn.addClass("pane-closed");
+      btn.removeClass("pane-opened");
+    }
+  }
+
   private ensureBreakpointsAreIndicated(sourceUri) {
     const bps = this.dbg.getEnabledBreakpointsForSource(sourceUri);
     for (const bp of bps) {

--- a/tools/kompos/src/view.ts
+++ b/tools/kompos/src/view.ts
@@ -429,11 +429,48 @@ export class View {
     $("#dbg-connect-btn").html("Reconnect");
   }
 
+  private getCodePaneExpander(actId: string) {
+    return $("#" + actId + " .activity-fold button");
+  }
+
+  private getCodePane(actId: string) {
+    return $("#" + actId + " .activity-source");
+  }
+
+  public isCodePaneExpanded(actId: string) {
+    const btn = this.getCodePaneExpander(actId);
+    return btn.hasClass("pane-opened");
+  }
+
+  public markCodePaneClosed(actId: string) {
+    const btn = this.getCodePaneExpander(actId);
+    const pane = this.getCodePane(actId);
+    const isClosed = btn.hasClass("pane-closed");
+    if (!isClosed) {
+      btn.addClass("pane-closed");
+      btn.removeClass("pane-opened");
+      pane.addClass("pane-closed");
+    }
+  }
+
+  private markCodePaneExpanded(actId: string) {
+    const btn = this.getCodePaneExpander(actId);
+    const pane = this.getCodePane(actId);
+    const isClosed = btn.hasClass("pane-closed");
+    if (isClosed) {
+      btn.removeClass("pane-closed");
+      btn.addClass("pane-opened");
+      pane.removeClass("pane-closed");
+    }
+  }
+
   /**
    * @returns true, if new source is displayed
    */
   public displaySource(activityId: number, source: Source, sourceId: string): boolean {
     const actId = getActivityId(activityId);
+    this.markCodePaneExpanded(actId);
+
     const container = $("#" + actId + " .activity-sources-list");
 
     // we mark the tab header as well as the tab content with a class


### PR DESCRIPTION
Allow to unfold the code pane for activities that have not hit a breakpoint yet.
Thus, enable exploration of source code for activity even if not stopped.

Think, the best would be to identify the allocation/start site of the activity, and show this site.