### PR TITLE
Abstract lexical constructs (preparation for Object Literals)

### DIFF
--- a/src/som/compiler/LexicalBuilder.java
+++ b/src/som/compiler/LexicalBuilder.java
@@ -1,0 +1,82 @@
+package som.compiler;
+
+import som.interpreter.LexicalScope;
+
+public class LexicalBuilder {
+
+  private final LexicalBuilder outerBuilder;
+  private int                  levelsToNextMixin = -1;
+  private int                  levelsToNextMethod = -1;
+
+  public LexicalBuilder(final LexicalBuilder outerBuilder) {
+    this.outerBuilder = outerBuilder;
+  }
+
+  public LexicalScope getScope() {
+    return null;
+  }
+
+  public LexicalBuilder getContextualSelf() {
+    return outerBuilder;
+  }
+
+  private MixinBuilder bubbleToNextMixinOrNull() {
+    LexicalBuilder builder = getContextualSelf();
+    levelsToNextMixin = 0;
+
+    while (true) {
+
+      if (builder == null) {
+        return null;
+      }
+
+      if (builder instanceof MixinBuilder) {
+        return (MixinBuilder) builder;
+      }
+      builder = builder.getContextualSelf();
+
+      levelsToNextMixin += 1;
+    }
+  }
+
+  private MethodBuilder bubbleToNextMethodOrNull() {
+    LexicalBuilder builder = getContextualSelf();
+    levelsToNextMethod = 1;
+
+    while (true) {
+
+      if (builder == null) {
+        return null;
+      }
+
+      if (builder instanceof MethodBuilder) {
+        return (MethodBuilder) builder;
+      }
+
+      builder = builder.getContextualSelf();
+      levelsToNextMethod += 1;
+    }
+  }
+
+  public MixinBuilder getOuterSelf() {
+    return bubbleToNextMixinOrNull();
+  }
+
+  public MethodBuilder getNextMethod() {
+    return bubbleToNextMethodOrNull();
+  }
+
+  public int countLevelsToNextMixin() {
+    if (levelsToNextMixin == -1) {
+      bubbleToNextMixinOrNull();
+    }
+    return levelsToNextMixin;
+  }
+
+  public int countLevelsToNextMethod() {
+    if (levelsToNextMethod == -1) {
+      getNextMethod();
+    }
+    return levelsToNextMethod;
+  }
+}

