### PR TITLE
Fix various single stepping issues

### DIFF
--- a/tools/kompos/src/debugger.ts
+++ b/tools/kompos/src/debugger.ts
@@ -2,12 +2,6 @@ import {IdMap, Source, StackFrame, SourceMessage, TaggedSourceCoordinate,
   Activity, ServerCapabilities, getSectionId} from "./messages";
 import {Breakpoint} from "./breakpoints";
 
-export function isRelevant(sc: TaggedSourceCoordinate) {
-  // ExpressionBreakpoint tag implies there is some kind of breakpoint there
-  // the specific kind is handled dynamically at run time
-  return -1 !== sc.tags.indexOf("ExpressionBreakpoint");
-}
-
 export class Debugger {
 
   private serverCapabilities?: ServerCapabilities;
@@ -81,11 +75,8 @@ export class Debugger {
   private addSections(s: Source) {
     let sId = this.getSourceId(s.uri);
     for (let sc of s.sections) {
-      // Filter out all non-relevant source sections
-      if (isRelevant(sc)) {
-        let id = getSectionId(sId, sc);
-        this.sections[id] = sc;
-      }
+      let id = getSectionId(sId, sc);
+      this.sections[id] = sc;
     }
   }
 

--- a/tools/kompos/src/ui-controller.ts
+++ b/tools/kompos/src/ui-controller.ts
@@ -141,10 +141,11 @@ export class UiController extends Controller {
       const sourceId = this.dbg.getSourceId(msg.stackFrames[0].sourceUri);
       const source = this.dbg.getSource(sourceId);
 
+      const newSource = this.view.displaySource(act, source, sourceId);
+
       const ssId = this.dbg.getSectionIdFromFrame(sourceId, msg.stackFrames[0]);
       const section = this.dbg.getSection(ssId);
 
-      const newSource = this.view.displaySource(act, source, sourceId);
       this.view.displayStackTrace(sourceId, msg, topFrameId, act, ssId, section);
       if (newSource) {
         this.ensureBreakpointsAreIndicated(sourceId);

--- a/tools/kompos/src/view.ts
+++ b/tools/kompos/src/view.ts
@@ -669,9 +669,14 @@ export class View {
   }
 
   private showFrame(frame: StackFrame, active: boolean, list: JQuery) {
-    const fileNameStart = frame.sourceUri.lastIndexOf("/") + 1;
-    const fileName = frame.sourceUri.substr(fileNameStart);
-    const location = fileName + ":" + frame.line + ":" + frame.column;
+    let location;
+    if (frame.sourceUri) {
+      const fileNameStart = frame.sourceUri.lastIndexOf("/") + 1;
+      const fileName = frame.sourceUri.substr(fileNameStart);
+      location = fileName + ":" + frame.line + ":" + frame.column;
+    } else {
+      location = "vmMirror";
+    }
 
     const entry = nodeFromTemplate("stack-trace-elem-tpl");
     entry.id = this.getFrameId(frame.id);

--- a/tools/kompos/src/view.ts
+++ b/tools/kompos/src/view.ts
@@ -714,6 +714,9 @@ export class View {
   }
 
   private hasCommonElements(a: string[], b: string[]) {
+    if (!Array.isArray(a) || !Array.isArray(b)) {
+      return false;
+    }
     for (const s of a) {
       for (const t of b) {
         if (s === t) {
@@ -726,7 +729,9 @@ export class View {
 
   private isSteppingApplicable(section: TaggedSourceCoordinate, step: SteppingType) {
     if (step.applicableTo) {
-      return this.hasCommonElements(section.tags, step.applicableTo);
+      // there can be cases where we don't actually have source section. TODO: fix this
+      const tags = section ? section.tags : [];
+      return this.hasCommonElements(tags, step.applicableTo);
     } else {
       return true;
     }
@@ -742,20 +747,22 @@ export class View {
   private highlightProgramPosition(sourceId: string, activity: Activity,
       ssId: string) {
 
-    let ss = document.getElementById(
-                        getSectionIdForActivity(ssId, activity.id));
-    $(ss).addClass("DbgCurrentNode");
-
     this.showSourceById(sourceId, activity);
 
-    const sourcePaneId = getSectionIdForActivity(sourceId, activity.id);
-    const sourcePaneElem = document.getElementById(sourcePaneId);
+    const ss = document.getElementById(
+                        getSectionIdForActivity(ssId, activity.id));
+    if (ss) { // there can be cases where we don't actually have source section. TODO: fix this
+      $(ss).addClass("DbgCurrentNode");
 
-    const defaultDuration = 100;
-    const edgeOffset      = 30;
+      const sourcePaneId = getSectionIdForActivity(sourceId, activity.id);
+      const sourcePaneElem = document.getElementById(sourcePaneId);
 
-    const scroller = zenscroll.createScroller(sourcePaneElem, defaultDuration, edgeOffset);
-    scroller.center(ss);
+      const defaultDuration = 100;
+      const edgeOffset      = 30;
+
+      const scroller = zenscroll.createScroller(sourcePaneElem, defaultDuration, edgeOffset);
+      scroller.center(ss);
+    }
   }
 
   private showSourceById(sourceId: string, activity: Activity) {


### PR DESCRIPTION
Stepping through the `Platform>>#start` method reveals a lot of bugs.

Fixed:
 - errors with primitives/vmMirror methods
 - can't filter source sections anymore, need them all for stepping buttons
 - make highlighting and stepping button update more robust for non-existing source sections (we have some of those at class headers, I think)