### PR TITLE
Improved #halt handling, WebSocket error reporting, handling resume

### DIFF
--- a/src/som/primitives/transactions/AtomicPrim.java
+++ b/src/som/primitives/transactions/AtomicPrim.java
@@ -2,6 +2,7 @@ package som.primitives.transactions;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
@@ -56,7 +57,9 @@ public abstract class AtomicPrim extends BinaryComplexOperation {
 
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
-    if (tag == Atomic.class || tag == ExpressionBreakpoint.class) {
+    if (tag == Atomic.class ||
+        tag == ExpressionBreakpoint.class ||
+        tag == StatementTag.class) {
       return true;
     }
     return super.isTaggedWith(tag);

--- a/src/tools/debugger/WebSocketHandler.java
+++ b/src/tools/debugger/WebSocketHandler.java
@@ -39,7 +39,7 @@ public class WebSocketHandler extends WebSocketServer {
     try {
       IncommingMessage respond = gson.fromJson(message, IncommingMessage.class);
       respond.process(connector, conn);
-    } catch (Exception ex) {
+    } catch (Throwable ex) {
       VM.errorPrint("Error while processing msg:" + message);
       ex.printStackTrace();
     }

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -46,7 +46,9 @@ public enum SteppingType {
   STEP_INTO("stepInto", "Step Into", Group.LOCAL_STEPPING, "arrow-down", null) {
     @Override
     public void process(final Suspension susp) {
+      startHandleFrameSkip(susp);
       susp.getEvent().prepareStepInto(1);
+      completeHandleFrameSkip(susp);
     }
   },
 
@@ -54,7 +56,9 @@ public enum SteppingType {
   STEP_OVER("stepOver", "Step Over", Group.LOCAL_STEPPING, "arrow-right", null) {
     @Override
     public void process(final Suspension susp) {
+      startHandleFrameSkip(susp);
       susp.getEvent().prepareStepOver(1);
+      completeHandleFrameSkip(susp);
     }
   },
 
@@ -62,7 +66,9 @@ public enum SteppingType {
   STEP_RETURN("return", "Return from Method", Group.LOCAL_STEPPING, "arrow-left", null) {
     @Override
     public void process(final Suspension susp) {
+      startHandleFrameSkip(susp);
       susp.getEvent().prepareStepOut();
+      completeHandleFrameSkip(susp);
     }
   },
 
@@ -105,7 +111,9 @@ public enum SteppingType {
   },
 
 
-  STEP_TO_RECEIVER_MESSAGE("todo",   "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final Suspension susp) { /* TODO */ } },
+  STEP_TO_RECEIVER_MESSAGE("todo",   "todo", Group.ACTOR_STEPPING, "arrow-right", null) {
+    @Override public void process(final Suspension susp) { }
+  },
   STEP_TO_PROMISE_RESOLUTION("todo", "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final Suspension susp) { /* TODO */ } },
   STEP_TO_NEXT_MESSAGE("todo",       "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final Suspension susp) { /* TODO */ } },
   STEP_RETURN_TO_PROMISE_RESOLUTION("todo", "todo", Group.ACTOR_STEPPING, "arrow-right", null) { @Override public void process(final Suspension susp) { /* TODO */ } };
@@ -122,10 +130,26 @@ public enum SteppingType {
     Group(final String label) { this.label = label; }
   }
 
+  private static void startHandleFrameSkip(final Suspension susp) {
+    if (susp.getFrameSkipCount() > 0) {
+      susp.getEvent().startComposedStepping();
+      for (int i = 0; i < susp.getFrameSkipCount(); i += 1) {
+        susp.getEvent().prepareStepOut();
+      }
+    }
+  }
+
+  private static void completeHandleFrameSkip(final Suspension susp) {
+    if (susp.getFrameSkipCount() > 0) {
+      susp.getEvent().prepareComposedStepping();
+    }
+  }
+
   public final String name;
   public final String label;
   public final Group  group;
   public final String icon;
+
   public final ActivityType[] forActivities;
 
   /** Tag to identify the source sections at which this step operation makes sense.

--- a/src/tools/debugger/frontend/Suspension.java
+++ b/src/tools/debugger/frontend/Suspension.java
@@ -140,7 +140,7 @@ public class Suspension {
       try {
         continueWaiting = tasks.take().execute();
         SteppingStrategy strategy = activityThread.getSteppingStrategy();
-        if (strategy != null) {
+        if (!continueWaiting && strategy != null) {
           strategy.handleResumeExecution(activity);
         }
 


### PR DESCRIPTION
- make sure that stepping on #halt is natural, and ignores primitive method
- catch all exceptions in web socket threads
- don't handle resume, when we don't actually resume execution