### PR TITLE
Fix race between symbol strings and trace data

### DIFF
--- a/src/tools/concurrency/TraceBuffer.java
+++ b/src/tools/concurrency/TraceBuffer.java
@@ -78,6 +78,7 @@ public class TraceBuffer {
     assert start == 0;
 
     storage.put(Events.ImplThread.id);
+    storage.putInt(0); // placeholder for symbol message id
     storage.putLong(threadId);
     storage.putLong(System.currentTimeMillis());
 

--- a/src/tools/concurrency/TraceParser.java
+++ b/src/tools/concurrency/TraceParser.java
@@ -182,6 +182,7 @@ public final class TraceParser {
             b.compact();
             channel.read(b);
             b.flip();
+            b.getInt();
             b.getLong(); // thread id
             b.getLong(); // time millis
             assert (b.position() + 1) == Events.ImplThread.size;

--- a/src/tools/debugger/FrontendConnector.java
+++ b/src/tools/debugger/FrontendConnector.java
@@ -207,8 +207,8 @@ public class FrontendConnector {
     sendSource(source, loadedSourcesTags, rootNodes.get(source));
   }
 
-  public void sendSymbols(final ArrayList<SSymbol> symbolsToWrite) {
-    send(new SymbolMessage(symbolsToWrite));
+  public void sendSymbols(final ArrayList<SSymbol> symbolsToWrite, final int msgNumber) {
+    send(new SymbolMessage(symbolsToWrite, msgNumber));
   }
 
   public void sendTracingData(final ByteBuffer b) {

--- a/src/tools/debugger/message/SymbolMessage.java
+++ b/src/tools/debugger/message/SymbolMessage.java
@@ -12,10 +12,12 @@ import tools.debugger.message.Message.OutgoingMessage;
 public class SymbolMessage extends OutgoingMessage {
   private final String[] symbols;
   private final int[]    ids;
+  private final int msgNumber;
 
-  public SymbolMessage(final ArrayList<SSymbol> symbols) {
+  public SymbolMessage(final ArrayList<SSymbol> symbols, final int msgNumber) {
     this.symbols = new String[symbols.size()];
     this.ids = new int[symbols.size()];
+    this.msgNumber = msgNumber;
     int i = 0;
 
     for (SSymbol s : symbols) {

--- a/tools/kompos/src/history-data.ts
+++ b/tools/kompos/src/history-data.ts
@@ -485,6 +485,8 @@ export class HistoryData {
     const causalMsg = this.readLong(data, i + 8);
     const nameId: number = data.getUint16(i + 16);
 
+    console.assert(this.strings[nameId], "Symbol table not yet initialized by backend. Doesn't contain string for " + nameId);
+
     const activity: Activity = {
       id: aid,
       type:      this.creationIdToActivityType[msgType],
@@ -510,6 +512,8 @@ export class HistoryData {
     const startLine: number = data.getUint16(i + 2);
     const startCol:  number = data.getUint16(i + 4);
     const charLen:   number = data.getUint16(i + 6);
+
+    console.assert(this.strings[fileId], "Symbol table not yet initialized by backend. Doesn't contain string for " + fileId);
     return {
       uri: this.strings[fileId],
       charLength:  charLen,
@@ -572,6 +576,8 @@ export class HistoryData {
   }
 
   public updateDataBin(data: DataView): Activity[] {
+    console.assert(this.strings, "Symbol table not yet initialized by backend.");
+
     const newActivities: Activity[] = [];
     let i = 0;
     let prevMessage = -1;

--- a/tools/kompos/src/history-data.ts
+++ b/tools/kompos/src/history-data.ts
@@ -51,7 +51,7 @@ enum TraceSize {
   PromiseResolution = 28,
   PromiseChained    = 17,
   Mailbox           = 21,
-  ImplThread        = 17,
+  ImplThread        = 21,
   MailboxContd      = 25,
 
   ActivityOrigin    =  9,
@@ -626,7 +626,7 @@ export class HistoryData {
           console.assert(i === (start + TraceSize.Mailbox));
           break;
         case Trace.ImplThread:
-          i += 16;
+          i += 20;
           console.assert(i === (start + TraceSize.ImplThread));
           break;
         case Trace.MailboxContd:

--- a/tools/kompos/src/messages.ts
+++ b/tools/kompos/src/messages.ts
@@ -97,6 +97,7 @@ export interface SymbolMessage {
   type: "SymbolMessage";
   symbols: string[];
   ids:   number[];
+  msgNumber: number;
 }
 
 export type BreakpointData = LineBreakpointData | SectionBreakpointData;

--- a/tools/kompos/src/ui-controller.ts
+++ b/tools/kompos/src/ui-controller.ts
@@ -4,7 +4,7 @@
 import {Controller}   from "./controller";
 import {Debugger}     from "./debugger";
 import {ActivityNode} from "./history-data";
-import {SourceMessage, SymbolMessage, StoppedMessage, StackTraceResponse,
+import {IdMap, SourceMessage, SymbolMessage, StoppedMessage, StackTraceResponse,
   ScopesResponse, VariablesResponse, ProgramInfoResponse, InitializationResponse,
   Activity, Source } from "./messages";
 import {LineBreakpoint, SectionBreakpoint, getBreakpointId,
@@ -23,6 +23,8 @@ export class UiController extends Controller {
 
   private actProm = {};
   private actPromResolve = {};
+  private traceData: IdMap<DataView> = {};
+  private receivedSymbols: number[] = [];
 
   constructor(dbg, view, vmConnection: VmConnection) {
     super(vmConnection);
@@ -174,11 +176,22 @@ export class UiController extends Controller {
 
   public onSymbolMessage(msg: SymbolMessage) {
     this.view.updateStringData(msg);
+    this.receivedSymbols.push(msg.msgNumber);
+
+    if(this.traceData[msg.msgNumber]){
+      this.onTracingData(this.traceData[msg.msgNumber]);
+    }
   }
 
   public onTracingData(data: DataView) {
-    this.newActivities(this.view.updateTraceData(data));
-    this.view.displaySystemView();
+    let requirement: number = data.getInt32(1);
+
+    if (this.receivedSymbols.indexOf(requirement) >= 0){
+      this.newActivities(this.view.updateTraceData(data));
+      this.view.displaySystemView();
+    } else {
+      this.traceData[requirement] = data;
+    }
   }
 
   public onUnknownMessage(msg: any) {

--- a/tools/kompos/src/view.ts
+++ b/tools/kompos/src/view.ts
@@ -373,6 +373,7 @@ export class View {
   }
 
   public updateTraceData(data: DataView): Activity[] {
+    console.assert(this.serverCapabilities, "Connection not yet completely established, but got trace data");
     return this.systemViz.updateData(data);
   }
 

--- a/tools/kompos/src/visualizations.ts
+++ b/tools/kompos/src/visualizations.ts
@@ -302,6 +302,12 @@ function createActivityLabel(g, activityTypes: EntityDef[]) {
       if (a.getGroupSize() > 1) {
         label += " (" + a.getGroupSize() + ")";
       }
+      console.assert(label.indexOf("undefined") < 0);
+      if (!(label.indexOf("undefined") < 0)) {
+        console.log(a);
+        debugger;
+      }
+
       return label;
     });
 }


### PR DESCRIPTION
@daumayr this is more a TODO than and PR. Could you please have a look at this?

If I remember correctly, you introduced this originally.
And lately, I am having trouble with strings not yet being available when a trace is parsed.

Could you add some way of synchronizing the two?
I see multiple possible options.
One would be to have a id for the last symbol message a trace depends on, and use promises in the frontend to check that the symbols are already there.

Another option could be to expect a response for the symbol message and deal with the race in the backend.

At the moment, we have a similar problems with the activity definitions.
And I solve that in the frontend with promises: https://github.com/smarr/SOMns/blob/master/tools/kompos/src/ui-controller.ts#L105