### PR TITLE
Use precise array type check

### DIFF
--- a/src/som/VM.java
+++ b/src/som/VM.java
@@ -131,11 +131,11 @@ public final class VM {
     graphPrinter.close();
   }
 
-  public VM(final String[] args, final boolean avoidExitForTesting) throws IOException {
+  public VM(final VmOptions vmOptions, final boolean avoidExitForTesting) throws IOException {
     vm = this;
 
     this.avoidExitForTesting = avoidExitForTesting;
-    options = new VmOptions(args);
+    options = vmOptions;
     objectSystem = new ObjectSystem(new SourcecodeCompiler(), structuralProbe);
     objectSystem.loadKernelAndPlatform(options.platformFile, options.kernelFile);
 
@@ -144,8 +144,8 @@ public final class VM {
     }
   }
 
-  public VM(final String[] args) throws IOException {
-    this(args, false);
+  public VM(final VmOptions vmOptions) throws IOException {
+    this(vmOptions, false);
   }
 
   public static void reportSyntaxElement(final Class<? extends Tags> type,
@@ -179,7 +179,7 @@ public final class VM {
     return lastExitCode;
   }
 
-  public static String[] getArguments() {
+  public static Object[] getArguments() {
     return vm.options.args;
   }
 
@@ -299,10 +299,11 @@ public final class VM {
   }
 
   public static void main(final String[] args) {
-    Builder builder = PolyglotEngine.newBuilder();
-    builder.config(SomLanguage.MIME_TYPE, SomLanguage.CMD_ARGS,   args);
-    builder.config(SomLanguage.MIME_TYPE, SomLanguage.AVOID_EXIT, false);
     VmOptions vmOptions = new VmOptions(args);
+    Builder builder = PolyglotEngine.newBuilder();
+    builder.config(SomLanguage.MIME_TYPE, SomLanguage.VM_OPTIONS,   vmOptions);
+    builder.config(SomLanguage.MIME_TYPE, SomLanguage.AVOID_EXIT, false);
+
 
     startExecution(builder, vmOptions);
   }

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -668,9 +668,8 @@ public final class MixinDefinition {
     return nestedMixinDefinitions.get(Symbols.symbolFor(string));
   }
 
-  public MixinDefinition[] getNestedMixinDefinitions() {
-    return nestedMixinDefinitions.values().toArray(
-        new MixinDefinition[nestedMixinDefinitions.size()]);
+  public Object[] getNestedMixinDefinitions() {
+    return nestedMixinDefinitions.values().toArray(new Object[0]);
   }
 
   public AccessModifier getAccessModifier() {

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -179,7 +179,7 @@ public final class MixinDefinition {
   // TODO: do we need to specialize this guard?
   @ExplodeLoop
   public static boolean sameSuperAndMixins(final Object superclassAndMixins, final Object cached) {
-    if (!(cached instanceof Object[])) {
+    if (cached.getClass() != Object[].class) {
       assert cached instanceof SClass;
       assert superclassAndMixins instanceof SClass;
 
@@ -189,7 +189,7 @@ public final class MixinDefinition {
       return result;
     }
 
-    if (!(superclassAndMixins instanceof Object[])) {
+    if (superclassAndMixins != Object[].class) {
       return false;
     }
 

--- a/src/som/interpreter/SomLanguage.java
+++ b/src/som/interpreter/SomLanguage.java
@@ -20,6 +20,7 @@ import com.oracle.truffle.api.source.Source;
 import som.VM;
 import som.compiler.MixinDefinition;
 import som.vm.NotYetImplementedException;
+import som.vm.VmOptions;
 import som.vm.constants.Nil;
 import som.vmobjects.SClass;
 import tools.concurrency.Tags.ChannelRead;
@@ -96,7 +97,7 @@ import tools.dym.Tags.VirtualInvokeReceiver;
 public final class SomLanguage extends TruffleLanguage<VM> {
 
   public static final String MIME_TYPE = "application/x-newspeak-som-ns";
-  public static final String CMD_ARGS  = "command-line-arguments";
+  public static final String VM_OPTIONS = "vm-options";
   public static final String AVOID_EXIT = "avoid-exit";
   public static final String FILE_EXTENSION = "som";
   public static final String DOT_FILE_EXTENSION = "." + FILE_EXTENSION;
@@ -136,7 +137,7 @@ public final class SomLanguage extends TruffleLanguage<VM> {
   protected VM createContext(final Env env) {
     VM vm;
     try {
-      vm = new VM((String[]) env.getConfig().get(CMD_ARGS),
+      vm = new VM((VmOptions) env.getConfig().get(VM_OPTIONS),
           (boolean) env.getConfig().get(AVOID_EXIT));
     } catch (IOException e) {
       throw new RuntimeException("Failed accessing kernel or platform code of SOMns.", e);

--- a/src/som/primitives/MirrorPrims.java
+++ b/src/som/primitives/MirrorPrims.java
@@ -1,6 +1,7 @@
 package som.primitives;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -58,7 +59,8 @@ public abstract class MirrorPrims {
     @Specialization
     public final SImmutableArray getMethod(final Object rcvr) {
       VM.thisMethodNeedsToBeOptimized("Uses Types.getClassOf, so, should be specialized in performance cirtical code");
-      SInvokable[] invokables = Types.getClassOf(rcvr).getMethods();
+      SInvokable[] is = Types.getClassOf(rcvr).getMethods();
+      Object[] invokables = Arrays.copyOf(is, is.length, Object[].class);
       return new SImmutableArray(invokables, Classes.valueArrayClass);
     }
   }
@@ -99,7 +101,7 @@ public abstract class MirrorPrims {
     public final Object getClassDefinition(final Object mixinHandle) {
       assert mixinHandle instanceof MixinDefinition;
       MixinDefinition def = (MixinDefinition) mixinHandle;
-      MixinDefinition[] nested = def.getNestedMixinDefinitions();
+      Object[] nested = def.getNestedMixinDefinitions();
       return new SImmutableArray(nested, Classes.valueArrayClass);
     }
   }
@@ -133,7 +135,7 @@ public abstract class MirrorPrims {
           methods.add((SInvokable) disp);
         }
       }
-      return new SImmutableArray(methods.toArray(new SInvokable[methods.size()]),
+      return new SImmutableArray(methods.toArray(new Object[0]),
           Classes.valueArrayClass);
     }
   }

--- a/src/som/vm/VmOptions.java
+++ b/src/som/vm/VmOptions.java
@@ -13,7 +13,7 @@ public class VmOptions {
 
   public String   platformFile = STANDARD_PLATFORM_FILE;
   public String   kernelFile   = STANDARD_KERNEL_FILE;
-  public final String[] args;
+  public final Object[] args;
   public final boolean showUsage;
 
   @CompilationFinal public boolean webDebuggerEnabled;
@@ -34,7 +34,7 @@ public class VmOptions {
     }
   }
 
-  private String[] processVmArguments(final String[] arguments) {
+  private Object[] processVmArguments(final String[] arguments) {
     int currentArg = 0;
 
     // parse optional --platform and --kernel, need to be the first arguments
@@ -71,9 +71,9 @@ public class VmOptions {
 
     // store remaining arguments
     if (currentArg < arguments.length) {
-      return Arrays.copyOfRange(arguments, currentArg, arguments.length);
+      return Arrays.copyOfRange(arguments, currentArg, arguments.length, Object[].class);
     } else {
-      return new String[0];
+      return new Object[0];
     }
   }
 

--- a/src/som/vmobjects/SArray.java
+++ b/src/som/vmobjects/SArray.java
@@ -80,10 +80,10 @@ public abstract class SArray extends SAbstractObject {
     return storage instanceof PartiallyEmptyArray;
   }
 
-  public boolean isObjectType()  { return storage instanceof Object[]; }
-  public boolean isLongType()    { return storage instanceof long[];   }
-  public boolean isDoubleType()  { return storage instanceof double[]; }
-  public boolean isBooleanType() { return storage instanceof boolean[]; }
+  public boolean isObjectType()  { return storage.getClass() == Object[].class; }
+  public boolean isLongType()    { return storage.getClass() == long[].class;   }
+  public boolean isDoubleType()  { return storage.getClass() == double[].class; }
+  public boolean isBooleanType() { return storage.getClass() == boolean[].class; }
 
   public boolean isSomePrimitiveType() {
     return isLongType() || isDoubleType() || isBooleanType();

--- a/src/tools/debugger/message/ProgramInfoResponse.java
+++ b/src/tools/debugger/message/ProgramInfoResponse.java
@@ -5,13 +5,13 @@ import tools.debugger.message.Message.OutgoingMessage;
 
 @SuppressWarnings("unused")
 public final class ProgramInfoResponse extends OutgoingMessage {
-  private final String[] args;
+  private final Object[] args;
 
-  private ProgramInfoResponse(final String[] args) {
+  private ProgramInfoResponse(final Object[] args) {
     this.args = args;
   }
 
-  public static ProgramInfoResponse create(final String[] args) {
+  public static ProgramInfoResponse create(final Object[] args) {
     return new ProgramInfoResponse(args);
   }
 }

--- a/tests/som/tests/BasicInterpreterTests.java
+++ b/tests/som/tests/BasicInterpreterTests.java
@@ -40,6 +40,7 @@ import com.oracle.truffle.api.vm.PolyglotEngine.Builder;
 import som.VM;
 import som.interpreter.SomLanguage;
 import som.interpreter.Types;
+import som.vm.VmOptions;
 import som.vmobjects.SClass;
 import som.vmobjects.SSymbol;
 
@@ -247,7 +248,7 @@ public class BasicInterpreterTests {
 
   protected VM getInitializedVM() throws IOException {
     Builder builder = PolyglotEngine.newBuilder();
-    builder.config(SomLanguage.MIME_TYPE, SomLanguage.CMD_ARGS, getVMArguments());
+    builder.config(SomLanguage.MIME_TYPE, SomLanguage.VM_OPTIONS, getVMArguments());
     builder.config(SomLanguage.MIME_TYPE, SomLanguage.AVOID_EXIT, true);
     PolyglotEngine engine = builder.build();
 
@@ -258,10 +259,10 @@ public class BasicInterpreterTests {
     return VM.getVM();
   }
 
-  protected String[] getVMArguments() {
-    return new String[] {
+  protected VmOptions getVMArguments() {
+    return new VmOptions(new String[] {
         "--platform",
-        "core-lib/TestSuite/BasicInterpreterTests/" + testClass + ".som" };
+        "core-lib/TestSuite/BasicInterpreterTests/" + testClass + ".som" });
   }
 
   @Override

--- a/tests/som/tests/SomPolyglotTests.java
+++ b/tests/som/tests/SomPolyglotTests.java
@@ -19,6 +19,7 @@ import com.oracle.truffle.tools.ProfilerInstrument;
 
 import som.VM;
 import som.interpreter.SomLanguage;
+import som.vm.VmOptions;
 
 
 public class SomPolyglotTests {
@@ -36,10 +37,10 @@ public class SomPolyglotTests {
 
   @Test
   public void startEngineWithCommandLineParametersForHelloWorld() throws IOException {
-    String[] args = new String[] {"core-lib/Hello.som"};
+    VmOptions options = new VmOptions(new String[] {"core-lib/Hello.som"});
 
     Builder builder = PolyglotEngine.newBuilder();
-    builder.config(SomLanguage.MIME_TYPE, SomLanguage.CMD_ARGS, args);
+    builder.config(SomLanguage.MIME_TYPE, SomLanguage.VM_OPTIONS, options);
     builder.config(SomLanguage.MIME_TYPE, SomLanguage.AVOID_EXIT, true);
     PolyglotEngine vm = builder.build();
     VM.setEngine(vm);
@@ -51,8 +52,9 @@ public class SomPolyglotTests {
   @Test
   public void startEngineForTesting() throws IOException {
     Builder builder = PolyglotEngine.newBuilder();
-    builder.config(SomLanguage.MIME_TYPE, SomLanguage.CMD_ARGS, new String[] {
-        "--platform", "core-lib/TestSuite/BasicInterpreterTests/Arrays.som"});
+    builder.config(SomLanguage.MIME_TYPE, SomLanguage.VM_OPTIONS,
+        new VmOptions(new String[] {
+            "--platform", "core-lib/TestSuite/BasicInterpreterTests/Arrays.som"}));
     builder.config(SomLanguage.MIME_TYPE, SomLanguage.AVOID_EXIT, true);
     PolyglotEngine engine = builder.build();
     VM.setEngine(engine);
@@ -68,10 +70,10 @@ public class SomPolyglotTests {
 
   @Test
   public void executeHelloWorldWithTruffleProfiler() throws IOException {
-    String[] args = new String[] {"core-lib/Hello.som"};
+    VmOptions options = new VmOptions(new String[] {"core-lib/Hello.som"});
 
     Builder builder = PolyglotEngine.newBuilder();
-    builder.config(SomLanguage.MIME_TYPE, SomLanguage.CMD_ARGS, args);
+    builder.config(SomLanguage.MIME_TYPE, SomLanguage.VM_OPTIONS, options);
     builder.config(SomLanguage.MIME_TYPE, SomLanguage.AVOID_EXIT, true);
     PolyglotEngine vm = builder.build();
     VM.setEngine(vm);
@@ -91,10 +93,10 @@ public class SomPolyglotTests {
 
   @Test
   public void executeHelloWorldWithoutTruffleProfiler() throws IOException {
-    String[] args = new String[] {"core-lib/Hello.som"};
+    VmOptions options = new VmOptions(new String[] {"core-lib/Hello.som"});
 
     Builder builder = PolyglotEngine.newBuilder();
-    builder.config(SomLanguage.MIME_TYPE, SomLanguage.CMD_ARGS, args);
+    builder.config(SomLanguage.MIME_TYPE, SomLanguage.VM_OPTIONS, options);
     builder.config(SomLanguage.MIME_TYPE, SomLanguage.AVOID_EXIT, true);
     PolyglotEngine vm = builder.build();
     VM.setEngine(vm);

--- a/tests/som/tests/SomTests.java
+++ b/tests/som/tests/SomTests.java
@@ -38,6 +38,7 @@ import com.oracle.truffle.api.vm.PolyglotEngine.Builder;
 
 import som.VM;
 import som.interpreter.SomLanguage;
+import som.vm.VmOptions;
 
 
 @RunWith(Parameterized.class)
@@ -78,12 +79,12 @@ public class SomTests {
   public void testSomeTest() throws IOException {
     Assume.assumeTrue(ignoreReason, ignoreReason == null);
 
-    String[] args = new String[] {
+    VmOptions options = new VmOptions(new String[] {
         "core-lib/TestSuite/TestRunner.som",
-        "core-lib/TestSuite/" + testName + ".som"};
+        "core-lib/TestSuite/" + testName + ".som"});
 
     Builder builder = PolyglotEngine.newBuilder();
-    builder.config(SomLanguage.MIME_TYPE, SomLanguage.CMD_ARGS, args);
+    builder.config(SomLanguage.MIME_TYPE, SomLanguage.VM_OPTIONS, options);
     builder.config(SomLanguage.MIME_TYPE, SomLanguage.AVOID_EXIT, true);
     PolyglotEngine engine = builder.build();
     VM.setEngine(engine);

--- a/tests/som/tests/TruffleSomTCK.java
+++ b/tests/som/tests/TruffleSomTCK.java
@@ -35,9 +35,10 @@ public class TruffleSomTCK extends TruffleTCK {
 
   @Override
   protected PolyglotEngine prepareVM(final PolyglotEngine.Builder preparedBuilder) throws IOException {
-    String[] args = new String [] {"--kernel", VmOptions.STANDARD_KERNEL_FILE,
-        "--platform", VmOptions.STANDARD_PLATFORM_FILE};
-    preparedBuilder.config(SomLanguage.MIME_TYPE, SomLanguage.CMD_ARGS, args);
+    VmOptions options = new VmOptions(new String [] {
+        "--kernel", VmOptions.STANDARD_KERNEL_FILE,
+        "--platform", VmOptions.STANDARD_PLATFORM_FILE});
+    preparedBuilder.config(SomLanguage.MIME_TYPE, SomLanguage.VM_OPTIONS, options);
     preparedBuilder.config(SomLanguage.MIME_TYPE, SomLanguage.AVOID_EXIT, true);
 
     InputStream in = getClass().getResourceAsStream("TruffleSomTCK.som");


### PR DESCRIPTION
Avoid use of `instanceof` in favor for precise `.getClass() == ` check.

This avoids some complexity for compilation, and potentially run time.
It doesn't have any relevant performance impact at the moment.
However, it also avoids Truffle's performance warning for `instanceof Object[]`, because it isn't a leaf type.

@richard-roberts would be great if you could review this.