### PR TITLE
Channel, Process, and Fork/Join stepping

### DIFF
--- a/src/som/interpreter/SomLanguage.java
+++ b/src/som/interpreter/SomLanguage.java
@@ -3,6 +3,7 @@ package som.interpreter;
 import java.io.IOException;
 
 import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.TruffleLanguage;
@@ -142,6 +143,11 @@ public final class SomLanguage extends TruffleLanguage<VM> {
 
   public VM getVM() {
     return vm;
+  }
+
+  public static VM getVM(final RootNode root) {
+    CompilerAsserts.neverPartOfCompilation("This is a simple hack to get the VM object, and should never be on the fast path");
+    return root.getLanguage(SomLanguage.class).getVM();
   }
 
   // Marker source used to start execution with command line arguments

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -184,7 +184,7 @@ public class Actor implements Activity {
   }
 
   protected static void handleBreakPoints(final EventualMessage msg, final WebDebugger dbg) {
-    if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && msg.isBreakpoint()) {
+    if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && msg.isMessageReceiverBreakpointSet()) {
       dbg.prepareSteppingUntilNextRootNode();
     }
   }

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -147,6 +147,13 @@ public class Actor implements Activity {
   @Override
   public long getId() { return 0; }
 
+  @Override
+  public void setStepToJoin(final boolean val) {
+    throw new UnsupportedOperationException(
+        "Return from activity, and step to join are not supported " +
+        "for event-loop actors. This code should never be reached.");
+  }
+
   /**
    * Send the give message to the actor.
    *

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -12,7 +12,6 @@ import som.VM;
 import som.interpreter.objectstorage.ObjectTransitionSafepoint;
 import som.primitives.ObjectPrims.IsValue;
 import som.vm.Activity;
-import som.vm.ActivityThread;
 import som.vm.VmSettings;
 import som.vmobjects.SAbstractObject;
 import som.vmobjects.SArray.STransferArray;
@@ -330,8 +329,7 @@ public class Actor implements Activity {
     }
   }
 
-  public static final class ActorProcessingThread extends TracingActivityThread
-      implements ActivityThread {
+  public static final class ActorProcessingThread extends TracingActivityThread {
     public EventualMessage currentMessage;
 
     protected Actor currentlyExecutingActor;

--- a/src/som/interpreter/actors/EventualMessage.java
+++ b/src/som/interpreter/actors/EventualMessage.java
@@ -323,7 +323,7 @@ public abstract class EventualMessage {
    * Indicates that execution should stop and yield to the debugger,
    * before the computed value is used to resolve the promise.
    */
-  public boolean isTriggerPromiseResolverBreakpoint() {
+  public boolean isPromiseResolverBreakpointSet() {
     return triggerPromiseResolverBreakpoint;
   }
 
@@ -331,7 +331,7 @@ public abstract class EventualMessage {
    * Indicates that execution should stop and yield to the debugger,
    * before the message is processed.
    */
-  public boolean isBreakpoint() {
+  public boolean isMessageReceiverBreakpointSet() {
     return triggerMessageReceiverBreakpoint;
   }
 

--- a/src/som/interpreter/actors/ReceivedMessage.java
+++ b/src/som/interpreter/actors/ReceivedMessage.java
@@ -38,7 +38,7 @@ public class ReceivedMessage extends ReceivedRootNode {
       promiseResolutionBreakpoint = msg.getResolver().getPromise().isTriggerPromiseResolutionBreakpoint();
     }
 
-    if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && msg.isTriggerPromiseResolverBreakpoint()) {
+    if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && msg.isPromiseResolverBreakpointSet()) {
       dbg.prepareSteppingAfterNextRootNode();
     }
 
@@ -71,7 +71,7 @@ public class ReceivedMessage extends ReceivedRootNode {
     public Object execute(final VirtualFrame frame) {
       EventualMessage msg = (EventualMessage) SArguments.rcvr(frame);
 
-      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && msg.isTriggerPromiseResolverBreakpoint()) {
+      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && msg.isPromiseResolverBreakpointSet()) {
         dbg.prepareSteppingAfterNextRootNode();
       }
 
@@ -99,7 +99,7 @@ public class ReceivedMessage extends ReceivedRootNode {
         promiseResolutionBreakpoint = msg.getResolver().getPromise().isTriggerPromiseResolutionBreakpoint();
       }
 
-      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && msg.isTriggerPromiseResolverBreakpoint()) {
+      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && msg.isPromiseResolverBreakpointSet()) {
         dbg.prepareSteppingAfterNextRootNode();
       }
 

--- a/src/som/interpreter/nodes/dispatch/AbstractGenericDispatchNode.java
+++ b/src/som/interpreter/nodes/dispatch/AbstractGenericDispatchNode.java
@@ -54,7 +54,7 @@ public abstract class AbstractGenericDispatchNode extends AbstractDispatchNode {
     SArray argumentsArray = SArguments.getArgumentsWithoutReceiver(arguments);
     Object[] args = new Object[] {arguments[0], selector, argumentsArray};
     CallTarget target = CachedDnuNode.getDnu(rcvrClass, selector,
-        call.getRootNode().getLanguage(SomLanguage.class).getVM());
+        SomLanguage.getVM(call.getRootNode()));
     return call.call(target, args);
   }
 

--- a/src/som/interpreter/nodes/dispatch/UninitializedDispatchNode.java
+++ b/src/som/interpreter/nodes/dispatch/UninitializedDispatchNode.java
@@ -89,7 +89,7 @@ public final class UninitializedDispatchNode {
       AbstractDispatchNode node;
       if (dispatchable == null) {
         node = new CachedDnuNode(rcvrClass, selector,
-            DispatchGuard.create(rcvr), getRootNode().getLanguage(SomLanguage.class).getVM(), newChainEnd);
+            DispatchGuard.create(rcvr), SomLanguage.getVM(getRootNode()), newChainEnd);
       } else {
         node = dispatchable.getDispatchNode(rcvr, firstArg, newChainEnd, forAtomic());
       }

--- a/src/som/primitives/ActivityJoin.java
+++ b/src/som/primitives/ActivityJoin.java
@@ -3,8 +3,11 @@ package som.primitives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
 
+import som.VM;
+import som.interpreter.actors.SuspendExecutionNodeGen;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
 import som.primitives.threading.TaskThreads.SomForkJoinTask;
 import som.vm.VmSettings;
@@ -18,12 +21,30 @@ public class ActivityJoin {
   @Primitive(primitive = "threadingThreadJoin:")
   @Primitive(selector = "join")
   public abstract static class JoinPrim extends UnaryExpressionNode {
-    public JoinPrim(final boolean ew, final SourceSection s) { super(ew, s); }
+    @Child protected UnaryExpressionNode haltNode;
+
+    public JoinPrim(final boolean ew, final SourceSection s) {
+      super(ew, s);
+      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
+        haltNode = insert(SuspendExecutionNodeGen.create(false, s, 2, null));
+        VM.insertInstrumentationWrapper(haltNode);
+      } else {
+        haltNode = null;
+      }
+    }
+
+    @TruffleBoundary
+    private static Object doJoin(final SomForkJoinTask task) {
+      return task.join();
+    }
 
     @Specialization
-    @TruffleBoundary
-    public final Object doTask(final SomForkJoinTask task) {
-      Object result = task.join();
+    public final Object doTask(final VirtualFrame frame, final SomForkJoinTask task) {
+      Object result = doJoin(task);
+
+      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && task.stopOnJoin()) {
+        haltNode.executeEvaluated(frame, result);
+      }
 
       if (VmSettings.ACTOR_TRACING) {
         ActorExecutionTrace.taskJoin(task.getMethod(), task.getId());

--- a/src/som/primitives/ActivityJoin.java
+++ b/src/som/primitives/ActivityJoin.java
@@ -10,6 +10,7 @@ import som.VM;
 import som.interpreter.actors.SuspendExecutionNodeGen;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
 import som.primitives.threading.TaskThreads.SomForkJoinTask;
+import som.primitives.threading.ThreadPrimitives.SomThread;
 import som.vm.VmSettings;
 import tools.concurrency.ActorExecutionTrace;
 import tools.concurrency.Tags.ExpressionBreakpoint;
@@ -53,9 +54,13 @@ public class ActivityJoin {
     }
 
     @Specialization
-    public final Object doThread(final Thread thread) {
+    public final Object doThread(final VirtualFrame frame, final SomThread thread) {
       try {
         thread.join();
+
+        if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && thread.stopOnJoin()) {
+          haltNode.executeEvaluated(frame, thread);
+        }
       } catch (InterruptedException e) {
         /* ignore for the moment */
       }

--- a/src/som/primitives/ActivitySpawn.java
+++ b/src/som/primitives/ActivitySpawn.java
@@ -8,6 +8,7 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
@@ -137,7 +138,9 @@ public abstract class ActivitySpawn {
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
-      if (tag == ActivityCreation.class || tag == ExpressionBreakpoint.class) {
+      if (tag == ActivityCreation.class ||
+          tag == ExpressionBreakpoint.class ||
+          tag == StatementTag.class) {
         return true;
       }
       return super.isTaggedWith(tag);
@@ -210,7 +213,9 @@ public abstract class ActivitySpawn {
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
-      if (tag == ActivityCreation.class || tag == ExpressionBreakpoint.class) {
+      if (tag == ActivityCreation.class ||
+          tag == ExpressionBreakpoint.class ||
+          tag == StatementTag.class) {
         return true;
       }
       return super.isTaggedWith(tag);

--- a/src/som/primitives/processes/ChannelPrimitives.java
+++ b/src/som/primitives/processes/ChannelPrimitives.java
@@ -87,6 +87,7 @@ public abstract class ChannelPrimitives {
   public static class Process implements Activity, Runnable {
     private final SObjectWithClass obj;
     private final boolean stopOnRootNode;
+    private boolean stopOnJoin;
 
     public Process(final SObjectWithClass obj, final boolean stopOnRootNode) {
       this.obj = obj;
@@ -116,6 +117,9 @@ public abstract class ChannelPrimitives {
 
     @Override
     public long getId() { return 0; }
+
+    @Override
+    public void setStepToJoin(final boolean val) { stopOnJoin = val; }
 
     public SObjectWithClass getProcObject() {
       return obj;

--- a/src/som/primitives/processes/ChannelPrimitives.java
+++ b/src/som/primitives/processes/ChannelPrimitives.java
@@ -1,6 +1,5 @@
 package som.primitives.processes;
 
-import java.util.HashSet;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory;
 import java.util.concurrent.ForkJoinWorkerThread;
@@ -58,12 +57,6 @@ public abstract class ChannelPrimitives {
     Out     = null; OutId     = null;
   }
 
-  private static final HashSet<Process> activeProcesses = new HashSet<>();
-
-  public static HashSet<Process> getActiveProcesses() {
-    return activeProcesses;
-  }
-
   public static final class ProcessThreadFactory implements ForkJoinWorkerThreadFactory {
     @Override
     public ForkJoinWorkerThread newThread(final ForkJoinPool pool) {
@@ -101,20 +94,12 @@ public abstract class ChannelPrimitives {
     public void run() {
       ((ProcessThread) Thread.currentThread()).current = this;
 
-      synchronized (activeProcesses) {
-        activeProcesses.add(this);
-      }
-
       try {
         SInvokable disp = (SInvokable) obj.getSOMClass().lookupMessage(
             Symbols.symbolFor("run"), AccessModifier.PROTECTED);
         disp.invoke(new Object[] {obj});
       } catch (Throwable t) {
         t.printStackTrace();
-      } finally {
-        synchronized (activeProcesses) {
-          activeProcesses.remove(this);
-        }
       }
     }
 

--- a/src/som/primitives/reflection/AbstractSymbolDispatch.java
+++ b/src/som/primitives/reflection/AbstractSymbolDispatch.java
@@ -51,7 +51,7 @@ public abstract class AbstractSymbolDispatch extends Node {
   public final AbstractMessageSendNode createForPerformNodes(
       final SSymbol selector) {
     return MessageSendNode.createForPerformNodes(selector, sourceSection,
-        getRootNode().getLanguage(SomLanguage.class).getVM());
+        SomLanguage.getVM(getRootNode()));
   }
 
   public static final ToArgumentsArrayNode createArgArrayNode() {

--- a/src/som/primitives/threading/TaskThreads.java
+++ b/src/som/primitives/threading/TaskThreads.java
@@ -24,6 +24,7 @@ public final class TaskThreads {
 
     private final Object[] argArray;
     private final boolean stopOnRoot;
+    private boolean stopOnJoin;
 
     public SomForkJoinTask(final Object[] argArray, final boolean stopOnRoot) {
       this.argArray   = argArray;
@@ -38,6 +39,10 @@ public final class TaskThreads {
       return ((SBlock) argArray[0]).getMethod();
     }
 
+    public boolean stopOnJoin() {
+      return stopOnJoin;
+    }
+
     @Override
     public final String getName() {
       return getMethod().toString();
@@ -47,6 +52,9 @@ public final class TaskThreads {
     public long getId() {
       return 0;
     }
+
+    @Override
+    public void setStepToJoin(final boolean val) { stopOnJoin = val; }
 
     @Override
     protected final Object compute() {

--- a/src/som/primitives/threading/ThreadPrimitives.java
+++ b/src/som/primitives/threading/ThreadPrimitives.java
@@ -13,6 +13,7 @@ import som.vm.ActivityThread;
 import som.vm.constants.Nil;
 import som.vmobjects.SBlock;
 import som.vmobjects.SClass;
+import tools.debugger.SteppingStrategy;
 import tools.debugger.entities.ActivityType;
 
 public final class ThreadPrimitives {
@@ -72,9 +73,21 @@ public final class ThreadPrimitives {
     private final Object[] args;
     private final SBlock block;
 
+    protected SteppingStrategy steppingStrategy;
+
     public SomThread(final SBlock block, final Object... args) {
       this.block = block;
       this.args  = args;
+    }
+
+    @Override
+    public SteppingStrategy getSteppingStrategy() {
+      return steppingStrategy;
+    }
+
+    @Override
+    public void setSteppingStrategy(final SteppingStrategy strategy) {
+      this.steppingStrategy = strategy;
     }
 
     @Override

--- a/src/som/primitives/threading/ThreadPrimitives.java
+++ b/src/som/primitives/threading/ThreadPrimitives.java
@@ -72,10 +72,13 @@ public final class ThreadPrimitives {
       implements Activity, ActivityThread {
     private final Object[] args;
     private final SBlock block;
+    private final boolean stopOnRoot;
+    private boolean stopOnJoin;
 
     protected SteppingStrategy steppingStrategy;
 
-    public SomThread(final SBlock block, final Object... args) {
+    public SomThread(final boolean stopOnRoot, final SBlock block, final Object... args) {
+      this.stopOnRoot = stopOnRoot;
       this.block = block;
       this.args  = args;
     }
@@ -92,6 +95,9 @@ public final class ThreadPrimitives {
 
     @Override
     public ActivityType getType() { return ActivityType.THREAD; }
+
+    @Override
+    public void setStepToJoin(final boolean val) { stopOnJoin = val; }
 
     @Override
     public void run() {

--- a/src/som/vm/Activity.java
+++ b/src/som/vm/Activity.java
@@ -6,4 +6,6 @@ public interface Activity {
   String getName();
   long getId();
   ActivityType getType();
+
+  void setStepToJoin(boolean val);
 }

--- a/src/som/vm/ActivityThread.java
+++ b/src/som/vm/ActivityThread.java
@@ -1,6 +1,12 @@
 package som.vm;
 
+import tools.debugger.SteppingStrategy;
 
 public interface ActivityThread {
   Activity getActivity();
+  SteppingStrategy getSteppingStrategy();
+  void setSteppingStrategy(SteppingStrategy strategy);
+
+  static ActivityThread currentThread() { return (ActivityThread) Thread.currentThread(); }
+  static SteppingStrategy steppingStrategy() { return currentThread().getSteppingStrategy(); }
 }

--- a/src/tools/concurrency/TracingActivityThread.java
+++ b/src/tools/concurrency/TracingActivityThread.java
@@ -8,6 +8,7 @@ import som.vm.Activity;
 import som.vm.ActivityThread;
 import som.vm.VmSettings;
 import tools.TraceData;
+import tools.debugger.SteppingStrategy;
 
 
 public abstract class TracingActivityThread extends ForkJoinWorkerThread
@@ -24,6 +25,8 @@ public abstract class TracingActivityThread extends ForkJoinWorkerThread
   public long erroredPromises;
 
   protected final TraceBuffer traceBuffer;
+
+  protected SteppingStrategy steppingStrategy;
 
   public TracingActivityThread(final ForkJoinPool pool) {
     super(pool);
@@ -42,6 +45,16 @@ public abstract class TracingActivityThread extends ForkJoinWorkerThread
 
   @Override
   public abstract Activity getActivity();
+
+  @Override
+  public SteppingStrategy getSteppingStrategy() {
+    return this.steppingStrategy;
+  }
+
+  @Override
+  public void setSteppingStrategy(final SteppingStrategy strategy) {
+    this.steppingStrategy = strategy;
+  }
 
   public long generateActivityId() {
     long result = nextActivityId;

--- a/src/tools/concurrency/TracingActivityThread.java
+++ b/src/tools/concurrency/TracingActivityThread.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import som.vm.Activity;
 import som.vm.ActivityThread;
 import som.vm.VmSettings;
 import tools.TraceData;
@@ -38,6 +39,9 @@ public abstract class TracingActivityThread extends ForkJoinWorkerThread
     }
     setName(getClass().getSimpleName() + "-" + threadId);
   }
+
+  @Override
+  public abstract Activity getActivity();
 
   public long generateActivityId() {
     long result = nextActivityId;

--- a/src/tools/debugger/SteppingStrategy.java
+++ b/src/tools/debugger/SteppingStrategy.java
@@ -11,11 +11,20 @@ public abstract class SteppingStrategy {
 
   /** Return true if the spawned activity should stop on its root node. */
   public boolean handleSpawn() { return false; }
-  public void prepareExecution(final WebDebugger dbg) { }
+  public boolean handleChannelMessage() { return false; }
 
+  // TODO: can I convert that into a simple location enum, or even Tag check???
   public static final class IntoSpawn extends SteppingStrategy {
     @Override
     public boolean handleSpawn() {
+      if (consumed) { return false; } else { consumed = true; }
+      return true;
+    }
+  }
+
+  public static final class ToChannelOpposite extends SteppingStrategy {
+    @Override
+    public boolean handleChannelMessage() {
       if (consumed) { return false; } else { consumed = true; }
       return true;
     }

--- a/src/tools/debugger/SteppingStrategy.java
+++ b/src/tools/debugger/SteppingStrategy.java
@@ -1,5 +1,6 @@
 package tools.debugger;
 
+import som.vm.Activity;
 
 public abstract class SteppingStrategy {
 
@@ -12,6 +13,8 @@ public abstract class SteppingStrategy {
   /** Return true if the spawned activity should stop on its root node. */
   public boolean handleSpawn() { return false; }
   public boolean handleChannelMessage() { return false; }
+
+  public void handleResumeExecution(final Activity activity) { }
 
   // TODO: can I convert that into a simple location enum, or even Tag check???
   public static final class IntoSpawn extends SteppingStrategy {
@@ -27,6 +30,15 @@ public abstract class SteppingStrategy {
     public boolean handleChannelMessage() {
       if (consumed) { return false; } else { consumed = true; }
       return true;
+    }
+  }
+
+  public static final class ReturnFromActivity extends SteppingStrategy {
+    @Override
+    public void handleResumeExecution(final Activity activity) {
+      if (consumed) { return; } else { consumed = true; }
+
+      activity.setStepToJoin(true);
     }
   }
 }

--- a/src/tools/debugger/SteppingStrategy.java
+++ b/src/tools/debugger/SteppingStrategy.java
@@ -1,0 +1,23 @@
+package tools.debugger;
+
+
+public abstract class SteppingStrategy {
+
+  protected boolean consumed;
+
+  public SteppingStrategy() {
+    consumed = false;
+  }
+
+  /** Return true if the spawned activity should stop on its root node. */
+  public boolean handleSpawn() { return false; }
+  public void prepareExecution(final WebDebugger dbg) { }
+
+  public static final class IntoSpawn extends SteppingStrategy {
+    @Override
+    public boolean handleSpawn() {
+      if (consumed) { return false; } else { consumed = true; }
+      return true;
+    }
+  }
+}

--- a/src/tools/debugger/SteppingStrategy.java
+++ b/src/tools/debugger/SteppingStrategy.java
@@ -16,6 +16,8 @@ public abstract class SteppingStrategy {
 
   public void handleResumeExecution(final Activity activity) { }
 
+  // TODO: can we get rid of the code doing the checking for those stepping things,
+  //       and integrate it into the breakpoint checking nodes?
   // TODO: can I convert that into a simple location enum, or even Tag check???
   public static final class IntoSpawn extends SteppingStrategy {
     @Override

--- a/src/tools/debugger/WebDebugger.java
+++ b/src/tools/debugger/WebDebugger.java
@@ -1,11 +1,9 @@
 package tools.debugger;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.WeakHashMap;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -23,7 +21,6 @@ import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
-import som.interpreter.actors.Actor;
 import som.vm.Activity;
 import som.vm.ActivityThread;
 import tools.SourceCoordinate;
@@ -73,9 +70,6 @@ public class WebDebugger extends TruffleInstrument implements SuspendedCallback 
 
   private final Map<Activity, Suspension> activityToSuspension = new HashMap<>();
   private final Map<Long, Suspension> idToSuspension           = new HashMap<>();
-
-  /** Actors that have been suspended at least once. */
-  private final Set<Actor> suspendedActors = Collections.newSetFromMap(new WeakHashMap<>());
 
   public void reportSyntaxElement(final Class<? extends Tags> type,
       final SourceSection source) {
@@ -133,11 +127,6 @@ public class WebDebugger extends TruffleInstrument implements SuspendedCallback 
     if (thread instanceof ActivityThread) {
       activityThread = (ActivityThread) thread;
       current = activityThread.getActivity();
-      if (current instanceof Actor) {
-        synchronized (suspendedActors) {
-          suspendedActors.add((Actor) current);
-        }
-      }
     } else {
       throw new RuntimeException("Support for " + thread.getClass().getName() + " not yet implemented.");
     }

--- a/src/tools/debugger/entities/BreakpointType.java
+++ b/src/tools/debugger/entities/BreakpointType.java
@@ -20,7 +20,7 @@ import tools.debugger.session.Breakpoints;
 import tools.debugger.session.SectionBreakpoint;
 
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public enum BreakpointType {
   @SerializedName("msgSenderBP")
   MSG_SENDER("msgSenderBP", "Message send",

--- a/src/tools/debugger/entities/BreakpointType.java
+++ b/src/tools/debugger/entities/BreakpointType.java
@@ -135,8 +135,14 @@ public enum BreakpointType {
     }
   },
 
-  // TODO: there is need for an ACTIVITY_CREATION_ROOT_NODE or some such breakpoint.
-  //       I am using it for the stepping already.
+  @SerializedName("activityOnExecBP")
+  ACTIVITY_ON_EXEC("activityOnExecBP", "On execution",
+      new Class[] {ActivityCreation.class}) {
+    @Override
+    public void registerOrUpdate(final Breakpoints bps, final SectionBreakpoint bpInfo) {
+      bps.addOrUpdateActivityOnExec(bpInfo);
+    }
+  },
 
   @SerializedName("activityBeforeJoinBP")
   ACTIVITY_BEFORE_JOIN("activityBeforeJoinBP", "Before join",

--- a/src/tools/debugger/entities/BreakpointType.java
+++ b/src/tools/debugger/entities/BreakpointType.java
@@ -135,6 +135,9 @@ public enum BreakpointType {
     }
   },
 
+  // TODO: there is need for an ACTIVITY_CREATION_ROOT_NODE or some such breakpoint.
+  //       I am using it for the stepping already.
+
   @SerializedName("activityBeforeJoinBP")
   ACTIVITY_BEFORE_JOIN("activityBeforeJoinBP", "Before join",
       new Class[] {ActivityJoin.class}) {

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -8,6 +8,7 @@ import tools.concurrency.Tags.ActivityCreation;
 import tools.concurrency.Tags.ChannelRead;
 import tools.concurrency.Tags.ChannelWrite;
 import tools.debugger.SteppingStrategy.IntoSpawn;
+import tools.debugger.SteppingStrategy.ReturnFromActivity;
 import tools.debugger.SteppingStrategy.ToChannelOpposite;
 import tools.debugger.frontend.Suspension;
 
@@ -73,6 +74,17 @@ public enum SteppingType {
       susp.getActivityThread().setSteppingStrategy(new IntoSpawn());
     }
   },
+
+  @SerializedName("returnFromActivity")
+  RETURN_FROM_ACTIVITY("returnFromActivity", "Return from Activity", Group.ACTIVITY_STEPPING, "arrow-left",
+      null, new ActivityType[] {ActivityType.PROCESS, ActivityType.TASK, ActivityType.THREAD}) {
+    @Override
+    public void process(final Suspension susp) {
+      susp.getEvent().prepareContinue();
+      susp.getActivityThread().setSteppingStrategy(new ReturnFromActivity());
+    }
+  },
+
 
   @SerializedName("stepToChannelRcvr")
   STEP_TO_CHANNEL_RCVR("stepToChannelRcvr", "Step to Receiver", Group.PROCESS_STEPPING, "arrow-right", new Class[] {ChannelWrite.class}) {

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -65,8 +65,8 @@ public enum SteppingType {
     }
   },
 
-  @SerializedName("stepIntoProc")
-  STEP_INTO_PROCESS("stepIntoProc", "Step into Process", Group.PROCESS_STEPPING, "arrow-down", new Class[] {ActivityCreation.class}) {
+  @SerializedName("stepIntoActivity")
+  STEP_INTO_ACTIVITY("stepIntoActivity", "Step into Activity", Group.ACTIVITY_STEPPING, "arrow-down", new Class[] {ActivityCreation.class}) {
     @Override
     public void process(final Suspension susp) {
       susp.getEvent().prepareStepOver(1);
@@ -101,6 +101,7 @@ public enum SteppingType {
   public enum Group {
     BASIC_CONTROLS("Basic Controls"),
     LOCAL_STEPPING("Local Stepping"),
+    ACTIVITY_STEPPING("Activity Stepping"),
     ACTOR_STEPPING("Actor Stepping"),
     PROCESS_STEPPING("Process Stepping");
 

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -8,6 +8,7 @@ import tools.concurrency.Tags.ActivityCreation;
 import tools.concurrency.Tags.ChannelRead;
 import tools.concurrency.Tags.ChannelWrite;
 import tools.debugger.SteppingStrategy.IntoSpawn;
+import tools.debugger.SteppingStrategy.ToChannelOpposite;
 import tools.debugger.frontend.Suspension;
 
 
@@ -77,7 +78,8 @@ public enum SteppingType {
   STEP_TO_CHANNEL_RCVR("stepToChannelRcvr", "Step to Receiver", Group.PROCESS_STEPPING, "arrow-right", new Class[] {ChannelWrite.class}) {
     @Override
     public void process(final Suspension susp) {
-      throw new NotYetImplementedException();
+      susp.getEvent().prepareStepOver(1);
+      susp.getActivityThread().setSteppingStrategy(new ToChannelOpposite());
     }
   },
 
@@ -85,7 +87,8 @@ public enum SteppingType {
   STEP_TO_CHANNEL_SENDER("stepToChannelSender", "Step to Sender", Group.PROCESS_STEPPING, "arrow-left", new Class[] {ChannelRead.class}) {
     @Override
     public void process(final Suspension susp) {
-      throw new NotYetImplementedException();
+      susp.getEvent().prepareStepInto(1);
+      susp.getActivityThread().setSteppingStrategy(new ToChannelOpposite());
     }
   },
 

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -114,6 +114,7 @@ public enum SteppingType {
   public final String label;
   public final Group  group;
   public final String icon;
+  public final ActivityType[] forActivities;
 
   /** Tag to identify the source sections at which this step operation makes sense.
       If no tags are given, it is assumed the operation is always valid. */
@@ -121,11 +122,17 @@ public enum SteppingType {
 
   SteppingType(final String name, final String label, final Group group, final String icon,
       final Class<? extends Tags>[] applicableTo) {
+    this(name, label, group, icon, applicableTo, null);
+  }
+
+  SteppingType(final String name, final String label, final Group group, final String icon,
+      final Class<? extends Tags>[] applicableTo, final ActivityType[] forActivities) {
     this.name  = name;
     this.label = label;
     this.group = group;
     this.icon  = icon;
-    this.applicableTo = applicableTo;
+    this.applicableTo  = applicableTo;
+    this.forActivities = forActivities;
   }
 
   public abstract void process(Suspension susp);

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -1,27 +1,32 @@
 package tools.debugger.entities;
 
 import com.google.gson.annotations.SerializedName;
-import com.oracle.truffle.api.debug.SuspendedEvent;
 
 import som.vm.NotYetImplementedException;
 import tools.concurrency.Tags;
+import tools.concurrency.Tags.ActivityCreation;
+import tools.concurrency.Tags.ChannelRead;
+import tools.concurrency.Tags.ChannelWrite;
+import tools.debugger.SteppingStrategy.IntoSpawn;
+import tools.debugger.frontend.Suspension;
 
 
 // TODO: stepping, is that the right name?
+@SuppressWarnings("unchecked")
 public enum SteppingType {
 
   @SerializedName("resume")
   RESUME("resume", "Resume Execution", Group.BASIC_CONTROLS, "play", null) {
     @Override
-    public void process(final SuspendedEvent event) {
-      event.prepareContinue();
+    public void process(final Suspension susp) {
+      susp.getEvent().prepareContinue();
     }
   },
 
   @SerializedName("pause")
   PAUSE("pause", "Pause Execution", Group.BASIC_CONTROLS, "pause", null) {
     @Override
-    public void process(final SuspendedEvent event) {
+    public void process(final Suspension susp) {
       // TODO: at this point, we don't have an `event`???!!!
       throw new NotYetImplementedException();
     }
@@ -30,44 +35,71 @@ public enum SteppingType {
   @SerializedName("stop")
   STOP("stop", "stop", Group.BASIC_CONTROLS, "stop", null) {
     @Override
-    public void process(final SuspendedEvent event) {
-      event.prepareKill();
+    public void process(final Suspension susp) {
+      susp.getEvent().prepareKill();
     }
   },
 
   @SerializedName("stepInto")
   STEP_INTO("stepInto", "Step Into", Group.LOCAL_STEPPING, "arrow-down", null) {
     @Override
-    public void process(final SuspendedEvent event) {
-      event.prepareStepInto(1);
+    public void process(final Suspension susp) {
+      susp.getEvent().prepareStepInto(1);
     }
   },
 
   @SerializedName("stepOver")
   STEP_OVER("stepOver", "Step Over", Group.LOCAL_STEPPING, "arrow-right", null) {
     @Override
-    public void process(final SuspendedEvent event) {
-      event.prepareStepOver(1);
+    public void process(final Suspension susp) {
+      susp.getEvent().prepareStepOver(1);
     }
   },
 
   @SerializedName("return")
   STEP_RETURN("return", "Return from Method", Group.LOCAL_STEPPING, "arrow-left", null) {
     @Override
-    public void process(final SuspendedEvent event) {
-      event.prepareStepOut();
+    public void process(final Suspension susp) {
+      susp.getEvent().prepareStepOut();
     }
   },
 
-  STEP_TO_RECEIVER_MESSAGE("todo", "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final SuspendedEvent event) { /* TODO */ } },
-  STEP_TO_PROMISE_RESOLUTION("todo", "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final SuspendedEvent event) { /* TODO */ } },
-  STEP_TO_NEXT_MESSAGE("todo", "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final SuspendedEvent event) { /* TODO */ } },
-  STEP_RETURN_TO_PROMISE_RESOLUTION("todo", "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final SuspendedEvent event) { /* TODO */ } };
+  @SerializedName("stepIntoProc")
+  STEP_INTO_PROCESS("stepIntoProc", "Step into Process", Group.PROCESS_STEPPING, "arrow-down", new Class[] {ActivityCreation.class}) {
+    @Override
+    public void process(final Suspension susp) {
+      susp.getEvent().prepareStepOver(1);
+      susp.getActivityThread().setSteppingStrategy(new IntoSpawn());
+    }
+  },
+
+  @SerializedName("stepToChannelRcvr")
+  STEP_TO_CHANNEL_RCVR("stepToChannelRcvr", "Step to Receiver", Group.PROCESS_STEPPING, "arrow-right", new Class[] {ChannelWrite.class}) {
+    @Override
+    public void process(final Suspension susp) {
+      throw new NotYetImplementedException();
+    }
+  },
+
+  @SerializedName("stepToChannelSender")
+  STEP_TO_CHANNEL_SENDER("stepToChannelSender", "Step to Sender", Group.PROCESS_STEPPING, "arrow-left", new Class[] {ChannelRead.class}) {
+    @Override
+    public void process(final Suspension susp) {
+      throw new NotYetImplementedException();
+    }
+  },
+
+
+  STEP_TO_RECEIVER_MESSAGE("todo",   "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final Suspension susp) { /* TODO */ } },
+  STEP_TO_PROMISE_RESOLUTION("todo", "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final Suspension susp) { /* TODO */ } },
+  STEP_TO_NEXT_MESSAGE("todo",       "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final Suspension susp) { /* TODO */ } },
+  STEP_RETURN_TO_PROMISE_RESOLUTION("todo", "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final Suspension susp) { /* TODO */ } };
 
   public enum Group {
     BASIC_CONTROLS("Basic Controls"),
     LOCAL_STEPPING("Local Stepping"),
-    ACTOR_STEPPING("Actor Stepping");
+    ACTOR_STEPPING("Actor Stepping"),
+    PROCESS_STEPPING("Process Stepping");
 
     public final String label;
 
@@ -92,5 +124,5 @@ public enum SteppingType {
     this.applicableTo = applicableTo;
   }
 
-  public abstract void process(SuspendedEvent event);
+  public abstract void process(Suspension susp);
 }

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -14,7 +14,7 @@ import tools.debugger.frontend.Suspension;
 
 
 // TODO: stepping, is that the right name?
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "rawtypes"})
 public enum SteppingType {
 
   @SerializedName("resume")

--- a/src/tools/debugger/frontend/Suspension.java
+++ b/src/tools/debugger/frontend/Suspension.java
@@ -12,6 +12,7 @@ import som.interpreter.actors.SuspendExecutionNode;
 import som.interpreter.objectstorage.ObjectTransitionSafepoint;
 import som.primitives.ObjectPrims.HaltPrim;
 import som.vm.Activity;
+import som.vm.ActivityThread;
 import tools.TraceData;
 import tools.debugger.FrontendConnector;
 import tools.debugger.frontend.ApplicationThreadTask.Resume;
@@ -29,12 +30,15 @@ import tools.debugger.frontend.ApplicationThreadTask.SendStackTrace;
 public class Suspension {
   public final long activityId;
   private final Activity activity;
+  private final ActivityThread activityThread;
   private final ArrayBlockingQueue<ApplicationThreadTask> tasks;
 
   private SuspendedEvent suspendedEvent;
   private ApplicationThreadStack stack;
 
-  public Suspension(final Activity activity, final long activityId) {
+  public Suspension(final ActivityThread activityThread,
+      final Activity activity, final long activityId) {
+    this.activityThread = activityThread;
     this.activity   = activity;
     this.activityId = activityId;
     this.tasks = new ArrayBlockingQueue<>(2);
@@ -144,6 +148,7 @@ public class Suspension {
     ObjectTransitionSafepoint.INSTANCE.register();
   }
 
+  public ActivityThread getActivityThread() { return activityThread; }
   public Activity getActivity() { return activity; }
   public synchronized SuspendedEvent getEvent() { return suspendedEvent; }
 }

--- a/src/tools/debugger/frontend/Suspension.java
+++ b/src/tools/debugger/frontend/Suspension.java
@@ -15,6 +15,7 @@ import som.vm.Activity;
 import som.vm.ActivityThread;
 import tools.TraceData;
 import tools.debugger.FrontendConnector;
+import tools.debugger.SteppingStrategy;
 import tools.debugger.frontend.ApplicationThreadTask.Resume;
 import tools.debugger.frontend.ApplicationThreadTask.SendStackTrace;
 
@@ -138,6 +139,11 @@ public class Suspension {
     while (continueWaiting) {
       try {
         continueWaiting = tasks.take().execute();
+        SteppingStrategy strategy = activityThread.getSteppingStrategy();
+        if (strategy != null) {
+          strategy.handleResumeExecution(activity);
+        }
+
       } catch (InterruptedException e) { /* Just continue waiting */ }
     }
     synchronized (this) {

--- a/src/tools/debugger/message/InitializationResponse.java
+++ b/src/tools/debugger/message/InitializationResponse.java
@@ -64,6 +64,7 @@ public final class InitializationResponse extends OutgoingMessage {
     private final String group;
     private final String icon;
     private final String[] applicableTo;
+    private final byte[] forActivities;
 
     private SteppingData(final SteppingType type) {
       this.name = type.name;
@@ -71,6 +72,18 @@ public final class InitializationResponse extends OutgoingMessage {
       this.group = type.group.label;
       this.icon  = type.icon;
       this.applicableTo = tagsToStrings(type.applicableTo);
+
+      if (type.forActivities != null) {
+        this.forActivities = new byte[type.forActivities.length];
+
+        int i = 0;
+        for (ActivityType t : type.forActivities) {
+          this.forActivities[i] = t.getId();
+          i += 1;
+        }
+      } else {
+        this.forActivities = null;
+      }
     }
   }
 

--- a/src/tools/debugger/message/StepMessage.java
+++ b/src/tools/debugger/message/StepMessage.java
@@ -23,8 +23,7 @@ public class StepMessage extends IncommingMessage {
   @Override
   public void process(final FrontendConnector connector, final WebSocket conn) {
     Suspension susp = connector.getSuspension(activityId);
-    assert susp.getEvent() != null : "didn't find SuspendEvent";
-    step.process(susp.getEvent());
+    step.process(susp);
     susp.resume();
   }
 }

--- a/tools/kompos/src/messages.ts
+++ b/tools/kompos/src/messages.ts
@@ -162,7 +162,8 @@ export interface SteppingType {
   label: string;    /** Label to use for display purposes. */
   group: string;    /** Group Label. */
   icon:  string;    /** Id of an icon known by the frontend. */
-  applicableTo?: string[]; /** The source section tags this stepping operation applies to. If empty, it applies unconditionally. */
+  applicableTo?: string[];  /** The source section tags this stepping operation applies to. If empty, it applies unconditionally. */
+  forActivities?: ActivityType[]; /** Ids of the activities this stepping operation applies to. If empty, it applies unconditionally. */
 }
 
 export interface EntityDef {

--- a/tools/kompos/src/ui-controller.ts
+++ b/tools/kompos/src/ui-controller.ts
@@ -45,7 +45,6 @@ export class UiController extends Controller {
   }
 
   public onConnect() {
-    dbgLog("[WS] open");
     this.reset();
     this.view.onConnect();
     const bps = this.dbg.getEnabledBreakpoints();
@@ -55,7 +54,6 @@ export class UiController extends Controller {
   }
 
   public onClose() {
-    dbgLog("[WS] close");
     this.view.onClose();
   }
 


### PR DESCRIPTION
Implement stepping on channel reads/writes and process creation, task creation, and return form activity.

This change also introduces stepping strategies to realize the stepping process.

- [x] added stepping into newly started process
- [x] add stepping to channel reader, from writer
- [x] add stepping to channel writer, from reader
- [x] add stepping to return from current activity (not applicable to actors)

- remove unused list of processes
- add `SomLanguage.getVM(rootNode)` for slow path use
- during debugging, fork/join threads need to track current task
- stepping types might be for specific types of activities only
- mark `#spawn:*` as statement to allow single stepping to it.