### PR TITLE
Message stepping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,5 @@ traces
 /tests/dym/old-results
 /tests/dym/results
 /tests/dym/expected-results
-/npm-debug.log
-/tools/kompos/npm-debug.log
+npm-debug.log*
 /.metadata

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -187,12 +187,6 @@ public class Actor implements Activity {
     mailboxExtension.append(msg);
   }
 
-  protected static void handleBreakPoints(final EventualMessage msg, final WebDebugger dbg) {
-    if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && msg.isMessageReceiverBreakpointSet()) {
-      dbg.prepareSteppingUntilNextRootNode();
-    }
-  }
-
   /**
    * Is scheduled on the fork/join pool and executes messages for a specific
    * actor.
@@ -268,7 +262,9 @@ public class Actor implements Activity {
     private void execute(final EventualMessage msg,
         final ActorProcessingThread currentThread, final WebDebugger dbg, final int i) {
       currentThread.currentMessage = msg;
-      handleBreakPoints(msg, dbg);
+      if (VmSettings.ACTOR_TRACING) {
+        TracingActor.handleBreakpointsAndStepping(msg, dbg, actor);
+      }
 
       if (i >= 0 && VmSettings.MESSAGE_TIMESTAMPS) {
         executionTimeStamps[i] = System.currentTimeMillis();
@@ -325,6 +321,8 @@ public class Actor implements Activity {
     }
   }
 
+  @Override
+  public void setStepToNextTurn(final boolean val) {  }
 
   public static final class ActorProcessingThreadFactory implements ForkJoinWorkerThreadFactory {
     @Override

--- a/src/som/interpreter/actors/EventualMessage.java
+++ b/src/som/interpreter/actors/EventualMessage.java
@@ -9,14 +9,11 @@ import som.VM;
 import som.interpreter.actors.Actor.ActorProcessingThread;
 import som.interpreter.actors.ReceivedMessage.ReceivedCallback;
 import som.interpreter.actors.SPromise.SResolver;
-import som.vm.Symbols;
 import som.vmobjects.SBlock;
 import som.vmobjects.SSymbol;
 
 
 public abstract class EventualMessage {
-  private static final SSymbol VALUE_SELECTOR = Symbols.symbolFor("value:");
-
   protected final Object[]  args;
   protected final SResolver resolver;
   protected final RootCallTarget onReceive;
@@ -233,13 +230,18 @@ public abstract class EventualMessage {
   /** The callback message to be send after a promise is resolved. */
   public static final class PromiseCallbackMessage extends PromiseMessage {
     protected final SPromise promise;
+    /**
+     * The promise on which this callback is registered on.
+     */
+    protected final SPromise promiseRegisteredOn;
 
     public PromiseCallbackMessage(final long causalMessageId, final Actor owner, final SBlock callback,
         final SResolver resolver, final RootCallTarget onReceive, final boolean triggerMessageReceiverBreakpoint,
-        final boolean triggerPromiseResolverBreakpoint, final SPromise parent) {
+        final boolean triggerPromiseResolverBreakpoint, final SPromise parent, final SPromise promiseRegisteredOn) {
       super(causalMessageId, new Object[] {callback, null}, owner, resolver, onReceive,
           triggerMessageReceiverBreakpoint, triggerPromiseResolverBreakpoint);
       this.promise = parent;
+      this.promiseRegisteredOn = promiseRegisteredOn;
     }
 
     @Override
@@ -276,6 +278,10 @@ public abstract class EventualMessage {
     @Override
     public SPromise getPromise() {
       return promise;
+    }
+
+    public SPromise getPromiseRegisteredOn() {
+      return promiseRegisteredOn;
     }
   }
 

--- a/src/som/interpreter/actors/ResolvePromiseNode.java
+++ b/src/som/interpreter/actors/ResolvePromiseNode.java
@@ -19,6 +19,8 @@ public abstract class ResolvePromiseNode extends AbstractPromiseResolutionNode {
 
   /**
    * Normal case, when the promise is resolved with a value that's not a promise.
+   * Here we need to distinguish the explicit promises to ask directly to the promise
+   * if a promise resolution breakpoint was set.
    */
   @Specialization(guards = {"notAPromise(result)"})
   public SResolver normalResolution(final VirtualFrame frame, final SResolver resolver, final Object result,

--- a/src/som/primitives/processes/ChannelPrimitives.java
+++ b/src/som/primitives/processes/ChannelPrimitives.java
@@ -119,6 +119,13 @@ public abstract class ChannelPrimitives {
     public String getName() {
       return obj.getSOMClass().getName().getString();
     }
+
+    @Override
+    public void setStepToNextTurn(final boolean val) {
+      throw new UnsupportedOperationException(
+          "Step to next turn is not supported " +
+          "for processes. This code should never be reached.");
+    }
   }
 
   public static class TracingProcess extends Process {

--- a/src/som/primitives/threading/TaskThreads.java
+++ b/src/som/primitives/threading/TaskThreads.java
@@ -54,6 +54,13 @@ public final class TaskThreads {
         ObjectTransitionSafepoint.INSTANCE.unregister();
       }
     }
+
+    @Override
+    public void setStepToNextTurn(final boolean val) {
+      throw new UnsupportedOperationException(
+          "Step to next turn is not supported " +
+          "for threads. This code should never be reached.");
+    }
   }
 
   public static class SomForkJoinTask extends SomTaskOrThread {

--- a/src/som/vm/Activity.java
+++ b/src/som/vm/Activity.java
@@ -14,4 +14,6 @@ public interface Activity {
   /** Set the flag that indicates a breakpoint on joining activity.
       Does nothing for non-tracing activities, i.e., when debugging is disabled. */
   default void setStepToJoin(final boolean val) { }
+
+  void setStepToNextTurn(boolean val);
 }

--- a/src/tools/debugger/SteppingStrategy.java
+++ b/src/tools/debugger/SteppingStrategy.java
@@ -1,6 +1,8 @@
 package tools.debugger;
 
 import som.vm.Activity;
+import som.vm.ActivityThread;
+import som.vm.VmSettings;
 
 public abstract class SteppingStrategy {
 
@@ -18,6 +20,12 @@ public abstract class SteppingStrategy {
   public boolean handleTxAfterCommit() { return false; }
 
   public void handleResumeExecution(final Activity activity) { }
+
+  public boolean handleMessageReceiver() { return false; }
+  public boolean handleMessageToPromiseResolution() { return false; }
+  public boolean handleMessageReturnFromTurn() { return false; }
+
+  public void handleMessageToNextTurn(final Activity activity) { }
 
   // TODO: can we get rid of the code doing the checking for those stepping things,
   //       and integrate it into the breakpoint checking nodes?
@@ -72,5 +80,62 @@ public abstract class SteppingStrategy {
 
       return true;
     }
+  }
+
+  public static final class ToMessageReceiver extends SteppingStrategy {
+    @Override
+    public boolean handleMessageReceiver() {
+        if (consumed) { return false; } else { consumed = true; }
+        return true;
+    }
+  }
+
+  public static final class ToPromiseResolution extends SteppingStrategy {
+    @Override
+    public boolean handleMessageToPromiseResolution() {
+        if (consumed) { return false; } else { consumed = true; }
+        return true;
+    }
+  }
+
+  public static final class ToNextTurn extends SteppingStrategy {
+    @Override
+    public void handleMessageToNextTurn(final Activity activity) {
+        if (consumed) { return; } else { consumed = true; }
+
+        activity.setStepToNextTurn(true);
+    }
+  }
+
+  public static final class ReturnFromTurnToPromiseResolution extends SteppingStrategy {
+    @Override
+    public boolean handleMessageReturnFromTurn() {
+        if (consumed) { return false; } else { consumed = true; }
+        return true;
+    }
+  }
+
+  /**
+   *  Return true if the given stepping strategy has been activated.
+   */
+  public static boolean isEnabled(final Class<? extends SteppingStrategy> strategyClass) {
+    if (!VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
+      return false;
+    }
+
+    SteppingStrategy strategy = ActivityThread.steppingStrategy();
+    if (strategy == null) {
+      return false;
+    }
+
+    if (strategy instanceof ToMessageReceiver && strategyClass.equals(ToMessageReceiver.class)) {
+      return strategy.handleMessageReceiver();
+    } else if (strategy instanceof ToPromiseResolution && strategyClass.equals(ToPromiseResolution.class)) {
+      return strategy.handleMessageToPromiseResolution();
+    } else if (strategy instanceof ReturnFromTurnToPromiseResolution && strategyClass.equals(ReturnFromTurnToPromiseResolution.class)) {
+      return strategy.handleMessageReturnFromTurn();
+    }
+
+    return false;
   }
 }

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -1,15 +1,17 @@
 package tools.debugger.entities;
 
 import com.google.gson.annotations.SerializedName;
-import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 
 import som.vm.NotYetImplementedException;
 import tools.concurrency.Tags;
 import tools.concurrency.Tags.ActivityCreation;
 import tools.concurrency.Tags.ChannelRead;
 import tools.concurrency.Tags.ChannelWrite;
+import tools.concurrency.Tags.CreatePromisePair;
 import tools.concurrency.Tags.EventualMessageSend;
-import tools.concurrency.Tags.ExpressionBreakpoint;
+import tools.concurrency.Tags.OnError;
+import tools.concurrency.Tags.WhenResolved;
+import tools.concurrency.Tags.WhenResolvedOnError;
 import tools.debugger.SteppingStrategy.AfterCommit;
 import tools.debugger.SteppingStrategy.IntoSpawn;
 import tools.debugger.SteppingStrategy.ReturnFromActivity;
@@ -159,7 +161,10 @@ public enum SteppingType {
     },
 
   @SerializedName("stepToPromiseResolution")
-  STEP_TO_PROMISE_RESOLUTION("stepToPromiseResolution", "Step to Promise Resolution", Group.ACTOR_STEPPING, "msg-white", new Class[] {ExpressionBreakpoint.class}, new ActivityType[] {ActivityType.ACTOR}) {
+  STEP_TO_PROMISE_RESOLUTION("stepToPromiseResolution", "Step to Promise Resolution",
+      Group.ACTOR_STEPPING, "msg-white",
+      new Class[] {EventualMessageSend.class, CreatePromisePair.class,
+          WhenResolved.class, WhenResolvedOnError.class, OnError.class}) {
       @Override public void process(final Suspension susp) {
        susp.getEvent().prepareStepOver(1);
        susp.getActivityThread().setSteppingStrategy(new ToPromiseResolution());
@@ -174,8 +179,10 @@ public enum SteppingType {
     }
   },
 
-  @SerializedName("stepReturnFromTurnToPromiseResolution")
-  STEP_RETURN_FROM_TURN_TO_PROMISE_RESOLUTION("stepReturnFromTurnToPromiseResolution", "Step Return From Turn to Promise Resolution", Group.ACTOR_STEPPING, "msg-embedded", new Class[] {StatementTag.class}, new ActivityType[] {ActivityType.ACTOR}) {
+  @SerializedName("returnFromTurnToPromiseResolution")
+  RETURN_FROM_TURN_TO_PROMISE_RESOLUTION("returnFromTurnToPromiseResolution",
+      "Return from Turn to Promise Resolution", Group.ACTOR_STEPPING, "msg-embedded",
+      null, new ActivityType[] {ActivityType.ACTOR}) {
     @Override public void process(final Suspension susp) {
       susp.getEvent().prepareStepOver(1);
       susp.getActivityThread().setSteppingStrategy(new ReturnFromTurnToPromiseResolution());

--- a/src/tools/debugger/frontend/Suspension.java
+++ b/src/tools/debugger/frontend/Suspension.java
@@ -148,6 +148,7 @@ public class Suspension {
         SteppingStrategy strategy = activityThread.getSteppingStrategy();
         if (!continueWaiting && strategy != null) {
           strategy.handleResumeExecution(activity);
+          strategy.handleMessageToNextTurn(activity);
         }
 
       } catch (InterruptedException e) { /* Just continue waiting */ }

--- a/tools/kompos/index.html
+++ b/tools/kompos/index.html
@@ -282,6 +282,11 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
   .trace-method {
     float:left;
   }
+  .log-scroll {
+    overflow-y:scroll;
+    height:100px;
+    padding: 1rem;
+  }
   </style>
 </head>
 <body>
@@ -330,7 +335,7 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
 </tbody>
 </table>
 
-<div id="debugger-log" class="panel-footer" style="font-size: 75%">
+<div id="debugger-log" class="panel-footer log-scroll" style="font-size: 75%">
 </div>
 
 <!-- Unicode Icons: incompletely supported
@@ -356,7 +361,6 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
             </button>
           </div>
         </div>
-
         <div class="activity-stack btn-group-vertical stack" data-toggle="buttons"></div>
 
         <table class="activity-scopes"><tbody></tbody></table>
@@ -400,12 +404,16 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
   <button id="bp-menu-btn" class="btn btn-secondary btn-sm btn-block bp-btn"></button>
 
   <div id="debugger-button-icons">
-    <i id="icon-play"        class="fa fa-play"></i>
-    <i id="icon-pause"       class="fa fa-pause"></i>
-    <i id="icon-stop"        class="fa fa-stop"></i>
-    <i id="icon-arrow-down"  class="fa fa-share" style="transform: rotate(90deg);"></i>
-    <i id="icon-arrow-right" class="fa fa-share"></i>
-    <i id="icon-arrow-left"  class="fa fa-reply" style="transform: scaleY(-1);"></i>
+    <i id="icon-play"         class="fa fa-play"></i>
+    <i id="icon-pause"        class="fa fa-pause"></i>
+    <i id="icon-stop"         class="fa fa-stop"></i>
+    <i id="icon-arrow-down"   class="fa fa-share" style="transform: rotate(90deg);"></i>
+    <i id="icon-arrow-right"  class="fa fa-share"></i>
+    <i id="icon-arrow-left"   class="fa fa-reply" style="transform: scaleY(-1);"></i>
+    <i id="icon-msg-open"     class="fa fa-envelope-open"></i>
+    <i id="icon-msg-close"    class="fa fa-envelope"></i>
+    <i id="icon-msg-white"    class="fa fa-envelope-o"></i>
+    <i id="icon-msg-embedded" class="fa fa-envelope-square"></i>
   </div>
 
   <div id="debugger-step-btn-group"


### PR DESCRIPTION
This pull request adds support for message stepping.
Specifically were added four operations: 

1. step-to-message-receiver: can be trigger only from the EventualSendNode. Stops execution in the receiver of the message.
2. step-to-promise-resolution: can be trigger from any expression that creates promises. Stops execution at promise resolution, before executing the callback. 
3. step-return-from-turn-to-promise-resolution: can be trigger from any StatementTag inside a turn. Stops execution at promise resolution after processing the turn.
4. step-to-next-turn: can be trigger from anywhere inside a turn. Stops execution in the next message of the mailbox of the current actor.

The main changes are:

- add in `SteppingType` class the implementation corresponding to the four stepping operations for actors.
- field `promiseRegisteredOn` in `PromiseCallbackMessage` class for support the step-return-from-turn-to-promise-resolution operation.
- in `EventualSendNode` class the method `hasMessageReceiverBreakpoint` is called when the messages are created, to check if was triggered any stepping operation and it updates the corresponding breakpoint flags. Similarly, in `PromisePrims` class a method `hasPromiseResolutionBreakpoint` is called to check the stepping and updates the corresponding breakpoint flags.
- add in `SteppingStrategy` class the method `isEnabled` to check if a given strategy has been enabled.
- in the `TracingActor` class is the method for handling breakpoints and stepping. This method was modified in order to check the flag of the actor corresponding to the step-to-next-turn and also to check if a step-return-from-turn-to-promise-resolution was executed.

TODO
- implement stepping tests.

Notes: 
- an improvement of the stepping visualization is going to be implemented in another branch.
- the message conditional breakpoint, and step until an operation is going to be implemented in another branch.