### PR TITLE
Add missing @TruffleBoundaries for SubstrateVM

### DIFF
--- a/src/som/VM.java
+++ b/src/som/VM.java
@@ -103,12 +103,14 @@ public final class VM {
 
   private final Map<String, Object> exports = new HashMap<>();
 
+  @TruffleBoundary
   public boolean registerExport(final String name, final Object value) {
     boolean wasExportedAlready = exports.containsKey(name);
     exports.put(name, value);
     return wasExportedAlready;
   }
 
+  @TruffleBoundary
   public Object getExport(final String name) {
     return exports.get(name);
   }
@@ -244,6 +246,7 @@ public final class VM {
    * Does minimal cleanup and disposes the polyglot engine, before doing a hard
    * exit. This method is expected to be called from main thread.
    */
+  @TruffleBoundary
   public void shutdownAndExit(final int errorCode) {
     if (truffleProfiler != null) {
       truffleProfiler.printHistograms(System.err);

--- a/src/som/interpreter/Invokable.java
+++ b/src/som/interpreter/Invokable.java
@@ -47,7 +47,7 @@ public abstract class Invokable extends RootNode {
   }
 
   @Override
-  public Object execute(final VirtualFrame frame) {
+  public final Object execute(final VirtualFrame frame) {
     return expressionOrSequence.executeGeneric(frame);
   }
 

--- a/src/som/interpreter/Method.java
+++ b/src/som/interpreter/Method.java
@@ -21,6 +21,7 @@
  */
 package som.interpreter;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.nodes.LoopNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeUtil;
@@ -121,6 +122,7 @@ public final class Method extends Invokable {
   }
 
   @Override
+  @TruffleBoundary
   public Invokable createAtomic() {
     assert !isAtomic : "We should only ask non-atomic invokables for their atomic version";
 

--- a/src/som/interpreter/SomException.java
+++ b/src/som/interpreter/SomException.java
@@ -1,37 +1,21 @@
 package som.interpreter;
 
+import com.oracle.truffle.api.nodes.ControlFlowException;
+
 import som.vmobjects.SAbstractObject;
 
 
-public final class SomException extends RuntimeException {
+public final class SomException extends ControlFlowException {
 
   private static final long serialVersionUID = -639789248178270606L;
   private final SAbstractObject somObj;
 
   public SomException(final SAbstractObject somObj) {
-      /*
-       * We use the super constructor that initializes the cause to null.
-       * Without that, the cause would be this exception itself. This helps
-       * escape analysis: it avoids the circle of an object pointing to itself.
-       */
-      super((Throwable) null);
       this.somObj = somObj;
   }
 
   public SAbstractObject getSomObject() {
     return somObj;
-  }
-
-  /**
-   * For performance reasons, this exception does not record any stack trace
-   * information.
-   *
-   * TODO: at some point, fill in a SOMns stack...
-   */
-  @SuppressWarnings("sync-override")
-  @Override
-  public Throwable fillInStackTrace() {
-      return null;
   }
 
   @Override

--- a/src/som/interpreter/nodes/dispatch/ForeignDispatchNode.java
+++ b/src/som/interpreter/nodes/dispatch/ForeignDispatchNode.java
@@ -1,5 +1,6 @@
 package som.interpreter.nodes.dispatch;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.ForeignAccess;
 import com.oracle.truffle.api.interop.Message;
@@ -37,6 +38,8 @@ public final class ForeignDispatchNode extends AbstractDispatchNode {
   }
 
   @Override
+  @TruffleBoundary
+  // TODO: needs to be optimized for compilation
   public Object executeDispatch(final Object[] arguments) {
     VM.thisMethodNeedsToBeOptimized("");
     Object rcvr = arguments[0];

--- a/src/som/interpreter/processes/SChannel.java
+++ b/src/som/interpreter/processes/SChannel.java
@@ -2,6 +2,8 @@ package som.interpreter.processes;
 
 import java.util.concurrent.SynchronousQueue;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+
 import som.primitives.processes.ChannelPrimitives;
 import som.vm.VmSettings;
 import som.vmobjects.SAbstractObject;
@@ -74,6 +76,7 @@ public class SChannel extends SAbstractObject {
       this.channel = channel;
     }
 
+    @TruffleBoundary
     public Object read() throws InterruptedException {
       return cell.take();
     }
@@ -117,6 +120,7 @@ public class SChannel extends SAbstractObject {
       this.channel = channel;
     }
 
+    @TruffleBoundary
     public void write(final Object value) throws InterruptedException {
       cell.put(value);
     }

--- a/src/som/interpreter/transactions/Transactions.java
+++ b/src/som/interpreter/transactions/Transactions.java
@@ -106,7 +106,6 @@ public final class Transactions {
     }
   }
 
-
   private void start() {
     objects = new IdentityHashMap<>();
     arrays  = new IdentityHashMap<>();
@@ -138,6 +137,7 @@ public final class Transactions {
         }
       };
 
+  @TruffleBoundary
   public static Transactions startTransaction() {
     Transactions t = transactions.get();
     t.start();
@@ -147,6 +147,7 @@ public final class Transactions {
   /**
    * @return true on success, otherwise false.
    */
+  @TruffleBoundary
   public boolean commit() {
     synchronized (globalCommitLock) {
       if (hasConflicts()) {

--- a/src/som/primitives/ActivitySpawn.java
+++ b/src/som/primitives/ActivitySpawn.java
@@ -119,6 +119,7 @@ public abstract class ActivitySpawn {
     }
 
     @Specialization(guards = "clazz == ThreadClass")
+    @TruffleBoundary
     public final SomThreadTask spawnThread(final SClass clazz, final SBlock block) {
       SomThreadTask thread = createThread(new Object[] {block},
           onExec.executeShouldHalt(), block, sourceSection);
@@ -183,6 +184,7 @@ public abstract class ActivitySpawn {
     }
 
     @Specialization(guards = "clazz == TaskClass")
+    @TruffleBoundary
     public SomForkJoinTask spawnTask(final SClass clazz, final SBlock block,
         final SArray somArgArr, final Object[] argArr) {
       SomForkJoinTask task = createTask(argArr,
@@ -192,6 +194,7 @@ public abstract class ActivitySpawn {
     }
 
     @Specialization(guards = "clazz == ThreadClass")
+    @TruffleBoundary
     public SomThreadTask spawnThread(final SClass clazz, final SBlock block,
         final SArray somArgArr, final Object[] argArr) {
       SomThreadTask thread = createThread(argArr,

--- a/src/som/primitives/EqualsPrim.java
+++ b/src/som/primitives/EqualsPrim.java
@@ -2,6 +2,7 @@ package som.primitives;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -36,6 +37,7 @@ public abstract class EqualsPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) == 0;
   }
@@ -79,11 +81,13 @@ public abstract class EqualsPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final double right) {
     // TODO: this needs to be properly specified, I don't really know what's
     //       the most useful semantics, but this comes 'close', I hope
@@ -91,6 +95,7 @@ public abstract class EqualsPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doDouble(final double left, final BigInteger right) {
     // TODO: this needs to be properly specified, I don't really know what's
     //       the most useful semantics, but this comes 'close', I hope
@@ -98,6 +103,7 @@ public abstract class EqualsPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }

--- a/src/som/primitives/HashPrim.java
+++ b/src/som/primitives/HashPrim.java
@@ -29,6 +29,7 @@ public abstract class HashPrim extends UnaryExpressionNode {
   }
 
   @Specialization
+  @TruffleBoundary
   public final long doSAbstractObject(final SAbstractObject receiver) {
     return receiver.hashCode();
   }

--- a/src/som/primitives/IntegerPrims.java
+++ b/src/som/primitives/IntegerPrims.java
@@ -2,6 +2,7 @@ package som.primitives;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.profiles.BranchProfile;
@@ -109,6 +110,7 @@ public abstract class IntegerPrims {
     }
 
     @Specialization
+    @TruffleBoundary
     public final Number doLongWithOverflow(final long receiver, final long right) {
       assert right >= 0;  // currently not defined for negative values of right
       assert right <= Integer.MAX_VALUE;

--- a/src/som/primitives/MirrorPrims.java
+++ b/src/som/primitives/MirrorPrims.java
@@ -3,6 +3,7 @@ package som.primitives;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -36,6 +37,7 @@ public abstract class MirrorPrims {
     public NestedClassesPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
+    @TruffleBoundary
     public final SMutableArray getNestedClasses(final SObjectWithClass rcvr) {
       SClass[] classes = rcvr.getSOMClass().getNestedClasses(rcvr);
       return new SMutableArray(classes, Classes.arrayClass);
@@ -48,6 +50,7 @@ public abstract class MirrorPrims {
     protected RespondsToPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
+    @TruffleBoundary
     public final boolean objectResondsTo(final Object rcvr, final SSymbol selector) {
       VM.thisMethodNeedsToBeOptimized("Uses Types.getClassOf, so, should be specialized in performance cirtical code");
       return Types.getClassOf(rcvr).canUnderstand(selector);
@@ -60,6 +63,7 @@ public abstract class MirrorPrims {
     public MethodsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
+    @TruffleBoundary
     public final SImmutableArray getMethod(final Object rcvr) {
       VM.thisMethodNeedsToBeOptimized("Uses Types.getClassOf, so, should be specialized in performance cirtical code");
       SInvokable[] is = Types.getClassOf(rcvr).getMethods();
@@ -122,6 +126,7 @@ public abstract class MirrorPrims {
     public NestedClassDefinitionsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
+    @TruffleBoundary
     public final Object getClassDefinition(final Object mixinHandle) {
       assert mixinHandle instanceof MixinDefinition;
       MixinDefinition def = (MixinDefinition) mixinHandle;
@@ -149,6 +154,7 @@ public abstract class MirrorPrims {
     public ClassDefMethodsPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
+    @TruffleBoundary
     public final SImmutableArray getName(final Object mixinHandle) {
       assert mixinHandle instanceof MixinDefinition;
       MixinDefinition def = (MixinDefinition) mixinHandle;
@@ -170,6 +176,7 @@ public abstract class MirrorPrims {
     protected ClassDefHasFactoryMethodPrim(final boolean eagWrap, final SourceSection source) { super(eagWrap, source); }
 
     @Specialization
+    @TruffleBoundary
     public final boolean hasFactoryMethod(final Object mixinHandle,
         final SSymbol selector) {
       assert mixinHandle instanceof MixinDefinition;

--- a/src/som/primitives/StringPrims.java
+++ b/src/som/primitives/StringPrims.java
@@ -1,5 +1,6 @@
 package som.primitives;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.profiles.BranchProfile;
@@ -33,21 +34,25 @@ public class StringPrims {
     }
 
     @Specialization
+    @TruffleBoundary
     public final String doString(final String receiver, final String argument) {
       return receiver + argument;
     }
 
     @Specialization
+    @TruffleBoundary
     public final String doString(final String receiver, final SSymbol argument) {
       return receiver + argument.getString();
     }
 
     @Specialization
+    @TruffleBoundary
     public final String doSSymbol(final SSymbol receiver, final String argument) {
       return receiver.getString() + argument;
     }
 
     @Specialization
+    @TruffleBoundary
     public final String doSSymbol(final SSymbol receiver, final SSymbol argument) {
       return receiver.getString() + argument.getString();
     }

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -107,6 +107,7 @@ public final class SystemPrims {
     public ExitPrim(final boolean eagWrap, final SourceSection source, final VM vm) { super(eagWrap, source); this.vm = vm; }
 
     @Specialization
+    @TruffleBoundary
     public final Object doSObject(final long error) {
       vm.requestExit((int) error);
       return Nil.nilObject;

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
@@ -78,6 +79,7 @@ public final class SystemPrims {
     protected LoadPrim(final boolean eagWrap, final SourceSection source, final VM vm) { super(eagWrap, source); this.vm = vm; }
 
     @Specialization
+    @TruffleBoundary
     public final Object doSObject(final String moduleName) {
       return loadModule(vm, moduleName);
     }
@@ -90,6 +92,7 @@ public final class SystemPrims {
     protected LoadNextToPrim(final boolean eagWrap, final SourceSection source, final VM vm) { super(eagWrap, source); this.vm = vm; }
 
     @Specialization
+    @TruffleBoundary
     public final Object load(final String filename, final SObjectWithClass moduleObj) {
       String path = moduleObj.getSOMClass().getMixinDefinition().getSourceSection().getSource().getPath();
       File file = new File(path);
@@ -150,6 +153,7 @@ public final class SystemPrims {
       return receiver;
     }
 
+    @TruffleBoundary
     public static void printStackTrace(final int skipDnuFrames, final SourceSection topNode) {
       ArrayList<String> method   = new ArrayList<String>();
       ArrayList<String> location = new ArrayList<String>();

--- a/src/som/primitives/TimerPrim.java
+++ b/src/som/primitives/TimerPrim.java
@@ -5,9 +5,9 @@ import java.util.TimerTask;
 import java.util.concurrent.ForkJoinPool;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
@@ -34,7 +34,8 @@ public abstract class TimerPrim extends BinaryComplexOperation{
   @Child protected WrapReferenceNode wrapper = WrapReferenceNodeGen.create();
 
   @Specialization
-  public final Object doResolveAfter(final VirtualFrame frame, final SResolver resolver, final long timeout) {
+  @TruffleBoundary
+  public final Object doResolveAfter(final SResolver resolver, final long timeout) {
     if (timer == null) {
       timer = new Timer();
     }

--- a/src/som/primitives/UnequalsPrim.java
+++ b/src/som/primitives/UnequalsPrim.java
@@ -2,6 +2,7 @@ package som.primitives;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -29,6 +30,7 @@ public abstract class UnequalsPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) != 0;
   }
@@ -59,11 +61,13 @@ public abstract class UnequalsPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }

--- a/src/som/primitives/arithmetic/AdditionPrim.java
+++ b/src/som/primitives/arithmetic/AdditionPrim.java
@@ -26,11 +26,13 @@ public abstract class AdditionPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final BigInteger doLongWithOverflow(final long left, final long argument) {
     return BigInteger.valueOf(left).add(BigInteger.valueOf(argument));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final BigInteger right) {
     BigInteger result = left.add(right);
     return reduceToLongIfPossible(result);
@@ -60,6 +62,7 @@ public abstract class AdditionPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLong(final long left, final BigInteger argument) {
     return doBigInteger(BigInteger.valueOf(left), argument);
   }
@@ -70,6 +73,7 @@ public abstract class AdditionPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }

--- a/src/som/primitives/arithmetic/ArithmeticPrim.java
+++ b/src/som/primitives/arithmetic/ArithmeticPrim.java
@@ -2,6 +2,7 @@ package som.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.BinaryBasicOperation;
@@ -20,6 +21,7 @@ public abstract class ArithmeticPrim extends BinaryBasicOperation {
     }
   }
 
+  @TruffleBoundary
   protected static final Number reduceToLongIfPossible(final BigInteger result) {
     if (result.bitLength() > Long.SIZE - 1) {
       return result;

--- a/src/som/primitives/arithmetic/DividePrim.java
+++ b/src/som/primitives/arithmetic/DividePrim.java
@@ -2,6 +2,7 @@ package som.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
@@ -20,17 +21,20 @@ public abstract class DividePrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final BigInteger right) {
     BigInteger result = left.divide(right);
     return reduceToLongIfPossible(result);
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }

--- a/src/som/primitives/arithmetic/GreaterThanOrEqualPrim.java
+++ b/src/som/primitives/arithmetic/GreaterThanOrEqualPrim.java
@@ -2,6 +2,7 @@ package som.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
@@ -21,6 +22,7 @@ public abstract class GreaterThanOrEqualPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) >= 0;
   }
@@ -31,6 +33,7 @@ public abstract class GreaterThanOrEqualPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
@@ -41,6 +44,7 @@ public abstract class GreaterThanOrEqualPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }

--- a/src/som/primitives/arithmetic/GreaterThanPrim.java
+++ b/src/som/primitives/arithmetic/GreaterThanPrim.java
@@ -2,6 +2,7 @@ package som.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
@@ -21,6 +22,7 @@ public abstract class GreaterThanPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) > 0;
   }
@@ -31,6 +33,7 @@ public abstract class GreaterThanPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
@@ -41,6 +44,7 @@ public abstract class GreaterThanPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }

--- a/src/som/primitives/arithmetic/LessThanOrEqualPrim.java
+++ b/src/som/primitives/arithmetic/LessThanOrEqualPrim.java
@@ -2,6 +2,7 @@ package som.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
@@ -21,6 +22,7 @@ public abstract class LessThanOrEqualPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) <= 0;
   }
@@ -31,6 +33,7 @@ public abstract class LessThanOrEqualPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
@@ -41,6 +44,7 @@ public abstract class LessThanOrEqualPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }

--- a/src/som/primitives/arithmetic/LessThanPrim.java
+++ b/src/som/primitives/arithmetic/LessThanPrim.java
@@ -2,6 +2,7 @@ package som.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
@@ -23,6 +24,7 @@ public abstract class LessThanPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final BigInteger right) {
     return left.compareTo(right) < 0;
   }
@@ -33,6 +35,7 @@ public abstract class LessThanPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
@@ -43,6 +46,7 @@ public abstract class LessThanPrim extends ComparisonPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final boolean doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }

--- a/src/som/primitives/arithmetic/ModuloPrim.java
+++ b/src/som/primitives/arithmetic/ModuloPrim.java
@@ -2,6 +2,7 @@ package som.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
@@ -27,16 +28,19 @@ public abstract class ModuloPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final BigInteger right) {
     return reduceToLongIfPossible(left.mod(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }

--- a/src/som/primitives/arithmetic/MultiplicationPrim.java
+++ b/src/som/primitives/arithmetic/MultiplicationPrim.java
@@ -2,6 +2,7 @@ package som.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.ExactMath;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -23,11 +24,13 @@ public abstract class MultiplicationPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLongWithOverflow(final long left, final long right) {
     return BigInteger.valueOf(left).multiply(BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final BigInteger right) {
     BigInteger result = left.multiply(right);
     return reduceToLongIfPossible(result);
@@ -39,6 +42,7 @@ public abstract class MultiplicationPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
@@ -49,6 +53,7 @@ public abstract class MultiplicationPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }

--- a/src/som/primitives/arithmetic/RemainderPrim.java
+++ b/src/som/primitives/arithmetic/RemainderPrim.java
@@ -2,6 +2,7 @@ package som.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
@@ -25,16 +26,19 @@ public abstract class RemainderPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final BigInteger right) {
     return reduceToLongIfPossible(left.remainder(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }

--- a/src/som/primitives/arithmetic/SqrtPrim.java
+++ b/src/som/primitives/arithmetic/SqrtPrim.java
@@ -2,6 +2,7 @@ package som.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
@@ -33,6 +34,7 @@ public abstract class SqrtPrim extends UnaryBasicOperation {
   }
 
   @Specialization
+  @TruffleBoundary
   public final double doBigInteger(final BigInteger receiver) {
     return Math.sqrt(receiver.doubleValue());
   }

--- a/src/som/primitives/arithmetic/SubtractionPrim.java
+++ b/src/som/primitives/arithmetic/SubtractionPrim.java
@@ -2,6 +2,7 @@ package som.primitives.arithmetic;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.ExactMath;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -23,11 +24,13 @@ public abstract class SubtractionPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final BigInteger doLongWithOverflow(final long left, final long right) {
     return BigInteger.valueOf(left).subtract(BigInteger.valueOf(right));
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final BigInteger right) {
     BigInteger result = left.subtract(right);
     return reduceToLongIfPossible(result);
@@ -39,6 +42,7 @@ public abstract class SubtractionPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
@@ -49,6 +53,7 @@ public abstract class SubtractionPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }

--- a/src/som/primitives/bitops/BitAndPrim.java
+++ b/src/som/primitives/bitops/BitAndPrim.java
@@ -2,6 +2,7 @@ package som.primitives.bitops;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
@@ -21,16 +22,19 @@ public abstract class BitAndPrim extends ArithmeticPrim {
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final BigInteger right) {
     return left.and(right);
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doLong(final long left, final BigInteger right) {
     return doBigInteger(BigInteger.valueOf(left), right);
   }
 
   @Specialization
+  @TruffleBoundary
   public final Object doBigInteger(final BigInteger left, final long right) {
     return doBigInteger(left, BigInteger.valueOf(right));
   }

--- a/src/som/primitives/processes/ChannelPrimitives.java
+++ b/src/som/primitives/processes/ChannelPrimitives.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory;
 import java.util.concurrent.ForkJoinWorkerThread;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -208,6 +209,7 @@ public abstract class ChannelPrimitives {
         }
         return result;
       } catch (InterruptedException e) {
+        CompilerDirectives.transferToInterpreter();
         throw new RuntimeException(e);
       }
     }
@@ -252,6 +254,7 @@ public abstract class ChannelPrimitives {
           haltNode.executeEvaluated(frame, val);
         }
       } catch (InterruptedException e) {
+        CompilerDirectives.transferToInterpreter();
         throw new RuntimeException(e);
       }
       return val;

--- a/src/som/primitives/reflection/AbstractSymbolDispatch.java
+++ b/src/som/primitives/reflection/AbstractSymbolDispatch.java
@@ -1,5 +1,6 @@
 package som.primitives.reflection;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -82,6 +83,7 @@ public abstract class AbstractSymbolDispatch extends Node {
   }
 
   @Specialization(replaces = "doCachedWithoutArgArr", guards = "argsArr == null")
+  @TruffleBoundary
   public Object doUncached(final Object receiver, final SSymbol selector,
       final Object argsArr,
       @Cached("create()") final IndirectCallNode call) {
@@ -98,6 +100,7 @@ public abstract class AbstractSymbolDispatch extends Node {
   }
 
   @Specialization(replaces = "doCached")
+  @TruffleBoundary
   public Object doUncached(final Object receiver, final SSymbol selector,
       final SArray argsArr,
       @Cached("create()") final IndirectCallNode call,

--- a/src/som/primitives/threading/ConditionPrimitives.java
+++ b/src/som/primitives/threading/ConditionPrimitives.java
@@ -3,6 +3,7 @@ package som.primitives.threading;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
@@ -19,6 +20,7 @@ public final class ConditionPrimitives {
     public SignalOnePrim(final boolean ew, final SourceSection s) { super(ew, s); }
 
     @Specialization
+    @TruffleBoundary
     public final Condition doCondition(final Condition cond) {
       cond.signal();
       return cond;
@@ -31,6 +33,7 @@ public final class ConditionPrimitives {
     public SignalAllPrim(final boolean ew, final SourceSection s) { super(ew, s); }
 
     @Specialization
+    @TruffleBoundary
     public final Condition doCondition(final Condition cond) {
       cond.signalAll();
       return cond;
@@ -43,6 +46,7 @@ public final class ConditionPrimitives {
     public AwaitPrim(final boolean ew, final SourceSection s) { super(ew, s); }
 
     @Specialization
+    @TruffleBoundary
     public final Condition doCondition(final Condition cond) {
       try {
         cond.await();
@@ -59,6 +63,7 @@ public final class ConditionPrimitives {
     public AwaitForPrim(final boolean ew, final SourceSection s) { super(ew, s); }
 
     @Specialization
+    @TruffleBoundary
     public final boolean doCondition(final Condition cond, final long milliseconds) {
       try {
         return cond.await(milliseconds, TimeUnit.MILLISECONDS);

--- a/src/som/primitives/threading/DelayPrimitives.java
+++ b/src/som/primitives/threading/DelayPrimitives.java
@@ -1,5 +1,6 @@
 package som.primitives.threading;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
@@ -17,6 +18,7 @@ public final class DelayPrimitives {
     public WaitPrim(final boolean ew, final SourceSection s) { super(ew, s); }
 
     @Specialization
+    @TruffleBoundary
     public final SObjectWithoutFields doLong(final long milliseconds) {
       try {
         Thread.sleep(milliseconds);

--- a/src/som/primitives/threading/MutexPrimitives.java
+++ b/src/som/primitives/threading/MutexPrimitives.java
@@ -89,6 +89,7 @@ public final class MutexPrimitives {
     public IsLockedPrim(final boolean ew, final SourceSection s) { super(ew, s); }
 
     @Specialization
+    @TruffleBoundary
     public boolean doLock(final ReentrantLock lock) {
       return lock.isLocked();
     }
@@ -100,6 +101,7 @@ public final class MutexPrimitives {
     public ConditionForPrim(final boolean ew, final SourceSection s) { super(ew, s); }
 
     @Specialization
+    @TruffleBoundary
     public Condition doLock(final ReentrantLock lock) {
       return lock.newCondition();
     }
@@ -112,6 +114,7 @@ public final class MutexPrimitives {
 
     // TODO: should I guard this on the mutex class?
     @Specialization
+    @TruffleBoundary
     public final ReentrantLock doSClass(final SClass clazz) {
       return new ReentrantLock();
     }

--- a/src/som/primitives/transactions/AtomicPrim.java
+++ b/src/som/primitives/transactions/AtomicPrim.java
@@ -42,6 +42,7 @@ public abstract class AtomicPrim extends BinaryComplexOperation {
 
   @Specialization
   public final Object atomic(final VirtualFrame frame, final SClass clazz, final SBlock block) {
+    // TODO: needs to be optimized for compilation
     if (VmSettings.TRUFFLE_DEBUGGER_ENABLED &&
         SteppingType.STEP_TO_NEXT_TX.isSet()) {
       haltNode.executeEvaluated(frame, block);

--- a/src/som/vm/ObjectSystem.java
+++ b/src/som/vm/ObjectSystem.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -349,6 +350,7 @@ Classes.transferClass.getSOMClass().setClassGroup(Classes.metaclassClass.getInst
     mainThreadCompleted.complete(errorCode);
   }
 
+  @TruffleBoundary
   public void executeApplication(final SObjectWithoutFields vmMirror, final Actor mainActor) {
     mainThreadCompleted = new CompletableFuture<>();
 
@@ -398,6 +400,7 @@ Classes.transferClass.getSOMClass().setClassGroup(Classes.metaclassClass.getInst
     }
   }
 
+  @TruffleBoundary
   public Object execute(final String selector) {
     SInvokable method = (SInvokable) platformClass.getSOMClass().lookupMessage(
         Symbols.symbolFor(selector), AccessModifier.PUBLIC);

--- a/src/som/vmobjects/SClass.java
+++ b/src/som/vmobjects/SClass.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Map;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 
 import som.VM;
@@ -193,6 +194,7 @@ public final class SClass extends SObjectWithClass {
     return dispatchables.containsKey(selector);
   }
 
+  @TruffleBoundary
   public SInvokable[] getMethods() {
     ArrayList<SInvokable> methods = new ArrayList<SInvokable>();
     for (Dispatchable disp : dispatchables.values()) {
@@ -203,6 +205,7 @@ public final class SClass extends SObjectWithClass {
     return methods.toArray(new SInvokable[methods.size()]);
   }
 
+  @TruffleBoundary
   public SClass[] getNestedClasses(final SObjectWithClass instance) {
     VM.thisMethodNeedsToBeOptimized("Not optimized, we do unrecorded invokes here");
     ArrayList<SClass> classes = new ArrayList<SClass>();

--- a/src/som/vmobjects/SInvokable.java
+++ b/src/som/vmobjects/SInvokable.java
@@ -29,6 +29,7 @@ import static som.interpreter.TruffleCompiler.transferToInterpreterAndInvalidate
 
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.source.SourceSection;
@@ -103,6 +104,7 @@ public class SInvokable extends SAbstractObject implements Dispatchable {
     return callTarget;
   }
 
+  @TruffleBoundary
   public final RootCallTarget getAtomicCallTarget() {
     if (atomicCallTarget == null) {
       synchronized (this) {

--- a/src/tools/dym/nodes/LateCallTargetNode.java
+++ b/src/tools/dym/nodes/LateCallTargetNode.java
@@ -1,14 +1,15 @@
 package tools.dym.nodes;
 
-import som.instrumentation.InstrumentableDirectCallNode;
-import som.interpreter.Invokable;
-import tools.dym.profiles.CallsiteProfile;
-
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.EventContext;
 import com.oracle.truffle.api.instrumentation.ExecutionEventNode;
 import com.oracle.truffle.api.instrumentation.ExecutionEventNodeFactory;
+
+import som.instrumentation.InstrumentableDirectCallNode;
+import som.interpreter.Invokable;
+import tools.dym.profiles.CallsiteProfile;
 
 
 public class LateCallTargetNode extends ExecutionEventNode {
@@ -20,6 +21,7 @@ public class LateCallTargetNode extends ExecutionEventNode {
     this.factory = factory;
   }
 
+  @TruffleBoundary
   private ExecutionEventNode specialize() {
     ExecutionEventNode parent = ctx.findParentEventNode(factory);
     InstrumentableDirectCallNode disp = (InstrumentableDirectCallNode) ctx.getInstrumentedNode();

--- a/src/tools/dym/nodes/LateClosureTargetNode.java
+++ b/src/tools/dym/nodes/LateClosureTargetNode.java
@@ -1,5 +1,6 @@
 package tools.dym.nodes;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.EventContext;
@@ -20,6 +21,7 @@ public class LateClosureTargetNode extends ExecutionEventNode {
     this.factory = factory;
   }
 
+  @TruffleBoundary
   private ExecutionEventNode specialize() {
     ExecutionEventNode parent = ctx.findParentEventNode(factory);
     InstrumentableBlockApplyNode disp = (InstrumentableBlockApplyNode) ctx.getInstrumentedNode();

--- a/src/tools/dym/profiles/ArrayCreationProfile.java
+++ b/src/tools/dym/profiles/ArrayCreationProfile.java
@@ -3,6 +3,7 @@ package tools.dym.profiles;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.source.SourceSection;
 
 
@@ -15,6 +16,7 @@ public class ArrayCreationProfile extends Counter {
     arraySizes = new HashMap<>();
   }
 
+  @TruffleBoundary
   public void profileArraySize(final int size) {
     arraySizes.merge(size, 1, Integer::sum);
   }


### PR DESCRIPTION
For SubstrateVM, we need to exclude code that does not need to be run-time compiled.
This is necessary to avoid a huge image, and reduce image creation time.

If code could benefit from run-time optimizations, it would need to be optimized for Truffle and partial evaluation first.