### PR TITLE
Make debugger agnostic to specific stepping operations

### DIFF
--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -25,6 +25,7 @@ import tools.concurrency.TracingActivityThread;
 import tools.concurrency.TracingActors.ReplayActor;
 import tools.concurrency.TracingActors.TracingActor;
 import tools.debugger.WebDebugger;
+import tools.debugger.entities.ActivityType;
 
 
 /**
@@ -95,6 +96,9 @@ public class Actor implements Activity {
     isExecuting = false;
     executor = createExecutor(vm);
   }
+
+  @Override
+  public ActivityType getType() { return ActivityType.ACTOR; }
 
   protected ExecAllMessages createExecutor(final VM vm) {
     return new ExecAllMessages(this, vm);

--- a/src/som/primitives/processes/ChannelPrimitives.java
+++ b/src/som/primitives/processes/ChannelPrimitives.java
@@ -36,6 +36,7 @@ import tools.concurrency.Tags.ChannelRead;
 import tools.concurrency.Tags.ChannelWrite;
 import tools.concurrency.Tags.ExpressionBreakpoint;
 import tools.concurrency.TracingActivityThread;
+import tools.debugger.entities.ActivityType;
 import tools.debugger.entities.BreakpointType;
 import tools.debugger.nodes.AbstractBreakpointNode;
 import tools.debugger.session.Breakpoints;
@@ -92,6 +93,9 @@ public abstract class ChannelPrimitives {
     public Process(final SObjectWithClass obj) {
       this.obj = obj;
     }
+
+    @Override
+    public ActivityType getType() { return ActivityType.PROCESS; }
 
     @Override
     public void run() {

--- a/src/som/primitives/threading/TaskThreads.java
+++ b/src/som/primitives/threading/TaskThreads.java
@@ -10,6 +10,7 @@ import som.vm.Activity;
 import som.vmobjects.SBlock;
 import som.vmobjects.SInvokable;
 import tools.concurrency.TracingActivityThread;
+import tools.debugger.entities.ActivityType;
 
 public final class TaskThreads {
 
@@ -22,6 +23,9 @@ public final class TaskThreads {
       this.argArray = argArray;
       assert argArray[0] instanceof SBlock : "First argument of a block needs to be the block object";
     }
+
+    @Override
+    public ActivityType getType() { return ActivityType.TASK; }
 
     public final SInvokable getMehtod() {
       return ((SBlock) argArray[0]).getMethod();

--- a/src/som/primitives/threading/ThreadPrimitives.java
+++ b/src/som/primitives/threading/ThreadPrimitives.java
@@ -13,6 +13,7 @@ import som.vm.ActivityThread;
 import som.vm.constants.Nil;
 import som.vmobjects.SBlock;
 import som.vmobjects.SClass;
+import tools.debugger.entities.ActivityType;
 
 public final class ThreadPrimitives {
   @GenerateNodeFactory
@@ -75,6 +76,9 @@ public final class ThreadPrimitives {
       this.block = block;
       this.args  = args;
     }
+
+    @Override
+    public ActivityType getType() { return ActivityType.THREAD; }
 
     @Override
     public void run() {

--- a/src/som/vm/Activity.java
+++ b/src/som/vm/Activity.java
@@ -1,7 +1,9 @@
 package som.vm;
 
+import tools.debugger.entities.ActivityType;
 
 public interface Activity {
   String getName();
   long getId();
+  ActivityType getType();
 }

--- a/src/tools/debugger/FrontendConnector.java
+++ b/src/tools/debugger/FrontendConnector.java
@@ -30,6 +30,7 @@ import tools.concurrency.ActorExecutionTrace;
 import tools.debugger.entities.ActivityType;
 import tools.debugger.entities.BreakpointType;
 import tools.debugger.entities.EntityType;
+import tools.debugger.entities.SteppingType;
 import tools.debugger.frontend.Suspension;
 import tools.debugger.message.InitializationResponse;
 import tools.debugger.message.Message;
@@ -279,7 +280,7 @@ public class FrontendConnector {
   public void completeConnection(final WebSocket conn) {
     clientConnected.complete(conn);
     send(InitializationResponse.create(EntityType.values(),
-        ActivityType.values(), BreakpointType.values()));
+        ActivityType.values(), BreakpointType.values(), SteppingType.values()));
   }
 
   public void shutdown() {

--- a/src/tools/debugger/WebDebugger.java
+++ b/src/tools/debugger/WebDebugger.java
@@ -40,11 +40,7 @@ import tools.debugger.message.ScopesResponse;
 import tools.debugger.message.SourceMessage;
 import tools.debugger.message.StackTraceRequest;
 import tools.debugger.message.StackTraceResponse;
-import tools.debugger.message.StepMessage.Resume;
-import tools.debugger.message.StepMessage.Return;
-import tools.debugger.message.StepMessage.StepInto;
-import tools.debugger.message.StepMessage.StepOver;
-import tools.debugger.message.StepMessage.Stop;
+import tools.debugger.message.StepMessage;
 import tools.debugger.message.StoppedMessage;
 import tools.debugger.message.SymbolMessage;
 import tools.debugger.message.TraceDataRequest;
@@ -191,7 +187,7 @@ public class WebDebugger extends TruffleInstrument implements SuspendedCallback 
 
   public static Gson createJsonProcessor() {
     ClassHierarchyAdapterFactory<OutgoingMessage> outMsgAF = new ClassHierarchyAdapterFactory<>(OutgoingMessage.class, "type");
-    outMsgAF.register("source",       SourceMessage.class);
+    outMsgAF.register("source", SourceMessage.class);
     outMsgAF.register(InitializationResponse.class);
     outMsgAF.register(StoppedMessage.class);
     outMsgAF.register(SymbolMessage.class);
@@ -202,12 +198,8 @@ public class WebDebugger extends TruffleInstrument implements SuspendedCallback 
 
     ClassHierarchyAdapterFactory<IncommingMessage> inMsgAF = new ClassHierarchyAdapterFactory<>(IncommingMessage.class, "action");
     inMsgAF.register(InitializeConnection.class);
-    inMsgAF.register("updateBreakpoint",   UpdateBreakpoint.class);
-    inMsgAF.register("stepInto", StepInto.class);
-    inMsgAF.register("stepOver", StepOver.class);
-    inMsgAF.register("return",   Return.class);
-    inMsgAF.register("resume",   Resume.class);
-    inMsgAF.register("stop",     Stop.class);
+    inMsgAF.register("updateBreakpoint", UpdateBreakpoint.class);
+    inMsgAF.register(StepMessage.class);
     inMsgAF.register(StackTraceRequest.class);
     inMsgAF.register(ScopesRequest.class);
     inMsgAF.register(VariablesRequest.class);

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -3,11 +3,40 @@ package tools.debugger.entities;
 import com.google.gson.annotations.SerializedName;
 import com.oracle.truffle.api.debug.SuspendedEvent;
 
+import som.vm.NotYetImplementedException;
+import tools.concurrency.Tags;
 
+
+// TODO: stepping, is that the right name?
 public enum SteppingType {
 
+  @SerializedName("resume")
+  RESUME("resume", "Resume Execution", Group.BASIC_CONTROLS, "play", null) {
+    @Override
+    public void process(final SuspendedEvent event) {
+      event.prepareContinue();
+    }
+  },
+
+  @SerializedName("pause")
+  PAUSE("pause", "Pause Execution", Group.BASIC_CONTROLS, "pause", null) {
+    @Override
+    public void process(final SuspendedEvent event) {
+      // TODO: at this point, we don't have an `event`???!!!
+      throw new NotYetImplementedException();
+    }
+  },
+
+  @SerializedName("stop")
+  STOP("stop", "stop", Group.BASIC_CONTROLS, "stop", null) {
+    @Override
+    public void process(final SuspendedEvent event) {
+      event.prepareKill();
+    }
+  },
+
   @SerializedName("stepInto")
-  STEP_INTO("stepInto", "step into") {
+  STEP_INTO("stepInto", "Step Into", Group.LOCAL_STEPPING, "arrow-down", null) {
     @Override
     public void process(final SuspendedEvent event) {
       event.prepareStepInto(1);
@@ -15,7 +44,7 @@ public enum SteppingType {
   },
 
   @SerializedName("stepOver")
-  STEP_OVER("stepOver", "step over") {
+  STEP_OVER("stepOver", "Step Over", Group.LOCAL_STEPPING, "arrow-right", null) {
     @Override
     public void process(final SuspendedEvent event) {
       event.prepareStepOver(1);
@@ -23,40 +52,44 @@ public enum SteppingType {
   },
 
   @SerializedName("return")
-  STEP_RETURN("return", "return") {
+  STEP_RETURN("return", "Return from Method", Group.LOCAL_STEPPING, "arrow-left", null) {
     @Override
     public void process(final SuspendedEvent event) {
       event.prepareStepOut();
     }
   },
 
-  @SerializedName("stop")
-  STOP("stop", "stop") {
-    @Override
-    public void process(final SuspendedEvent event) {
-      event.prepareKill();
-    }
-  },
+  STEP_TO_RECEIVER_MESSAGE("todo", "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final SuspendedEvent event) { /* TODO */ } },
+  STEP_TO_PROMISE_RESOLUTION("todo", "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final SuspendedEvent event) { /* TODO */ } },
+  STEP_TO_NEXT_MESSAGE("todo", "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final SuspendedEvent event) { /* TODO */ } },
+  STEP_RETURN_TO_PROMISE_RESOLUTION("todo", "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final SuspendedEvent event) { /* TODO */ } };
 
-  @SerializedName("resume")
-  RESUME("resume", "resume") {
-    @Override
-    public void process(final SuspendedEvent event) {
-      event.prepareContinue();
-    }
-  },
+  public enum Group {
+    BASIC_CONTROLS("Basic Controls"),
+    LOCAL_STEPPING("Local Stepping"),
+    ACTOR_STEPPING("Actor Stepping");
 
-  STEP_TO_RECEIVER_MESSAGE("todo", "todo") { @Override public void process(final SuspendedEvent event) { /* TODO */ } },
-  STEP_TO_PROMISE_RESOLUTION("todo", "todo") { @Override public void process(final SuspendedEvent event) { /* TODO */ } },
-  STEP_TO_NEXT_MESSAGE("todo", "todo") { @Override public void process(final SuspendedEvent event) { /* TODO */ } },
-  STEP_RETURN_TO_PROMISE_RESOLUTION("todo", "todo") { @Override public void process(final SuspendedEvent event) { /* TODO */ } };
+    public final String label;
+
+    Group(final String label) { this.label = label; }
+  }
 
   public final String name;
   public final String label;
+  public final Group  group;
+  public final String icon;
 
-  SteppingType(final String name, final String label) {
+  /** Tag to identify the source sections at which this step operation makes sense.
+      If no tags are given, it is assumed the operation is always valid. */
+  public final Class<? extends Tags>[] applicableTo;
+
+  SteppingType(final String name, final String label, final Group group, final String icon,
+      final Class<? extends Tags>[] applicableTo) {
     this.name  = name;
     this.label = label;
+    this.group = group;
+    this.icon  = icon;
+    this.applicableTo = applicableTo;
   }
 
   public abstract void process(SuspendedEvent event);

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -1,0 +1,13 @@
+package tools.debugger.entities;
+
+public enum SteppingType {
+  STEP_INTO,
+  STEP_OVER,
+  STEP_RETURN,
+  STEP_TO_RECEIVER_MESSAGE,
+  STEP_TO_PROMISE_RESOLUTION,
+  STEP_TO_NEXT_MESSAGE,
+  STEP_RETURN_TO_PROMISE_RESOLUTION,
+  STOP,
+  RESUME
+}

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -1,13 +1,63 @@
 package tools.debugger.entities;
 
+import com.google.gson.annotations.SerializedName;
+import com.oracle.truffle.api.debug.SuspendedEvent;
+
+
 public enum SteppingType {
-  STEP_INTO,
-  STEP_OVER,
-  STEP_RETURN,
-  STEP_TO_RECEIVER_MESSAGE,
-  STEP_TO_PROMISE_RESOLUTION,
-  STEP_TO_NEXT_MESSAGE,
-  STEP_RETURN_TO_PROMISE_RESOLUTION,
-  STOP,
-  RESUME
+
+  @SerializedName("stepInto")
+  STEP_INTO("stepInto", "step into") {
+    @Override
+    public void process(final SuspendedEvent event) {
+      event.prepareStepInto(1);
+    }
+  },
+
+  @SerializedName("stepOver")
+  STEP_OVER("stepOver", "step over") {
+    @Override
+    public void process(final SuspendedEvent event) {
+      event.prepareStepOver(1);
+    }
+  },
+
+  @SerializedName("return")
+  STEP_RETURN("return", "return") {
+    @Override
+    public void process(final SuspendedEvent event) {
+      event.prepareStepOut();
+    }
+  },
+
+  @SerializedName("stop")
+  STOP("stop", "stop") {
+    @Override
+    public void process(final SuspendedEvent event) {
+      event.prepareKill();
+    }
+  },
+
+  @SerializedName("resume")
+  RESUME("resume", "resume") {
+    @Override
+    public void process(final SuspendedEvent event) {
+      event.prepareContinue();
+    }
+  },
+
+  STEP_TO_RECEIVER_MESSAGE("todo", "todo") { @Override public void process(final SuspendedEvent event) { /* TODO */ } },
+  STEP_TO_PROMISE_RESOLUTION("todo", "todo") { @Override public void process(final SuspendedEvent event) { /* TODO */ } },
+  STEP_TO_NEXT_MESSAGE("todo", "todo") { @Override public void process(final SuspendedEvent event) { /* TODO */ } },
+  STEP_RETURN_TO_PROMISE_RESOLUTION("todo", "todo") { @Override public void process(final SuspendedEvent event) { /* TODO */ } };
+
+  public final String name;
+  public final String label;
+
+  SteppingType(final String name, final String label) {
+    this.name  = name;
+    this.label = label;
+  }
+
+  public abstract void process(SuspendedEvent event);
 }

--- a/src/tools/debugger/frontend/Suspension.java
+++ b/src/tools/debugger/frontend/Suspension.java
@@ -11,6 +11,7 @@ import som.interpreter.LexicalScope.MethodScope;
 import som.interpreter.actors.SuspendExecutionNode;
 import som.interpreter.objectstorage.ObjectTransitionSafepoint;
 import som.primitives.ObjectPrims.HaltPrim;
+import som.vm.Activity;
 import tools.TraceData;
 import tools.debugger.FrontendConnector;
 import tools.debugger.frontend.ApplicationThreadTask.Resume;
@@ -27,13 +28,13 @@ import tools.debugger.frontend.ApplicationThreadTask.SendStackTrace;
  */
 public class Suspension {
   public final long activityId;
-  private final Object activity;
+  private final Activity activity;
   private final ArrayBlockingQueue<ApplicationThreadTask> tasks;
 
   private SuspendedEvent suspendedEvent;
   private ApplicationThreadStack stack;
 
-  public Suspension(final Object activity, final long activityId) {
+  public Suspension(final Activity activity, final long activityId) {
     this.activity   = activity;
     this.activityId = activityId;
     this.tasks = new ArrayBlockingQueue<>(2);
@@ -143,6 +144,6 @@ public class Suspension {
     ObjectTransitionSafepoint.INSTANCE.register();
   }
 
-  public Object getActivity() { return activity; }
+  public Activity getActivity() { return activity; }
   public synchronized SuspendedEvent getEvent() { return suspendedEvent; }
 }

--- a/src/tools/debugger/message/InitializationResponse.java
+++ b/src/tools/debugger/message/InitializationResponse.java
@@ -3,6 +3,7 @@ package tools.debugger.message;
 import tools.debugger.entities.ActivityType;
 import tools.debugger.entities.BreakpointType;
 import tools.debugger.entities.EntityType;
+import tools.debugger.entities.SteppingType;
 import tools.debugger.message.Message.OutgoingMessage;
 
 
@@ -45,17 +46,45 @@ public final class InitializationResponse extends OutgoingMessage {
     }
   }
 
+  private static final class SteppingData {
+    private final String name;
+    private final String label;
+    private final String group;
+    private final String icon;
+    private final String[] applicableTo;
+
+    private SteppingData(final SteppingType type) {
+      this.name = type.name;
+      this.label = type.label;
+      this.group = type.group.label;
+      this.icon  = type.icon;
+
+      if (type.applicableTo == null) {
+          this.applicableTo = null;
+      } else {
+        this.applicableTo = new String[type.applicableTo.length];
+
+        for (int i = 0; i < type.applicableTo.length; i += 1) {
+          applicableTo[i] = type.applicableTo[i].getSimpleName();
+        }
+      }
+    }
+  }
+
   private static final class ServerCapabilities {
     private final Type[] activityTypes;
     private final Type[] entityTypes;
     private final BreakpointData[] breakpointTypes;
+    private final SteppingData[] steppingTypes;
 
     private ServerCapabilities(final EntityType[] supportedEntities,
         final ActivityType[] supportedActivities,
-        final BreakpointType[] supportedBreakpoints) {
+        final BreakpointType[] supportedBreakpoints,
+        final SteppingType[] supportedSteps) {
       activityTypes   = new Type[supportedActivities.length];
       entityTypes     = new Type[supportedEntities.length];
       breakpointTypes = new BreakpointData[supportedBreakpoints.length];
+      steppingTypes   = new SteppingData[supportedSteps.length];
 
       int i = 0;
       for (EntityType e : supportedEntities) {
@@ -74,12 +103,19 @@ public final class InitializationResponse extends OutgoingMessage {
         breakpointTypes[i] = new BreakpointData(e);
         i += 1;
       }
+
+      i = 0;
+      for (SteppingType e : supportedSteps) {
+        steppingTypes[i] = new SteppingData(e);
+        i += 1;
+      }
     }
   }
 
   public static InitializationResponse create(final EntityType[] supportedEntities,
-      final ActivityType[] supportedActivities, final BreakpointType[] supportedBreakpoints) {
+      final ActivityType[] supportedActivities, final BreakpointType[] supportedBreakpoints,
+      final SteppingType[] supportedSteps) {
     return new InitializationResponse(new ServerCapabilities(supportedEntities,
-        supportedActivities, supportedBreakpoints));
+        supportedActivities, supportedBreakpoints, supportedSteps));
   }
 }

--- a/src/tools/debugger/message/StepMessage.java
+++ b/src/tools/debugger/message/StepMessage.java
@@ -2,64 +2,29 @@ package tools.debugger.message;
 
 import org.java_websocket.WebSocket;
 
-import com.oracle.truffle.api.debug.SuspendedEvent;
-
 import tools.debugger.FrontendConnector;
+import tools.debugger.entities.SteppingType;
 import tools.debugger.frontend.Suspension;
 import tools.debugger.message.Message.IncommingMessage;
 
-public abstract class StepMessage extends IncommingMessage {
+
+public class StepMessage extends IncommingMessage {
   private final long activityId;
+  private final SteppingType step;
 
   /**
    * Note: meant for serialization.
    */
-  protected StepMessage() {
+  public StepMessage() {
     activityId = -1;
+    step       = null;
   }
 
   @Override
   public void process(final FrontendConnector connector, final WebSocket conn) {
     Suspension susp = connector.getSuspension(activityId);
     assert susp.getEvent() != null : "didn't find SuspendEvent";
-    process(susp.getEvent());
+    step.process(susp.getEvent());
     susp.resume();
-  }
-
-  public abstract void process(SuspendedEvent event);
-
-  public static class StepInto extends StepMessage {
-    @Override
-    public void process(final SuspendedEvent event) {
-      event.prepareStepInto(1);
-    }
-  }
-
-  public static class StepOver extends StepMessage {
-    @Override
-    public void process(final SuspendedEvent event) {
-      event.prepareStepOver(1);
-    }
-  }
-
-  public static class Return extends StepMessage {
-    @Override
-    public void process(final SuspendedEvent event) {
-      event.prepareStepOut();
-    }
-  }
-
-  public static class Resume extends StepMessage {
-    @Override
-    public void process(final SuspendedEvent event) {
-      event.prepareContinue();
-    }
-  }
-
-  public static class Stop extends StepMessage {
-    @Override
-    public void process(final SuspendedEvent event) {
-      event.prepareKill();
-    }
   }
 }

--- a/tests/debugger/JsonTests.java
+++ b/tests/debugger/JsonTests.java
@@ -20,6 +20,7 @@ import tools.debugger.WebDebugger;
 import tools.debugger.entities.ActivityType;
 import tools.debugger.entities.BreakpointType;
 import tools.debugger.entities.EntityType;
+import tools.debugger.entities.SteppingType;
 import tools.debugger.message.InitializationResponse;
 import tools.debugger.message.InitializeConnection;
 import tools.debugger.message.Message.IncommingMessage;
@@ -173,7 +174,9 @@ public class JsonTests {
   @Test
   public void initializeResponseSerialize() {
     String result = gson.toJson(InitializationResponse.create(
-        EntityType.values(), ActivityType.values(), BreakpointType.values()), OutgoingMessage.class);
+        EntityType.values(), ActivityType.values(), BreakpointType.values(),
+        SteppingType.values()),
+      OutgoingMessage.class);
     // This test is only doing a very basic sanity check
     assertTrue(1000 < result.length());
   }

--- a/tools/kompos/index.html
+++ b/tools/kompos/index.html
@@ -348,22 +348,7 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
 
       <div class="activity-state col-3">
         <div class="activity-actions btn-toolbar" role="toolbar" aria-label="Debugger Controls">
-          <!-- TODO: still need the activity id somehow here in the onclick handler -->
-          <div class="btn-group btn-group-xs" role="group" aria-label="Basic Controls">
-            <button class="act-resume btn btn-secondary btn-sm disabled" type="button" title="Resume Execution"
-                    onclick="ctrl.resumeExecution(getAttribute('data-actid'));"><i class="fa fa-play"></i></button>
-            <button class="act-pause btn btn-secondary btn-sm" type="button" title="Pause Execution"
-                    onclick="ctrl.pauseExecution(getAttribute('data-actid'));"><i class="fa fa-pause"></i></button>
-          </div>
-
-          <div class="btn-group btn-group-xs" role="group" aria-label="Stepping">
-            <button class="act-step-into btn btn-secondary btn-sm disabled" type="button" title="Step Into"
-                    onclick="ctrl.stepInto(getAttribute('data-actid'));"><i class="fa fa-share" style="transform: rotate(90deg);"></i></button>
-            <button class="act-step-over btn btn-secondary btn-sm disabled" type="button" title="Step Over"
-                    onclick="ctrl.stepOver(getAttribute('data-actid'));"><i class="fa fa-share"></i></button>
-            <button class="act-return btn btn-secondary btn-sm disabled" type="button" title="Return from Method"
-                    onclick="ctrl.returnFromExecution(getAttribute('data-actid'));"><i class="fa fa-reply" style="transform: scaleY(-1);"></i></button>
-          </div>
+          <div class="debugger-button-groups"></div>
           <div class="btn-group btn-group-xs activity-fold" role="group" aria-label="Stepping">
             <button class="btn btn-secondary pane-closed"
               onclick="ctrl.toggleCodePane(getAttribute('data-actid'));">
@@ -413,6 +398,22 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
 
   <div id="bp-menu" class="dropdown-content"></div>
   <button id="bp-menu-btn" class="btn btn-secondary btn-sm btn-block bp-btn"></button>
+
+  <div id="debugger-button-icons">
+    <i id="icon-play"        class="fa fa-play"></i>
+    <i id="icon-pause"       class="fa fa-pause"></i>
+    <i id="icon-stop"        class="fa fa-stop"></i>
+    <i id="icon-arrow-down"  class="fa fa-share" style="transform: rotate(90deg);"></i>
+    <i id="icon-arrow-right" class="fa fa-share"></i>
+    <i id="icon-arrow-left"  class="fa fa-reply" style="transform: scaleY(-1);"></i>
+  </div>
+
+  <div id="debugger-step-btn-group"
+    class="btn-group btn-group-xs" role="group" aria-label="LABEL"></div>
+  <button id="debugger-step-btn"
+    class="act-resume btn btn-secondary btn-sm" type="button" disabled="disabled"
+    title="TITLE" data-actid="ACTID" data-step="STEPID"
+    onclick="ctrl.step(getAttribute('data-actid'), getAttribute('data-step'));">LABEL</button>
 </div>
 
 <!-- REM: https://github.com/earmbrust/bootstrap-window -->

--- a/tools/kompos/index.html
+++ b/tools/kompos/index.html
@@ -305,24 +305,6 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
   <div class="btn-group btn-group-xs" role="group" aria-label="Basic Controls">
     <button id="dbg-connect-btn" type="button" class="btn btn-secondary btn-sm" onclick="ctrl.toggleConnection();">Connecting</button>
   </div>
-
-  <div class="btn-group btn-group-xs" role="group" aria-label="Basic Controls">
-    <button id="dbg-btn-resume" type="button" class="btn btn-secondary btn-sm disabled" title="Resume Execution"
-            onclick="ctrl.resumeExecution();"><i class="fa fa-play"></i></button>
-    <button id="dbg-btn-pause"  type="button" class="btn btn-secondary btn-sm" title="Pause Execution"
-            onclick="ctrl.pauseExecution();"><i class="fa fa-pause"></i></button>
-    <button id="dbg-btn-stop"   type="button" class="btn btn-secondary btn-sm" title="Stop Execution"
-            onclick="ctrl.stopExecution();"><i class="fa fa-stop"></i></button>
-  </div>
-
-  <div class="btn-group btn-group-xs" role="group" aria-label="Stepping">
-    <button id="dbg-btn-step-into" type="button" class="btn btn-secondary btn-sm disabled" title="Step Into"
-            onclick="ctrl.stepInto();"><i class="fa fa-share" style="transform: rotate(90deg);"></i></button>
-    <button id="dbg-btn-step-over" type="button" class="btn btn-secondary btn-sm disabled" title="Step Over"
-            onclick="ctrl.stepOver();"><i class="fa fa-share"></i></button>
-    <button id="dbg-btn-return"    type="button" class="btn btn-secondary btn-sm disabled" title="Return from Method"
-            onclick="ctrl.returnFromExecution();"><i class="fa fa-reply" style="transform: scaleY(-1);"></i></button>
-  </div>
 </div>
 
 <table class="table" id="breakpoints" style="font-size: 75%;">

--- a/tools/kompos/src/debugger.ts
+++ b/tools/kompos/src/debugger.ts
@@ -1,4 +1,4 @@
-import {IdMap, Source, SourceCoordinate, SourceMessage, TaggedSourceCoordinate,
+import {IdMap, Source, StackFrame, SourceMessage, TaggedSourceCoordinate,
   Activity, ServerCapabilities, getSectionId} from "./messages";
 import {Breakpoint} from "./breakpoints";
 
@@ -29,7 +29,7 @@ export class Debugger {
   /**
    * All source sections relevant for the debugger, indexed by {@link getSectionId}.
    */
-  private sections: IdMap<SourceCoordinate>;
+  private sections: IdMap<TaggedSourceCoordinate>;
 
   private breakpoints: IdMap<IdMap<Breakpoint>>;
 
@@ -56,6 +56,15 @@ export class Debugger {
     return this.sources[id];
   }
 
+  public getSectionIdFromFrame(sourceId: string, frame: StackFrame) {
+    const line = frame.line,
+      column = frame.column,
+      length = frame.length;
+
+    return getSectionId(sourceId,
+                 {startLine: line, startColumn: column, charLength: length});
+  }
+
   public addSource(msg: SourceMessage): Source {
     const s = msg.source;
     let id = this.getSourceId(s.uri);
@@ -65,7 +74,7 @@ export class Debugger {
     return s;
   }
 
-  public getSection(id: string): SourceCoordinate {
+  public getSection(id: string): TaggedSourceCoordinate {
     return this.sections[id];
   }
 
@@ -85,7 +94,7 @@ export class Debugger {
     for (let meth of s.methods) {
       let ssId = getSectionId(sId, meth.sourceSection);
       if (!(ssId in this.sections)) {
-        this.sections[ssId] = meth.sourceSection;
+        this.sections[ssId] = <any> meth.sourceSection;
       }
     }
   }

--- a/tools/kompos/src/messages.ts
+++ b/tools/kompos/src/messages.ts
@@ -193,13 +193,14 @@ interface UpdateBreakpoint {
   breakpoint: BreakpointData;
 }
 
-export type StepType = "stepInto" | "stepOver" | "return" | "resume" | "stop";
-
 export interface StepMessage {
-  action: StepType;
+  action: "StepMessage";
 
   /** Id of the suspended activity. */
   activityId: number;
+
+  /** Name of the stepping operation requested. */
+  step: string;
 }
 
 export interface StackTraceRequest {

--- a/tools/kompos/src/messages.ts
+++ b/tools/kompos/src/messages.ts
@@ -157,6 +157,14 @@ export interface BreakpointType {
   applicableTo: string[];  /** Set of source section tags, for which the breakpoint is applicable. */
 }
 
+export interface SteppingType {
+  name:  string;    /** Identifier used for communication. */
+  label: string;    /** Label to use for display purposes. */
+  group: string;    /** Group Label. */
+  icon:  string;    /** Id of an icon known by the frontend. */
+  applicableTo?: string[]; /** The source section tags this stepping operation applies to. If empty, it applies unconditionally. */
+}
+
 export interface EntityDef {
   id:         number;
   creation:   number;
@@ -168,6 +176,7 @@ export interface ServerCapabilities {
   activityTypes:   EntityDef[];
   entityTypes:     EntityDef[];
   breakpointTypes: BreakpointType[];
+  steppingTypes:   SteppingType[];
 }
 
 export interface InitializationResponse {

--- a/tools/kompos/src/ui-controller.ts
+++ b/tools/kompos/src/ui-controller.ts
@@ -13,9 +13,6 @@ import {dbgLog}       from "./source";
 import {View, getActivityIdFromView, getSourceIdFrom, getSourceIdFromSection} from "./view";
 import {VmConnection} from "./vm-connection";
 
-// TODO: remove
-import {SteppingType} from "../tests/somns-support";
-
 /**
  * The controller binds the domain model and the views, and mediates their
  * interaction.
@@ -144,8 +141,11 @@ export class UiController extends Controller {
       const sourceId = this.dbg.getSourceId(msg.stackFrames[0].sourceUri);
       const source = this.dbg.getSource(sourceId);
 
+      const ssId = this.dbg.getSectionIdFromFrame(sourceId, msg.stackFrames[0]);
+      const section = this.dbg.getSection(ssId);
+
       const newSource = this.view.displaySource(act, source, sourceId);
-      this.view.displayStackTrace(sourceId, msg, topFrameId, act);
+      this.view.displayStackTrace(sourceId, msg, topFrameId, act, ssId, section);
       if (newSource) {
         this.ensureBreakpointsAreIndicated(sourceId);
       }
@@ -217,52 +217,16 @@ export class UiController extends Controller {
     this.view.updateSectionBreakpoint(<SectionBreakpoint> breakpoint);
   }
 
-  public resumeExecution(actId: string) {
+  public step(actId: string, step: string) {
     const activityId = getActivityIdFromView(actId);
     const act = this.dbg.getActivity(activityId);
 
+    // Note: in general, we assume that all stepping operations lead to a
+    // running activity. However, some operations, might discontinue execution
+    // completely. These need extra support/interaction with the back-end/interpreter.
     if (act.running) { return; }
     act.running = true;
-    this.vmConnection.sendDebuggerAction(SteppingType.RESUME, act);
+    this.vmConnection.sendDebuggerAction(step, act);
     this.view.onContinueExecution(act);
-  }
-
-  public pauseExecution(actId: string) {
-    const activityId = getActivityIdFromView(actId);
-    const act = this.dbg.getActivity(activityId);
-    if (!act.running) { return; }
-    console.assert(false, "TODO");
-  }
-
-  /** End program, typically terminating it completely. */
-  public stopExecution() {
-    // TODO
-  }
-
-  public stepInto(actId: string) {
-    const activityId = getActivityIdFromView(actId);
-    const act = this.dbg.getActivity(activityId);
-    if (act.running) { return; }
-    act.running = true;
-    this.view.onContinueExecution(act);
-    this.vmConnection.sendDebuggerAction(SteppingType.STEP_INTO, act);
-  }
-
-  public stepOver(actId: string) {
-    const activityId = getActivityIdFromView(actId);
-    const act = this.dbg.getActivity(activityId);
-    if (act.running) { return; }
-    act.running = true;
-    this.view.onContinueExecution(act);
-    this.vmConnection.sendDebuggerAction(SteppingType.STEP_OVER, act);
-  }
-
-  public returnFromExecution(actId: string) {
-    const activityId = getActivityIdFromView(actId);
-    const act = this.dbg.getActivity(activityId);
-    if (act.running) { return; }
-    act.running = true;
-    this.view.onContinueExecution(act);
-    this.vmConnection.sendDebuggerAction(SteppingType.RETURN, act);
   }
 }

--- a/tools/kompos/src/ui-controller.ts
+++ b/tools/kompos/src/ui-controller.ts
@@ -13,6 +13,9 @@ import {dbgLog}       from "./source";
 import {View, getActivityIdFromView, getSourceIdFrom, getSourceIdFromSection} from "./view";
 import {VmConnection} from "./vm-connection";
 
+// TODO: remove
+import {SteppingType} from "../tests/somns-support";
+
 /**
  * The controller binds the domain model and the views, and mediates their
  * interaction.
@@ -220,7 +223,7 @@ export class UiController extends Controller {
 
     if (act.running) { return; }
     act.running = true;
-    this.vmConnection.sendDebuggerAction("resume", act);
+    this.vmConnection.sendDebuggerAction(SteppingType.RESUME, act);
     this.view.onContinueExecution(act);
   }
 
@@ -242,7 +245,7 @@ export class UiController extends Controller {
     if (act.running) { return; }
     act.running = true;
     this.view.onContinueExecution(act);
-    this.vmConnection.sendDebuggerAction("stepInto", act);
+    this.vmConnection.sendDebuggerAction(SteppingType.STEP_INTO, act);
   }
 
   public stepOver(actId: string) {
@@ -251,7 +254,7 @@ export class UiController extends Controller {
     if (act.running) { return; }
     act.running = true;
     this.view.onContinueExecution(act);
-    this.vmConnection.sendDebuggerAction("stepOver", act);
+    this.vmConnection.sendDebuggerAction(SteppingType.STEP_OVER, act);
   }
 
   public returnFromExecution(actId: string) {
@@ -260,6 +263,6 @@ export class UiController extends Controller {
     if (act.running) { return; }
     act.running = true;
     this.view.onContinueExecution(act);
-    this.vmConnection.sendDebuggerAction("return", act);
+    this.vmConnection.sendDebuggerAction(SteppingType.RETURN, act);
   }
 }

--- a/tools/kompos/src/vm-connection.ts
+++ b/tools/kompos/src/vm-connection.ts
@@ -4,7 +4,7 @@
 import * as WebSocket from "ws";
 
 import {Controller} from "./controller";
-import {Activity, Message, Respond, StepType, BreakpointData} from "./messages";
+import {Activity, Message, Respond, BreakpointData} from "./messages";
 
 const DBG_PORT   = 7977;
 const TRACE_PORT = 7978;
@@ -138,9 +138,10 @@ export class VmConnection {
     });
   };
 
-  public sendDebuggerAction(action: StepType, activity: Activity) {
+  public sendDebuggerAction(step: string, activity: Activity) {
     this.send({
-      action: action,
+      action: "StepMessage",
+      step:   step,
       activityId: activity.id});
   }
 

--- a/tools/kompos/tests/basic-protocol.ts
+++ b/tools/kompos/tests/basic-protocol.ts
@@ -10,7 +10,7 @@ import { SOM, PING_PONG_URI, ControllerWithInitialBreakpoints,
 
 import { SourceMessage, createLineBreakpointData,
   createSectionBreakpointData } from "../src/messages";
-import { BreakpointType as BT } from "./somns-support";
+import { BreakpointType as BT, SteppingType as ST } from "./somns-support";
 
 let connectionPossible = false;
 function onlyWithConnection(fn) {
@@ -291,7 +291,7 @@ describe("Basic Protocol", function() {
       return new Promise((resolve, _reject) => {
         ctrl.stackP.then(_ => {
           conn.fullyConnected.then(_ => {
-            conn.sendDebuggerAction("stepInto", ctrl.stoppedActivities[0]);
+            conn.sendDebuggerAction(ST.STEP_INTO, ctrl.stoppedActivities[0]);
           });
 
           const p = ctrl.getStackP(1).then(msgAfterStep => {
@@ -310,7 +310,7 @@ describe("Basic Protocol", function() {
             // set another breakpoint, after stepping, and with connection
             const lbp = createLineBreakpointData(PING_PONG_URI, 22, true);
             conn.updateBreakpoint(lbp);
-            conn.sendDebuggerAction("resume", ctrl.stoppedActivities[1]);
+            conn.sendDebuggerAction(ST.RESUME, ctrl.stoppedActivities[1]);
           });
         }),
         ctrl.getStackP(2).then(msgLineBP => {
@@ -328,7 +328,7 @@ describe("Basic Protocol", function() {
 
             const lbp22 = createLineBreakpointData(PING_PONG_URI, 22, false);
             conn.updateBreakpoint(lbp22);
-            conn.sendDebuggerAction("resume", ctrl.stoppedActivities[2]);
+            conn.sendDebuggerAction(ST.RESUME, ctrl.stoppedActivities[2]);
 
             const p = ctrl.getStackP(3).then(msgLineBP => {
               expectStack(msgLineBP.stackFrames, 1, "Ping>>#ping", 23);

--- a/tools/kompos/tests/somns-support.ts
+++ b/tools/kompos/tests/somns-support.ts
@@ -36,3 +36,11 @@ export namespace BreakpointType {
   export const CHANNEL_BEFORE_RCV  = "channelBeforeRcvBP";
   export const CHANNEL_AFTER_SEND  = "channelAfterSendBP";
 }
+
+export namespace SteppingType {
+  export const STEP_INTO = "stepInto";
+  export const STEP_OVER = "stepOver";
+  export const RETURN    = "return";
+  export const RESUME    = "resume";
+  export const STOP      = "stop";
+}


### PR DESCRIPTION
Use `SteppingType` to realize stepping similar to breakpoints
- encode metadata in SteppingType
- have only one concrete StepMessage
- based on https://github.com/smarr/SOMns/commit/618a077a0abb4578896a99e7c5f62a59be01f229

Use `SteppingType` data from backend to create stepping buttons
- reorder button declarations for better UI experience
- define stepping grouping already in backend
- use icon templates in frontend by name
- remove old debugger buttons from system view
