### PR TITLE
Improve stepping, and code consistency

### DIFF
--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -145,9 +145,6 @@ public class Actor implements Activity {
   }
 
   @Override
-  public long getId() { return 0; }
-
-  @Override
   public void setStepToJoin(final boolean val) {
     throw new UnsupportedOperationException(
         "Return from activity, and step to join are not supported " +

--- a/src/som/primitives/ActivityJoin.java
+++ b/src/som/primitives/ActivityJoin.java
@@ -26,7 +26,7 @@ public class ActivityJoin {
     public JoinPrim(final boolean ew, final SourceSection s) {
       super(ew, s);
       if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
-        haltNode = insert(SuspendExecutionNodeGen.create(false, s, 2, null));
+        haltNode = insert(SuspendExecutionNodeGen.create(false, s, 0, null));
         VM.insertInstrumentationWrapper(haltNode);
       } else {
         haltNode = null;

--- a/src/som/primitives/ActivitySpawn.java
+++ b/src/som/primitives/ActivitySpawn.java
@@ -76,7 +76,7 @@ public abstract class ActivitySpawn {
       ActorExecutionTrace.processCreation(result, origin);
       return result;
     } else {
-      return new Process(obj, stopOnRoot);
+      return new Process(obj);
     }
   }
 

--- a/src/som/primitives/processes/ChannelPrimitives.java
+++ b/src/som/primitives/processes/ChannelPrimitives.java
@@ -80,7 +80,7 @@ public abstract class ChannelPrimitives {
 
     @Override
     public long getCurrentMessageId() {
-      return -1;
+      return 0;
     }
   }
 

--- a/src/som/primitives/threading/TaskThreads.java
+++ b/src/som/primitives/threading/TaskThreads.java
@@ -165,7 +165,7 @@ public final class TaskThreads {
 
     @Override
     public long getCurrentMessageId() {
-      return -1;
+      return 0;
     }
 
     @Override

--- a/src/som/primitives/threading/TaskThreads.java
+++ b/src/som/primitives/threading/TaskThreads.java
@@ -24,7 +24,6 @@ public final class TaskThreads {
 
     protected final Object[] argArray;
     protected final boolean stopOnRoot;
-    protected boolean stopOnJoin;
 
     public SomTaskOrThread(final Object[] argArray, final boolean stopOnRoot) {
       this.argArray   = argArray;
@@ -36,17 +35,7 @@ public final class TaskThreads {
       return ((SBlock) argArray[0]).getMethod();
     }
 
-    public final boolean stopOnJoin() {
-      return stopOnJoin;
-    }
-
-    @Override
-    public long getId() {
-      return 0;
-    }
-
-    @Override
-    public void setStepToJoin(final boolean val) { stopOnJoin = val; }
+    public boolean stopOnJoin() { return false; }
 
     @Override
     protected final Object compute() {
@@ -87,6 +76,7 @@ public final class TaskThreads {
     private static final long serialVersionUID = -2763766745049695112L;
 
     private final long id;
+    protected boolean stopOnJoin;
 
     public TracedForkJoinTask(final Object[] argArray, final boolean stopOnRoot) {
       super(argArray, stopOnRoot);
@@ -97,6 +87,14 @@ public final class TaskThreads {
         this.id = 0; // main actor
       }
     }
+
+    @Override
+    public final boolean stopOnJoin() {
+      return stopOnJoin;
+    }
+
+    @Override
+    public void setStepToJoin(final boolean val) { stopOnJoin = val; }
 
     @Override
     public long getId() {
@@ -132,6 +130,7 @@ public final class TaskThreads {
     private static final long serialVersionUID = -7527703048413603761L;
 
     private final long id;
+    protected boolean stopOnJoin;
 
     public TracedThreadTask(final Object[] argArray, final boolean stopOnRoot) {
       super(argArray, stopOnRoot);
@@ -142,6 +141,14 @@ public final class TaskThreads {
         this.id = 0; // main actor
       }
     }
+
+    @Override
+    public final boolean stopOnJoin() {
+      return stopOnJoin;
+    }
+
+    @Override
+    public void setStepToJoin(final boolean val) { stopOnJoin = val; }
 
     @Override
     public long getId() {

--- a/src/som/vm/Activity.java
+++ b/src/som/vm/Activity.java
@@ -4,8 +4,14 @@ import tools.debugger.entities.ActivityType;
 
 public interface Activity {
   String getName();
-  long getId();
+
+  /** The activity id.
+      For non-tracing activities, the id is 0. */
+  default long getId() { return 0; }
+
   ActivityType getType();
 
-  void setStepToJoin(boolean val);
+  /** Set the flag that indicates a breakpoint on joining activity.
+      Does nothing for non-tracing activities, i.e., when debugging is disabled. */
+  default void setStepToJoin(final boolean val) { }
 }

--- a/src/tools/concurrency/TracingActivityThread.java
+++ b/src/tools/concurrency/TracingActivityThread.java
@@ -99,6 +99,7 @@ public abstract class TracingActivityThread extends ForkJoinWorkerThread
     long result = nextActivityId;
     nextActivityId++;
     assert TraceData.isWithinJSIntValueRange(result);
+    assert result != -1 : "-1 is not a valid activity id";
     return result;
   }
 


### PR DESCRIPTION
- message ids shouldn't be -1, causes problems with the frontend
- fix `#join` operations skipping top two stack frames, was a copy'n'paste mistake
- refactor debugging related code to be in the `Tracing*` activities
- use default methods on `Activity` interface for code reuse