### PR TITLE
Make replay more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased] - [Work in Progress][v4]
 
   - Updated to Truffle 0.25
+  - Fixed trace replay ([PR #127](https://github.com/smarr/SOMns/pull/127))
 
 ## [0.3.0] - [2017-04-06 &lt;Programming&gt;'17 Demo][v3]
 

--- a/src/som/interpreter/actors/EventualMessage.java
+++ b/src/som/interpreter/actors/EventualMessage.java
@@ -259,7 +259,7 @@ public abstract class EventualMessage {
 
     @Override
     public SSymbol getSelector() {
-      return VALUE_SELECTOR;
+      return ((SBlock) args[0]).getMethod().getSignature();
     }
 
     @Override

--- a/src/som/interpreter/actors/SPromise.java
+++ b/src/som/interpreter/actors/SPromise.java
@@ -107,7 +107,6 @@ public class SPromise extends SObjectWithClass {
   }
 
   public long getPromiseId() { return 0; }
-  public long getReplayPromiseId() { return 0; }
 
   public final Actor getOwner() {
     return owner;
@@ -244,7 +243,7 @@ public class SPromise extends SObjectWithClass {
   }
 
   protected static class STracingPromise extends SPromise {
-    protected final long promiseId;
+    protected long promiseId;
 
     protected STracingPromise(final Actor owner,
         final boolean triggerPromiseResolutionBreakpoint, final boolean triggerExplicitPromiseResolverBreakpoint,
@@ -262,8 +261,6 @@ public class SPromise extends SObjectWithClass {
   }
 
   protected static final class SReplayPromise extends STracingPromise {
-    protected final long replayId;
-
     protected SReplayPromise(final Actor owner,
         final boolean triggerPromiseResolutionBreakpoint, final boolean triggerExplicitPromiseResolverBreakpoint,
         final boolean explicitPromise) {
@@ -271,11 +268,8 @@ public class SPromise extends SObjectWithClass {
       ReplayActor creator = (ReplayActor) EventualMessage.getActorCurrentMessageIsExecutionOn();
 
       assert creator.getReplayPromiseIds() != null && creator.getReplayPromiseIds().size() > 0;
-      replayId = creator.getReplayPromiseIds().remove();
+      promiseId = creator.getReplayPromiseIds().remove();
     }
-
-    @Override
-    public long getReplayPromiseId() { return replayId; }
   }
 
   public static SResolver createResolver(final SPromise promise) {

--- a/src/som/primitives/actors/PromisePrims.java
+++ b/src/som/primitives/actors/PromisePrims.java
@@ -146,7 +146,7 @@ public final class PromisePrims {
       SResolver resolver = SPromise.createResolver(promise);
 
       PromiseCallbackMessage pcm = new PromiseCallbackMessage(EventualMessage.getCurrentExecutingMessageId(), rcvr.getOwner(),
-          block, resolver, blockCallTarget, false, promiseResolverBreakpoint.executeCheckIsSetAndEnabled(), promise);
+          block, resolver, blockCallTarget, false, promiseResolverBreakpoint.executeCheckIsSetAndEnabled(), rcvr);
       registerNode.register(rcvr, pcm, current);
 
       return promise;

--- a/src/tools/concurrency/TraceBuffer.java
+++ b/src/tools/concurrency/TraceBuffer.java
@@ -311,7 +311,7 @@ public class TraceBuffer {
     recordMailbox(baseMessageId, mailboxNo, receiver);
     writeMessage(m, sendTS, VmSettings.MESSAGE_TIMESTAMPS ? execTS[0] : 0);
 
-    int idx = 0;
+    int idx = 1;
 
     if (moreCurrent != null) {
       Iterator<Long> it = null;

--- a/src/tools/concurrency/TraceParser.java
+++ b/src/tools/concurrency/TraceParser.java
@@ -282,6 +282,7 @@ public final class TraceParser {
     final long actorId;
     int childNo;
     int mailboxNo;
+    boolean sorted = false;
     ArrayList<ActorNode> children;
 
     ActorNode(final long actorId) {
@@ -309,10 +310,14 @@ public final class TraceParser {
 
       child.childNo = children.size();
       children.add(child);
-      java.util.Collections.sort(children);
     }
 
     protected ActorNode getChild(final int childNo) {
+      if (!sorted) {
+        java.util.Collections.sort(children);
+        sorted = true;
+      }
+
       assert children != null : "Actor does not exist in trace!";
       assert children.size() > childNo : "Actor does not exist in trace!";
       return children.get(childNo);

--- a/src/tools/concurrency/TraceParser.java
+++ b/src/tools/concurrency/TraceParser.java
@@ -9,6 +9,7 @@ import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -172,7 +173,6 @@ public final class TraceParser {
             if (!resolvedPromises.containsKey(cause)) {
               resolvedPromises.put(cause, new ArrayList<>());
             }
-            VM.println("ERROR");
 
             resolvedPromises.get(cause).add(promise);
             parseParameter(); // param
@@ -346,7 +346,7 @@ public final class TraceParser {
 
     protected ActorNode getChild(final int childNo) {
       if (!sorted) {
-        java.util.Collections.sort(children);
+        Collections.sort(children);
         sorted = true;
       }
 

--- a/src/tools/concurrency/TraceParser.java
+++ b/src/tools/concurrency/TraceParser.java
@@ -204,6 +204,7 @@ public final class TraceParser {
     }
 
     assert unmappedActors.isEmpty();
+    assert unmappedPromises.isEmpty();
 
     VM.println("Trace with " + parsedMessages + " Messages and " + parsedActors + " Actors sucessfully parsed!");
   }

--- a/src/tools/concurrency/TracingActors.java
+++ b/src/tools/concurrency/TracingActors.java
@@ -141,7 +141,7 @@ public class TracingActors {
 
     private static void printMsg(final EventualMessage msg) {
       if (msg instanceof PromiseMessage) {
-        VM.println("\t" + "PromiseMessage " + msg.getSelector() + " from " + msg.getSender().getId() + " PID " + ((PromiseMessage) msg).getPromise().getPromiseId());
+        VM.println("\t" + "PromiseMessage " + msg.getSelector() + " from " + msg.getSender().getId() + " PID " + ((SReplayPromise) ((PromiseMessage) msg).getPromise()).getResolvingActor());
       } else {
         VM.println("\t" + "Message" + msg.getSelector() + " from " + msg.getSender().getId());
       }


### PR DESCRIPTION
Had to change the approach for PromiseMessages, due to a race between PromiseResolution and registration of callbacks. Instead of checking PromiseId now the Id of the resolving actor is used, also Promise callbacks now use the symbol of the block instead of #value.

- Removed extra replayId fields
- Fixed offset of Mailbox Contd. events
- Fixed mailbox numbering
- various other fixes