--- a/src/som/compiler/MixinBuilder.java
+++ b/src/som/compiler/MixinBuilder.java
@@ -148,8 +148,8 @@ public final class MixinBuilder extends LexicalBuilder {
     this.instanceScope = new MixinScope(getOuterSelf() != null ? getOuterSelf().getInstanceScope() : null);
     this.classScope = new MixinScope(getOuterSelf() != null ? getOuterSelf().getInstanceScope() : null);
 
-    this.initializer          = new MethodBuilder(this, this.instanceScope);
-    this.primaryFactoryMethod = new MethodBuilder(this, this.classScope);
+    this.initializer          = new MethodBuilder(this);
+    this.primaryFactoryMethod = new MethodBuilder(this);
     this.superclassAndMixinResolutionBuilder = createSuperclassResolutionBuilder();
 
     this.accessModifier = accessModifier;
@@ -337,7 +337,8 @@ public final class MixinBuilder extends LexicalBuilder {
     return classSide;
   }
 
-  public MixinScope getScopeForCurrentParserPosition() {
+  @Override
+  public MixinScope getScope() {
     if (classSide) {
       return classScope;
     } else {
@@ -413,8 +414,7 @@ public final class MixinBuilder extends LexicalBuilder {
       definitionMethod = new MethodBuilder(true, language);
     } else {
       MixinBuilder mixinBuilder = getOuterSelf();
-      definitionMethod = new MethodBuilder(mixinBuilder,
-          mixinBuilder.getInstanceScope());
+      definitionMethod = new MethodBuilder(mixinBuilder);
     }
 
     // self is going to be the enclosing object

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -145,8 +145,8 @@ public final class MixinDefinition {
   }
 
   public MixinDefinition getOuter() {
-    assert instanceScope.getOuter() == classScope.getOuter() : "Inconsistent outer scope?";
-    return instanceScope.getOuter();
+    assert instanceScope.getOuterMixin() == classScope.getOuterMixin() : "Inconsistent outer scope?";
+    return instanceScope.getOuterMixin();
   }
 
   // TODO: does this really have to be an invokable?

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -752,8 +752,7 @@ public class Parser {
     SourceCoordinate coord = getCoordinate();
 
     AccessModifier accessModifier = accessModifier();
-    MethodBuilder builder = new MethodBuilder(
-        mxnBuilder, mxnBuilder.getScopeForCurrentParserPosition());
+    MethodBuilder builder = new MethodBuilder(mxnBuilder);
 
     messagePattern(builder);
     expect(Equal,

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -1230,7 +1230,7 @@ public class Parser {
       assert !eventualSend;
       return createImplicitReceiverSend(msg, args,
           builder.getCurrentMethodScope(),
-          builder.getEnclosingMixinBuilder().getMixinId(), source, language.getVM());
+          builder.getOuterSelf().getMixinId(), source, language.getVM());
     }
   }
 
@@ -1486,7 +1486,10 @@ public class Parser {
       blockPattern(builder);
     }
 
-    String outerMethodName = stripColons(builder.getOuterBuilder().
+    if (builder.getNextMethod() == null) {
+      throw new java.lang.NullPointerException("The outer context of a block should never be null");
+    }
+    String outerMethodName = stripColons(builder.getNextMethod().
         getSignature().getString());
 
     // generate Block signature

--- a/src/som/interpreter/InliningVisitor.java
+++ b/src/som/interpreter/InliningVisitor.java
@@ -54,7 +54,7 @@ public final class InliningVisitor implements NodeVisitor {
         return new ScopeElement(v, lvl);
       }
     }
-    MethodScope outer = scope.getOuterMethodScopeOrNull();
+    MethodScope outer = scope.getNextMethodScope();
     if (outer == null) {
       throw new IllegalStateException("Couldn't find var: " + var.toString());
     } else {

--- a/src/som/interpreter/nodes/ContextualNode.java
+++ b/src/som/interpreter/nodes/ContextualNode.java
@@ -29,7 +29,7 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.SArguments;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
-import som.vmobjects.SBlock;
+import som.vmobjects.SObjectWithContext;
 
 
 public abstract class ContextualNode extends ExprWithTagsNode {
@@ -49,16 +49,16 @@ public abstract class ContextualNode extends ExprWithTagsNode {
 
   @ExplodeLoop
   protected final MaterializedFrame determineContext(final VirtualFrame frame) {
-    SBlock self = (SBlock) SArguments.rcvr(frame);
+    SObjectWithContext contextualSelf = (SObjectWithContext) SArguments.rcvr(frame);
     int i = contextLevel - 1;
 
     while (i > 0) {
-      self = (SBlock) self.getOuterSelf();
+      contextualSelf = (SObjectWithContext) contextualSelf.getContextualSelf();
       i--;
     }
 
     // Graal needs help here to see that this is always a MaterializedFrame
     // so, we record explicitly a class profile
-    return frameType.profile(self.getContext());
+    return frameType.profile(contextualSelf.getContext());
   }
 }

--- a/src/som/vmobjects/SBlock.java
+++ b/src/som/vmobjects/SBlock.java
@@ -32,7 +32,7 @@ import som.interop.SBlockInteropMessageResolutionForeign;
 import som.interpreter.SArguments;
 
 
-public final class SBlock extends SAbstractObject implements TruffleObject {
+public final class SBlock extends SAbstractObject implements TruffleObject, SObjectWithContext {
 
   private final SInvokable        method;
   private final MaterializedFrame context;
@@ -49,12 +49,14 @@ public final class SBlock extends SAbstractObject implements TruffleObject {
     return method;
   }
 
+  @Override
   public MaterializedFrame getContext() {
     assert context != null;
     return context;
   }
 
-  public Object getOuterSelf() {
+  @Override
+  public Object getContextualSelf() {
     return SArguments.rcvr(getContext());
   }
 
@@ -78,3 +80,4 @@ public final class SBlock extends SAbstractObject implements TruffleObject {
     return SBlockInteropMessageResolutionForeign.ACCESS;
   }
 }
+

--- a/src/som/vmobjects/SObjectWithContext.java
+++ b/src/som/vmobjects/SObjectWithContext.java
@@ -1,0 +1,11 @@
+package som.vmobjects;
+
+import com.oracle.truffle.api.frame.MaterializedFrame;
+
+public interface SObjectWithContext {
+
+  MaterializedFrame getContext();
+  Object getContextualSelf();
+
+}
+

--- a/src/tools/debugger/message/ScopesResponse.java
+++ b/src/tools/debugger/message/ScopesResponse.java
@@ -55,7 +55,7 @@ public final class ScopesResponse extends Response {
 
   private static void addScopes(final ArrayList<Scope> scopes,
       final MethodScope method, final Object rcvr, final Suspension suspension) {
-    MethodScope outer = method.getOuterMethodScopeOrNull();
+    MethodScope outer = method.getNextMethodScope();
     if (outer != null) {
       assert rcvr instanceof SBlock;
       MaterializedFrame mFrame = ((SBlock) rcvr).getContext();


### PR DESCRIPTION
In order to enable a cleaner implementation of object literals I have generalised the behaviour for the nesting of lexical constructs. In particular, I have introduced a new `LexicalBuilder` superclass, of which `MethodBuilder` and `MixinBuilder` are subclasses.

LexicalBuilder builders can be nested arbitrarily. By relaxing the nesting in this way, it will be simpler to reuse `MixinBuilder`s to implement objects literals (issue #86, which requires `MixinBuilder`s to be nested inside of `MethodBuilder`s).

Beyond enabling a simpler implementation for object literals, these changes remove the need for builders to keep a reference to both the outer self (in the sense of the containing object) and the contextual self - now only the contextual self is needed. Similar changes have been implemented in the `LexicalScope` construct.

Finally, the introduction of the `SObjectWithContext` provides an single interface for interacting with VM objects that have a context. Currently the only implementor of this context is `SBlock`, but soon to be joined by `SObjectWithClass` to enable object literals.