### PR TITLE
Fix issues with unfolding sources for some activities

### DIFF
--- a/src/tools/SourceCoordinate.java
+++ b/src/tools/SourceCoordinate.java
@@ -5,8 +5,11 @@ import java.net.URISyntaxException;
 import java.util.Objects;
 import java.util.Set;
 
+import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 
+import som.vm.Symbols;
+import som.vmobjects.SSymbol;
 import tools.debugger.Tags;
 
 /**
@@ -121,5 +124,9 @@ public class SourceCoordinate {
 
   public static String getLocationQualifier(final SourceSection section) {
     return ":" + section.getStartLine() + ":" + section.getStartColumn();
+  }
+
+  public static SSymbol getURI(final Source source) {
+    return Symbols.symbolFor(source.getURI().toString());
   }
 }

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -43,6 +43,7 @@ import som.vmobjects.SSymbol;
 import tools.ObjectBuffer;
 import tools.TraceData;
 import tools.debugger.FrontendConnector;
+import tools.debugger.PrimitiveCallOrigin;
 
 
 /**
@@ -281,8 +282,19 @@ public class ActorExecutionTrace {
   }
 
   public static void processCreation(final TracingProcess proc, final SourceSection section) {
+    SourceSection s = getPrimitiveCaller(section);
     TracingActivityThread t = getThread();
-    t.getBuffer().recordProcessCreation(proc, t.getCurrentMessageId(), section);
+    t.getBuffer().recordProcessCreation(proc, t.getCurrentMessageId(), s);
+  }
+
+  private static SourceSection getPrimitiveCaller(final SourceSection section) {
+    SourceSection s;
+    if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && section.getSource().isInternal()) {
+      s = PrimitiveCallOrigin.getCaller();
+    } else {
+      s = section;
+    }
+    return s;
   }
 
   public static void processCompletion(final TracingProcess proc) {
@@ -292,8 +304,9 @@ public class ActorExecutionTrace {
 
   public static void taskSpawn(final SInvokable method, final long activityId,
       final SourceSection section) {
+    SourceSection s = getPrimitiveCaller(section);
     TracingActivityThread t = getThread();
-    t.getBuffer().recordTaskSpawn(method, activityId, t.getCurrentMessageId(), section);
+    t.getBuffer().recordTaskSpawn(method, activityId, t.getCurrentMessageId(), s);
   }
 
   public static void taskJoin(final SInvokable method, final long activityId) {
@@ -355,9 +368,11 @@ public class ActorExecutionTrace {
 
   public static void channelCreation(final SChannel channel,
       final SourceSection section) {
+    SourceSection s = getPrimitiveCaller(section);
+
     TracingActivityThread t = getThread();
     t.getBuffer().recordChannelCreation(t.getActivity().getId(),
-        ((TracingChannel) channel).getId(), section);
+        ((TracingChannel) channel).getId(), s);
   }
 
   private static TracingActivityThread getThread() {

--- a/src/tools/concurrency/TraceBuffer.java
+++ b/src/tools/concurrency/TraceBuffer.java
@@ -23,6 +23,7 @@ import som.vmobjects.SAbstractObject;
 import som.vmobjects.SClass;
 import som.vmobjects.SInvokable;
 import tools.ObjectBuffer;
+import tools.SourceCoordinate;
 import tools.TraceData;
 import tools.concurrency.ActorExecutionTrace.Events;
 import tools.concurrency.ActorExecutionTrace.ParamTypes;
@@ -132,7 +133,9 @@ public class TraceBuffer {
   }
 
   private void writeSourceSection(final SourceSection origin) {
-    storage.putShort(Symbols.symbolFor(origin.getSource().getURI().toString()).getSymbolId());
+    assert !origin.getSource().isInternal() :
+      "Need special handling to ensure we see user code reported to trace/debugger";
+    storage.putShort(SourceCoordinate.getURI(origin.getSource()).getSymbolId());
     storage.putShort((short) origin.getStartLine());
     storage.putShort((short) origin.getStartColumn());
     storage.putShort((short) origin.getCharLength());

--- a/src/tools/debugger/PrimitiveCallOrigin.java
+++ b/src/tools/debugger/PrimitiveCallOrigin.java
@@ -1,0 +1,33 @@
+package tools.debugger;
+
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.frame.FrameInstance;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.SourceSection;
+
+import som.interpreter.nodes.MessageSendNode.GenericMessageSendNode;
+
+public class PrimitiveCallOrigin {
+  public static Node getCallerNode() {
+    int[] level = new int[1];
+
+    FrameInstance f = Truffle.getRuntime().iterateFrames(fi -> {
+      if (level[0] == 2) {
+        return fi;
+      }
+      level[0]++;
+      return null;
+    });
+    return f.getCallNode();
+  }
+
+  public static SourceSection getCaller() {
+    Node directCallNode = getCallerNode();
+    Node current = directCallNode;
+
+    while (!(current instanceof GenericMessageSendNode)) {
+      current = current.getParent();
+    }
+    return current.getSourceSection();
+  }
+}

--- a/src/tools/debugger/WebDebugger.java
+++ b/src/tools/debugger/WebDebugger.java
@@ -24,6 +24,7 @@ import com.oracle.truffle.api.source.SourceSection;
 import som.interpreter.actors.Actor;
 import som.vm.Activity;
 import som.vm.ActivityThread;
+import tools.SourceCoordinate;
 import tools.TraceData;
 import tools.debugger.frontend.Suspension;
 import tools.debugger.message.InitialBreakpointsMessage;
@@ -89,6 +90,8 @@ public class WebDebugger extends TruffleInstrument implements SuspendedCallback 
   }
 
   public void reportLoadedSource(final Source source) {
+    // register source URI as symbol to make sure it's send to the debugger
+    SourceCoordinate.getURI(source);
     connector.sendLoadedSource(source, loadedSourcesTags, rootNodes);
   }
 


### PR DESCRIPTION
- [x] fix an ordering problem, which caused the source URI not being available when unfolding a pane
- [x] fix the source info for activities that are created from normal primitives and not from eager primitives, obtain the caller's source section for those cases