### PR TITLE
Fix Threads for Tracing, and add STM stepping support

### DIFF
--- a/core-lib/TestSuite/ThreadingTests.som
+++ b/core-lib/TestSuite/ThreadingTests.som
@@ -61,21 +61,22 @@ class ThreadingTests usingPlatform: platform testFramework: minitest = (
     public testSpawning = (
       | thread |
       thread := Thread spawn: [].
-
-      self assert: (thread name beginsWith: 'Thread-').
+      self assert: (thread name beginsWith: 'Thread(').
 
       thread := Thread spawn: [:i | i ] with: (Array with: 1).
-      self assert: (thread name beginsWith: 'Thread-')
+      thread name println.
+      self assert: (thread name beginsWith: 'Thread(')
     )
 
     public testThreadInterface = (
       | thread thread2 executed |
       executed := false.
-      thread := Thread spawn: [ executed := true ].
+      thread := Thread spawn: [
+        executed := true.
+        Thread current
+      ].
       thread name: 'bar'.
       self assert: 'bar'  equals: thread name.
-
-      thread == thread.
 
       self assert: thread is: thread join.
       self assert: executed.
@@ -85,7 +86,7 @@ class ThreadingTests usingPlatform: platform testFramework: minitest = (
       thread  := Thread current.
       thread2 := Thread current.
       self assert: thread is: thread2.
-      self deny: thread == nil.
+      self assert: thread == nil.
     )
 
     public testThreadCurrent = (

--- a/src/som/interpreter/Types.java
+++ b/src/som/interpreter/Types.java
@@ -35,6 +35,7 @@ import som.interpreter.nodes.DummyParent;
 import som.primitives.SizeAndLengthPrim;
 import som.primitives.SizeAndLengthPrimFactory;
 import som.primitives.threading.TaskThreads.SomForkJoinTask;
+import som.primitives.threading.TaskThreads.SomThreadTask;
 import som.primitives.threading.ThreadingModule;
 import som.vm.constants.Classes;
 import som.vm.constants.Nil;
@@ -84,7 +85,7 @@ public class Types {
       return Classes.stringClass;
     } else if (obj instanceof Double) {
       return Classes.doubleClass;
-    } else if (obj instanceof Thread) {
+    } else if (obj instanceof SomThreadTask) {
       assert ThreadingModule.ThreadClass != null;
       return ThreadingModule.ThreadClass;
     } else if (obj instanceof ReentrantLock) {

--- a/src/som/interpreter/nodes/OuterObjectRead.java
+++ b/src/som/interpreter/nodes/OuterObjectRead.java
@@ -22,6 +22,7 @@ import som.interpreter.processes.SChannel.SChannelOutput;
 import som.primitives.actors.ActorClasses;
 import som.primitives.processes.ChannelPrimitives;
 import som.primitives.threading.TaskThreads.SomForkJoinTask;
+import som.primitives.threading.TaskThreads.SomThreadTask;
 import som.primitives.threading.ThreadingModule;
 import som.vm.VmSettings;
 import som.vm.constants.KernelObj;
@@ -184,7 +185,7 @@ public abstract class OuterObjectRead
   public Object doSBlock(final SBlock receiver) { return KernelObj.kernel; }
 
   @Specialization(guards = {"contextLevel == 1", "mixinId == ThreadClassId"})
-  public Object doThread(final Thread receiver) {
+  public Object doThread(final SomThreadTask receiver) {
     assert ThreadingModule.ThreadingModule != null;
     return ThreadingModule.ThreadingModule;
   }
@@ -226,7 +227,7 @@ public abstract class OuterObjectRead
   }
 
   @Specialization(guards = {"contextLevel == 1", "mixinId != ThreadClassId"})
-  public Object doThreadInKernelScope(final Thread receiver) {
+  public Object doThreadInKernelScope(final SomThreadTask receiver) {
     return KernelObj.kernel;
   }
 

--- a/src/som/primitives/EqualsEqualsPrim.java
+++ b/src/som/primitives/EqualsEqualsPrim.java
@@ -8,6 +8,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.actors.SFarReference;
+import som.primitives.threading.TaskThreads.SomThreadTask;
 import som.vmobjects.SArray.SMutableArray;
 import som.vmobjects.SBlock;
 import som.vmobjects.SInvokable;
@@ -54,7 +55,7 @@ public abstract class EqualsEqualsPrim extends ComparisonPrim {
   }
 
   @Specialization
-  public final boolean doThread(final Thread left, final Object right) {
+  public final boolean doThread(final SomThreadTask left, final Object right) {
     return left == right;
   }
 

--- a/src/som/primitives/threading/TaskThreads.java
+++ b/src/som/primitives/threading/TaskThreads.java
@@ -19,33 +19,25 @@ import tools.debugger.entities.ActivityType;
 
 public final class TaskThreads {
 
-  public static class SomForkJoinTask extends RecursiveTask<Object> implements Activity {
-    private static final long serialVersionUID = -2145613708553535622L;
+  public abstract static class SomTaskOrThread extends RecursiveTask<Object> implements Activity {
+    private static final long serialVersionUID = 4823503369882151811L;
 
-    private final Object[] argArray;
-    private final boolean stopOnRoot;
-    private boolean stopOnJoin;
+    protected final Object[] argArray;
+    protected final boolean stopOnRoot;
+    protected boolean stopOnJoin;
 
-    public SomForkJoinTask(final Object[] argArray, final boolean stopOnRoot) {
+    public SomTaskOrThread(final Object[] argArray, final boolean stopOnRoot) {
       this.argArray   = argArray;
       this.stopOnRoot = stopOnRoot;
       assert argArray[0] instanceof SBlock : "First argument of a block needs to be the block object";
     }
 
-    @Override
-    public ActivityType getType() { return ActivityType.TASK; }
-
     public final SInvokable getMethod() {
       return ((SBlock) argArray[0]).getMethod();
     }
 
-    public boolean stopOnJoin() {
+    public final boolean stopOnJoin() {
       return stopOnJoin;
-    }
-
-    @Override
-    public final String getName() {
-      return getMethod().toString();
     }
 
     @Override
@@ -64,14 +56,31 @@ public final class TaskThreads {
         if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && stopOnRoot) {
           WebDebugger dbg = SomLanguage.getVM(target.getRootNode()).getWebDebugger();
           dbg.prepareSteppingUntilNextRootNode();
-          ForkJoinThread thread = (ForkJoinThread) Thread.currentThread();
-          thread.task = this;
         }
+
+        ForkJoinThread thread = (ForkJoinThread) Thread.currentThread();
+        thread.task = this;
         return target.call(argArray);
       } finally {
         ObjectTransitionSafepoint.INSTANCE.unregister();
       }
     }
+  }
+
+  public static class SomForkJoinTask extends SomTaskOrThread {
+    private static final long serialVersionUID = -2145613708553535622L;
+
+    public SomForkJoinTask(final Object[] argArray, final boolean stopOnRoot) {
+      super(argArray, stopOnRoot);
+    }
+
+    @Override
+    public String getName() {
+      return getMethod().toString();
+    }
+
+    @Override
+    public ActivityType getType() { return ActivityType.TASK; }
   }
 
   public static class TracedForkJoinTask extends SomForkJoinTask {
@@ -82,7 +91,7 @@ public final class TaskThreads {
     public TracedForkJoinTask(final Object[] argArray, final boolean stopOnRoot) {
       super(argArray, stopOnRoot);
       if (Thread.currentThread() instanceof TracingActivityThread) {
-        TracingActivityThread t = (TracingActivityThread) Thread.currentThread();
+        TracingActivityThread t = TracingActivityThread.currentThread();
         this.id = t.generateActivityId();
       } else {
         this.id = 0; // main actor
@@ -95,7 +104,52 @@ public final class TaskThreads {
     }
   }
 
-  public static final class ForkJoinThreadFactor implements ForkJoinWorkerThreadFactory {
+  public static class SomThreadTask extends SomTaskOrThread {
+    private static final long serialVersionUID = -8700297704150992350L;
+
+    private String name;
+
+    public SomThreadTask(final Object[] argArray, final boolean stopOnRoot) {
+      super(argArray, stopOnRoot);
+      name = "Thread(" + getMethod().getSignature().getString() + ")";
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    @Override
+    public ActivityType getType() { return ActivityType.THREAD; }
+  }
+
+  public static class TracedThreadTask extends SomThreadTask {
+
+    private static final long serialVersionUID = -7527703048413603761L;
+
+    private final long id;
+
+    public TracedThreadTask(final Object[] argArray, final boolean stopOnRoot) {
+      super(argArray, stopOnRoot);
+      if (Thread.currentThread() instanceof TracingActivityThread) {
+        TracingActivityThread t = TracingActivityThread.currentThread();
+        this.id = t.generateActivityId();
+      } else {
+        this.id = 0; // main actor
+      }
+    }
+
+    @Override
+    public long getId() {
+      return id;
+    }
+  }
+
+  public static final class ForkJoinThreadFactory implements ForkJoinWorkerThreadFactory {
     @Override
     public ForkJoinWorkerThread newThread(final ForkJoinPool pool) {
       return new ForkJoinThread(pool);
@@ -103,7 +157,7 @@ public final class TaskThreads {
   }
 
   private static final class ForkJoinThread extends TracingActivityThread {
-    private SomForkJoinTask task;
+    private SomTaskOrThread task;
 
     protected ForkJoinThread(final ForkJoinPool pool) {
       super(pool);
@@ -111,7 +165,7 @@ public final class TaskThreads {
 
     @Override
     public long getCurrentMessageId() {
-      return 0;
+      return -1;
     }
 
     @Override

--- a/src/som/vm/ActivityThread.java
+++ b/src/som/vm/ActivityThread.java
@@ -2,6 +2,8 @@ package som.vm;
 
 import tools.debugger.SteppingStrategy;
 
+
+// TODO: think this is not needed anymore and can be removed
 public interface ActivityThread {
   Activity getActivity();
   SteppingStrategy getSteppingStrategy();

--- a/src/tools/TraceData.java
+++ b/src/tools/TraceData.java
@@ -19,7 +19,8 @@ public class TraceData {
 
   public static final byte TASK_SPAWN         = 13;
   public static final byte TASK_JOIN          = 14;
-  public static final byte THREAD             = 15;
+  public static final byte THREAD_SPAWN       = 15;
+  public static final byte THREAD_JOIN        = 16;
   public static final byte IMPL_THREAD        = 21;
 
   // Note, the following constants are manually defined, based on the assumption

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -161,7 +161,7 @@ public class ActorExecutionTrace {
   }
 
   @TruffleBoundary
-  static synchronized ByteBuffer getEmptyBuffer() {
+  public static synchronized ByteBuffer getEmptyBuffer() {
     try {
       return emptyBuffers.take();
     } catch (InterruptedException e) {
@@ -233,6 +233,9 @@ public class ActorExecutionTrace {
 
     TaskSpawn(TraceData.TASK_SPAWN, 19),
     TaskJoin(TraceData.TASK_JOIN,   11),
+
+    ThreadSpawn(TraceData.THREAD_SPAWN, 19),
+    ThreadJoin(TraceData.THREAD_JOIN,   11),
 
     PromiseError(TraceData.PROMISE_ERROR, 28),
 
@@ -307,6 +310,13 @@ public class ActorExecutionTrace {
     SourceSection s = getPrimitiveCaller(section);
     TracingActivityThread t = getThread();
     t.getBuffer().recordTaskSpawn(method, activityId, t.getCurrentMessageId(), s);
+  }
+
+  public static void threadSpawn(final SInvokable method, final long activityId,
+      final SourceSection section) {
+    SourceSection s = getPrimitiveCaller(section);
+    TracingActivityThread t = getThread();
+    t.getBuffer().recordThreadSpawn(method, activityId, t.getCurrentMessageId(), s);
   }
 
   public static void taskJoin(final SInvokable method, final long activityId) {

--- a/src/tools/concurrency/TraceBuffer.java
+++ b/src/tools/concurrency/TraceBuffer.java
@@ -44,14 +44,14 @@ public class TraceBuffer {
 
   protected TraceBuffer() { }
 
-  void init(final ByteBuffer storage, final long threadId) {
+  public void init(final ByteBuffer storage, final long threadId) {
     this.storage = storage;
     this.threadId = threadId;
     assert storage.order() == ByteOrder.BIG_ENDIAN;
     recordThreadId();
   }
 
-  void returnBuffer() {
+  public void returnBuffer() {
     ActorExecutionTrace.returnBuffer(storage);
     storage = null;
   }
@@ -196,6 +196,12 @@ public class TraceBuffer {
   public void recordTaskSpawn(final SInvokable method, final long activityId,
       final long causalMessageId, final SourceSection section) {
     recordActivityCreation(Events.TaskSpawn, activityId, causalMessageId,
+        method.getSignature().getSymbolId(), section);
+  }
+
+  public void recordThreadSpawn(final SInvokable method, final long activityId,
+      final long causalMessageId, final SourceSection section) {
+    recordActivityCreation(Events.ThreadSpawn, activityId, causalMessageId,
         method.getSignature().getSymbolId(), section);
   }
 

--- a/src/tools/concurrency/TracingActivityThread.java
+++ b/src/tools/concurrency/TracingActivityThread.java
@@ -13,7 +13,7 @@ import tools.debugger.SteppingStrategy;
 
 public abstract class TracingActivityThread extends ForkJoinWorkerThread
     implements ActivityThread {
-  private static AtomicInteger threadIdGen = new AtomicInteger(1);
+  public static AtomicInteger threadIdGen = new AtomicInteger(1);
   protected final long threadId;
   protected long nextActivityId = 1;
   protected long nextMessageId;

--- a/src/tools/debugger/SteppingStrategy.java
+++ b/src/tools/debugger/SteppingStrategy.java
@@ -13,6 +13,7 @@ public abstract class SteppingStrategy {
   /** Return true if the spawned activity should stop on its root node. */
   public boolean handleSpawn() { return false; }
   public boolean handleChannelMessage() { return false; }
+  public boolean handleTx() { return false; }
 
   public void handleResumeExecution(final Activity activity) { }
 
@@ -41,6 +42,15 @@ public abstract class SteppingStrategy {
       if (consumed) { return; } else { consumed = true; }
 
       activity.setStepToJoin(true);
+    }
+  }
+
+  public static final class ToNextTransaction extends SteppingStrategy {
+    @Override
+    public boolean handleTx() {
+      if (consumed) { return false; } else { consumed = true; }
+
+      return true;
     }
   }
 }

--- a/src/tools/debugger/SteppingStrategy.java
+++ b/src/tools/debugger/SteppingStrategy.java
@@ -14,6 +14,8 @@ public abstract class SteppingStrategy {
   public boolean handleSpawn() { return false; }
   public boolean handleChannelMessage() { return false; }
   public boolean handleTx() { return false; }
+  public boolean handleTxCommit() { return false; }
+  public boolean handleTxAfterCommit() { return false; }
 
   public void handleResumeExecution(final Activity activity) { }
 
@@ -48,6 +50,24 @@ public abstract class SteppingStrategy {
   public static final class ToNextTransaction extends SteppingStrategy {
     @Override
     public boolean handleTx() {
+      if (consumed) { return false; } else { consumed = true; }
+
+      return true;
+    }
+  }
+
+  public static final class ToNextCommit extends SteppingStrategy {
+    @Override
+    public boolean handleTxCommit() {
+      if (consumed) { return false; } else { consumed = true; }
+
+      return true;
+    }
+  }
+
+  public static final class AfterCommit extends SteppingStrategy {
+    @Override
+    public boolean handleTxAfterCommit() {
       if (consumed) { return false; } else { consumed = true; }
 
       return true;

--- a/src/tools/debugger/WebDebugger.java
+++ b/src/tools/debugger/WebDebugger.java
@@ -22,9 +22,9 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.vm.Activity;
-import som.vm.ActivityThread;
 import tools.SourceCoordinate;
 import tools.TraceData;
+import tools.concurrency.TracingActivityThread;
 import tools.debugger.frontend.Suspension;
 import tools.debugger.message.InitializationResponse;
 import tools.debugger.message.InitializeConnection;
@@ -106,7 +106,7 @@ public class WebDebugger extends TruffleInstrument implements SuspendedCallback 
   }
 
   private synchronized Suspension getSuspension(final Activity activity,
-      final ActivityThread activityThread) {
+      final TracingActivityThread activityThread) {
     Suspension suspension = activityToSuspension.get(activity);
     if (suspension == null) {
       long id = activity.getId();
@@ -123,9 +123,9 @@ public class WebDebugger extends TruffleInstrument implements SuspendedCallback 
   private Suspension getSuspension() {
     Thread thread = Thread.currentThread();
     Activity current;
-    ActivityThread activityThread;
-    if (thread instanceof ActivityThread) {
-      activityThread = (ActivityThread) thread;
+    TracingActivityThread activityThread;
+    if (thread instanceof TracingActivityThread) {
+      activityThread = (TracingActivityThread) thread;
       current = activityThread.getActivity();
     } else {
       throw new RuntimeException("Support for " + thread.getClass().getName() + " not yet implemented.");

--- a/src/tools/debugger/entities/EntityType.java
+++ b/src/tools/debugger/entities/EntityType.java
@@ -36,4 +36,14 @@ public enum EntityType {
     this.creation   = (byte) creation;
     this.completion = (byte) completion;
   }
+
+  public static byte[] getIds(final EntityType[] entities) {
+    if (entities == null) { return null; }
+
+    byte[] entityIds = new byte[entities.length];
+    for (int i = 0; i < entities.length; i += 1) {
+      entityIds[i] = entities[i].id;
+    }
+    return entityIds;
+  }
 }

--- a/src/tools/debugger/entities/EntityType.java
+++ b/src/tools/debugger/entities/EntityType.java
@@ -10,7 +10,7 @@ public enum EntityType {
   PROMISE("promise", 5, TraceData.PROMISE_CREATION, 10),
   TURN("turn",       6, 11, 12),
   TASK("task",       7, TraceData.TASK_SPAWN, TraceData.TASK_JOIN),
-  THREAD("thread",   8, TraceData.THREAD, 16),
+  THREAD("thread",   8, TraceData.THREAD_SPAWN, TraceData.THREAD_JOIN),
   LOCK("lock",       9, 17, 18),
   TRANSACTION("transaction", 10, 19, 20),
 

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -7,9 +7,11 @@ import tools.concurrency.Tags;
 import tools.concurrency.Tags.ActivityCreation;
 import tools.concurrency.Tags.ChannelRead;
 import tools.concurrency.Tags.ChannelWrite;
+import tools.debugger.SteppingStrategy.AfterCommit;
 import tools.debugger.SteppingStrategy.IntoSpawn;
 import tools.debugger.SteppingStrategy.ReturnFromActivity;
 import tools.debugger.SteppingStrategy.ToChannelOpposite;
+import tools.debugger.SteppingStrategy.ToNextCommit;
 import tools.debugger.SteppingStrategy.ToNextTransaction;
 import tools.debugger.frontend.Suspension;
 
@@ -120,6 +122,26 @@ public enum SteppingType {
     }
   },
 
+  @SerializedName("stepToCommit")
+  STEP_TO_COMMIT("stepToCommit", "Step to Commit", Group.TX_STEPPING, "arrow-right",
+      null, null, new EntityType[] {EntityType.TRANSACTION}) {
+    @Override
+    public void process(final Suspension susp) {
+      susp.getEvent().prepareContinue();
+      susp.getActivityThread().setSteppingStrategy(new ToNextCommit());
+
+    }
+  },
+
+  @SerializedName("stepAfterCommit")
+  STEP_AFTER_COMMIT("stepAfterCommit", "Complete Transaction", Group.TX_STEPPING, "arrow-left",
+      null, null, new EntityType[] {EntityType.TRANSACTION}) {
+    @Override
+    public void process(final Suspension susp) {
+      susp.getEvent().prepareContinue();
+      susp.getActivityThread().setSteppingStrategy(new AfterCommit());
+    }
+  },
 
   STEP_TO_RECEIVER_MESSAGE("todo",   "todo", Group.ACTOR_STEPPING, "arrow-right", null) {
     @Override public void process(final Suspension susp) { }

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -10,6 +10,7 @@ import tools.concurrency.Tags.ChannelWrite;
 import tools.debugger.SteppingStrategy.IntoSpawn;
 import tools.debugger.SteppingStrategy.ReturnFromActivity;
 import tools.debugger.SteppingStrategy.ToChannelOpposite;
+import tools.debugger.SteppingStrategy.ToNextTransaction;
 import tools.debugger.frontend.Suspension;
 
 
@@ -110,6 +111,15 @@ public enum SteppingType {
     }
   },
 
+  @SerializedName("stepToNextTx")
+  STEP_TO_NEXT_TX("stepToNextTx", "Step to next Transaction", Group.ACTIVITY_STEPPING, "arrow-right", null, null) {
+    @Override
+    public void process(final Suspension susp) {
+      susp.getEvent().prepareContinue();
+      susp.getActivityThread().setSteppingStrategy(new ToNextTransaction());
+    }
+  },
+
 
   STEP_TO_RECEIVER_MESSAGE("todo",   "todo", Group.ACTOR_STEPPING, "arrow-right", null) {
     @Override public void process(final Suspension susp) { }
@@ -123,7 +133,8 @@ public enum SteppingType {
     LOCAL_STEPPING("Local Stepping"),
     ACTIVITY_STEPPING("Activity Stepping"),
     ACTOR_STEPPING("Actor Stepping"),
-    PROCESS_STEPPING("Process Stepping");
+    PROCESS_STEPPING("Process Stepping"),
+    TX_STEPPING("Transaction Stepping");
 
     public final String label;
 

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -156,19 +156,29 @@ public enum SteppingType {
       If no tags are given, it is assumed the operation is always valid. */
   public final Class<? extends Tags>[] applicableTo;
 
+  /** Stepping operation is only available when in the dynamic scope of the given entity.
+      If no entity types are given, it is assumed the operation is always valid. */
+  public final EntityType[] inScope;
+
   SteppingType(final String name, final String label, final Group group, final String icon,
       final Class<? extends Tags>[] applicableTo) {
-    this(name, label, group, icon, applicableTo, null);
+    this(name, label, group, icon, applicableTo, null, null);
   }
 
   SteppingType(final String name, final String label, final Group group, final String icon,
       final Class<? extends Tags>[] applicableTo, final ActivityType[] forActivities) {
+    this(name, label, group, icon, applicableTo, forActivities, null);
+  }
+
+  SteppingType(final String name, final String label, final Group group, final String icon,
+      final Class<? extends Tags>[] applicableTo, final ActivityType[] forActivities, final EntityType[] inScope) {
     this.name  = name;
     this.label = label;
     this.group = group;
     this.icon  = icon;
     this.applicableTo  = applicableTo;
     this.forActivities = forActivities;
+    this.inScope = inScope;
   }
 
   public abstract void process(Suspension susp);

--- a/src/tools/debugger/frontend/Suspension.java
+++ b/src/tools/debugger/frontend/Suspension.java
@@ -14,6 +14,7 @@ import som.primitives.ObjectPrims.HaltPrim;
 import som.vm.Activity;
 import som.vm.ActivityThread;
 import tools.TraceData;
+import tools.concurrency.TracingActivityThread;
 import tools.debugger.FrontendConnector;
 import tools.debugger.SteppingStrategy;
 import tools.debugger.entities.EntityType;
@@ -32,13 +33,13 @@ import tools.debugger.frontend.ApplicationThreadTask.SendStackTrace;
 public class Suspension {
   public final long activityId;
   private final Activity activity;
-  private final ActivityThread activityThread;
+  private final TracingActivityThread activityThread;
   private final ArrayBlockingQueue<ApplicationThreadTask> tasks;
 
   private SuspendedEvent suspendedEvent;
   private ApplicationThreadStack stack;
 
-  public Suspension(final ActivityThread activityThread,
+  public Suspension(final TracingActivityThread activityThread,
       final Activity activity, final long activityId) {
     this.activityThread = activityThread;
     this.activity   = activity;

--- a/src/tools/debugger/frontend/Suspension.java
+++ b/src/tools/debugger/frontend/Suspension.java
@@ -16,6 +16,7 @@ import som.vm.ActivityThread;
 import tools.TraceData;
 import tools.debugger.FrontendConnector;
 import tools.debugger.SteppingStrategy;
+import tools.debugger.entities.EntityType;
 import tools.debugger.frontend.ApplicationThreadTask.Resume;
 import tools.debugger.frontend.ApplicationThreadTask.SendStackTrace;
 
@@ -52,6 +53,10 @@ public class Suspension {
 
   public synchronized ArrayList<DebugStackFrame> getStackFrames() {
     return stack.get();
+  }
+
+  public EntityType[] getCurrentEntityScopes() {
+    return activityThread.getConcurrentEntityScopes();
   }
 
   public synchronized long addScope(final MaterializedFrame frame,

--- a/src/tools/debugger/message/InitializationResponse.java
+++ b/src/tools/debugger/message/InitializationResponse.java
@@ -65,6 +65,7 @@ public final class InitializationResponse extends OutgoingMessage {
     private final String icon;
     private final String[] applicableTo;
     private final byte[] forActivities;
+    private final byte[] inScope;
 
     private SteppingData(final SteppingType type) {
       this.name = type.name;
@@ -72,6 +73,7 @@ public final class InitializationResponse extends OutgoingMessage {
       this.group = type.group.label;
       this.icon  = type.icon;
       this.applicableTo = tagsToStrings(type.applicableTo);
+      this.inScope = EntityType.getIds(type.inScope);
 
       if (type.forActivities != null) {
         this.forActivities = new byte[type.forActivities.length];

--- a/tools/kompos/src/messages.ts
+++ b/tools/kompos/src/messages.ts
@@ -164,6 +164,7 @@ export interface SteppingType {
   icon:  string;    /** Id of an icon known by the frontend. */
   applicableTo?: string[];  /** The source section tags this stepping operation applies to. If empty, it applies unconditionally. */
   forActivities?: ActivityType[]; /** Ids of the activities this stepping operation applies to. If empty, it applies unconditionally. */
+  inScope: EntityType[]; /** Ids of the entities, which need to be in dynamic scope so this stepping type applies. If empty, it applies unconditionally. */
 }
 
 export interface EntityDef {
@@ -256,6 +257,7 @@ export interface StackTraceResponse {
   stackFrames: StackFrame[];
   totalFrames: number;
   requestId:   number;
+  concurrentEntityScopes?: EntityType[];
 }
 
 export interface ScopesRequest {


### PR DESCRIPTION
- add transaction stepping
  - next transaction
  - step to commit
  - step after commit

Add the notion of dynamic concurrent entity scope for stepping buttons.
This allows us to enable buttons for transactions or under held locks only.
Similar to the 'current activity' notion, but as a stack of dynamic activations.

Turn threads also into tasks on a fork/join pool to have a uniform representation and simplify tracing and debugging infrastructure.