### PR TITLE
Add support for SubstrateVM

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -22,5 +22,6 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/BlackDiamonds"/>
 	<classpathentry kind="src" path="/com.oracle.truffle.tools.profiler"/>
 	<classpathentry kind="src" path="/org.graalvm.polyglot.tck"/>
+	<classpathentry kind="src" path="/com.oracle.svm.core"/>
 	<classpathentry kind="output" path="build/classes"/>
 </classpath>

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
 variables:
   PYTHONUNBUFFERED: "true"
   JVMCI_BIN: /home/gitlab-runner/.local/graal-core/bin/java
+  JVMCI_HOME: /home/gitlab-runner/.local/graal-core/
   JVMCI_VERSION_CHECK: ignore
   ECLIPSE_EXE: /home/gitlab-runner/.local/eclipse/eclipse
   JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
@@ -26,7 +27,7 @@ kompos_and_dym_tests:
   tags: [benchmarks, infinity]
   script:
     - ant -Dskip.graal=true jacoco-lib compile dynamic-metrics-tests superinstructions-tests
-    - cd tools/kompos && npm install . && npm -s run verify && npm test
+    - (cd tools/kompos && npm install . && npm -s run verify && npm test)
 
 replay_tests:
   stage: full-test
@@ -34,6 +35,11 @@ replay_tests:
   script:
     - timeout 10m ant -Dskip.graal=true replay-tests
 
+svm_tests:
+  stage: full-test
+  tags: [benchmarks, infinity]
+  script:
+    - ant native
 
 benchmark_savina_job:
   stage: benchmark

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
     - secure: PrFbSr/qjhVXrpiOzrcEMUZrnjEWJmvx5DC9QdaAmnUKpG9/7mJBQVgNziVj+GWfW84WJpkOsQf+I2lx7/cQsWQKad/t8wtypl30wGesSTpAgl5fCiKLOBAbOghKXir+WIaxtcATPPffur9OLh3ogEcmIQbVi682YUKmA5zF11JZdpCR4QONc/u+DqB29FuHru/cFiesYP0Oz82A+M0UtMcYsurKIxdKMD4YK/uSG892PUrcZU6STXlukhgQuy3PitSWkYV2KGxXMVKzWGM7dJvRggN05r/S871pscuRwZ+Doxqr9b17B3umCHi3i4KXmNH+Esb0p1mvegs0iS/b7RyA5SENre+H24n3SOeXTa3wSpTnF90XxQrDEBbY5wV7lN7MJG+pHxkOvoZt6pS3f7x2VYR8Joa4J+Gf6IDvxZMiCd1v3N1kc9ygyvJmHf5wDmLMdupk0/frojApDXfJT6bqiVL3S0FqZpXSPGAsKYf8wfn30Xz/YUBsnfUQ/a21Zz52+OTqPbt32Hf1FGYIEJSkZJUN90Q8rHVJt9zPg37xKCDuf6bxlvT040KSzuuXtizLkOnHq2rhg4Oad/JTw3d4NzPoRVzUI9qDKPrA7RdUAjmrB04Z1f3g/I6w3h2B9JTSFAzBcMZ5NYZhIqE31GQukgStaqC98y32/zo9xFs=
     - secure: "WalAXxkaD+B+mMBN+1QXrsQVl90984+giSLl7dgPwTPdQ/Ka/8AlX4n53HATztgmjwgJbM+Y53YhoSR6Zaj8CRUL6WhXGwNA2q7Xma8q0WNmX8LmoBsJlw44G50yGQOv20vTRw4SqPJp58f4PQanAAs4iPuNBOMGYji4eg60pC1bV5ZNyB5HalxQQQR5PyV647Ooa4WmP3YYLlx4FWqhh33kM3pt9RUOw8ZmVYwOqZ54qJur8Tl3Hp33R7rQ/YMNIenR1wnRunNlV/g8O8xLzUM2qjW1p+XKK08SVI/EyDn1ZtNxyzuhBp1OYxwPVLD28I4r6e/nIEr8+HnBeaUX3y43AjL6x/rzr4KTyPeCNhOYLgcdLM3A5tO/ae+KPKWXBXOwkmxjq7aF6v1Qj5uC/X1Vyb8u6EZETbrx7yNymBHyWpqM4OfljCFyU1c1JjOjsEkhWzE9YoNzhG2bMTBbpUz1gSA/6UCqjhK+3LzneTR/ZmN4RmMlsqTM98E6SMiaGGhqTENIu1UwuPpzl4pv0LJdGoxvR+2aIOZrUI/mD8iuqNoy/gQGU36OiuKencbAVjXBOJXjZueW/VcJ4ivX6Ch4rnFONLKvL2z04cu9tD8IJQfJEmjEieSI44ZCh0LXrMZRJ9bjLpIbhnRbtZ4LP6eBCOtxOwiyKIoueN1y8Fk="
 
+    - JVMCI_VERSION="jvmci-0.48"
+    - JDK8_UPDATE_VERSION="172"
+
 notifications:
   slack:
     secure: I4ZII92TFLy6vlyX98ns7BaFwA4Qo/o7Av2fnUQW6FfW13EF7Taregu20BIYFFMsiigXCAtvPjqH4HVLpZgK6gZXhbCuI8kl15ZsfRWXcgGSfGZw2De8YS845+QXjc0fq0i46IAVWIey/ImfJrmP7aqjQfWS3XRRpz1kVf7A3/UYghn4GYfJ4VvCglU+LI6qa5lbEXeZAWR0Ndelhuwj7cBSWlLNM2PEmhnf4FsOVQ986S0nmlmjybkYu2NmO+tBmoydjLr5cLt3U9maiLruJ/01ebxfML37W1GOGRUqkSc2G95TohKyiTkluL/HqBMiXXD7cXkuldpTLREnrdQqImyvqu5nq0Tr8vOjJ776LCHDFHv//CkBF1W8n7H9QHwEQonq+Hu2iPOec23Os0b1SlqLVc+1Fy88G7KkvFN430ugiJBzW5+Qk9TUE8CBwL4FixeO3nv0UYleigjGgrpYRL+yWPqwxEMQAWZN6W2YGY10rPYT0eooukEbmNphWzz/vFO4UCphMSMt6SLoN7r3br7DYLRUevdK8vrIUb1LUQPGMYf7WIdMnckme7y+oJ3SR2YO6+vs3EyQsF1AdJqpbvag0/AbWHFVi2vfwrvKZwperPLtXE+EXh8B+Ck62gcYsTyUuMpoEws/+DqHUFByOgDbPDFBmFYwPWCoZh4h3Rw=
@@ -19,6 +22,7 @@ matrix:
     - env: TASK=kompos-tests
     - env: TASK=replay1-tests
     - env: TASK=replay2-tests
+    - env: TASK=native
 
     - os:   linux
       dist: trusty
@@ -41,6 +45,14 @@ matrix:
     - os: osx
 
 install: |
+  if [ "$TRAVIS_OS_NAME" = "linux" ]
+  then
+    JDK_TAR=${TRAVIS_BUILD_DIR}/../jdk.tar.gz
+    wget https://github.com/graalvm/openjdk8-jvmci-builder/releases/download/${JVMCI_VERSION}/openjdk-8u${JDK8_UPDATE_VERSION}-${JVMCI_VERSION}-linux-amd64.tar.gz -O ${JDK_TAR}
+    tar -C ${TRAVIS_BUILD_DIR}/.. -xzf ${JDK_TAR}
+    export JVMCI_HOME=${TRAVIS_BUILD_DIR}/../openjdk1.8.0_${JDK8_UPDATE_VERSION}-${JVMCI_VERSION}
+  fi
+
   if [ "$TASK" = "checkstyle" ]
   then
     export ECLIPSE_TAR=eclipse.tar.gz
@@ -58,3 +70,4 @@ script:
   - if [ "$TASK" = "replay1-tests" ]; then ant $SG compile       && ./tests/replay/test.sh 1; fi
   - if [ "$TASK" = "replay2-tests" ]; then ant $SG compile       && ./tests/replay/test.sh 2; fi
   - if [ "$TASK" = "unit-tests"    ]; then ant compile           && ./som core-lib/TestSuite/TestRunner.ns; fi
+  - if [ "$TASK" = "native"        ]; then ant native; fi

--- a/build.xml
+++ b/build.xml
@@ -15,11 +15,12 @@
     <property name="sdk.dir"     location="${lib.dir}/truffle/sdk" />
     <property name="tools.dir"   location="${lib.dir}/truffle/tools" />
     <property name="svm.dir"     location="${lib.dir}/truffle/substratevm" />
+    <property name="compiler.build" location="${graal.dir}/mxbuild/dists" />
     <property name="sdk.build"   location="${sdk.dir}/mxbuild/dists" />
     <property name="tools.build" location="${tools.dir}/mxbuild/dists" />
     <property name="svm.build"   location="${svm.dir}/mxbuild/dists" />
     <property name="truffle.build" location="${truffle.dir}/mxbuild/dists" />
-    <property name="somns-deps.version" value="0.3.5" />
+    <property name="somns-deps.version" value="0.3.6" />
     <property name="checkstyle.version" value="8.11" />
     <property name="jacoco.version"     value="0.8.0" />
 
@@ -33,21 +34,51 @@
 
     <property environment="env"/>
 
-    <path id="project.classpath">
-        <pathelement location="${classes.dir}" />
-        <pathelement location="${unit.dir}" />
-        <pathelement location="${bd.dir}/build/classes" />
+    <path id="boot.cp">
         <pathelement location="${sdk.build}/graal-sdk.jar" />
+        <pathelement location="${truffle.build}/truffle-api.jar" />
+    </path>
+    
+    <path id="svm.cp">
+        <pathelement location="${svm.build}/objectfile.jar" />
+        <pathelement location="${svm.build}/pointsto.jar" />
+        <pathelement location="${svm.build}/svm.jar" />
+        <pathelement location="${compiler.build}/graal-management.jar" />
+        <pathelement location="${compiler.build}/graal.jar" />
+        
+        <pathelement location="${env.JVMCI_HOME}/jre/lib/jvmci/jvmci-api.jar" />
+        <pathelement location="${env.JVMCI_HOME}/jre/lib/jvmci/jvmci-hotspot.jar" />
+    </path>
+
+    <path id="common.cp">
+        <pathelement location="${classes.dir}" />
+        <pathelement location="${bd.dir}/build/classes" />
+        <pathelement location="${lib.dir}/somns-deps.jar" />
+        
+        <pathelement location="${svm.build}/svm-core.jar" />
+        <pathelement location="${tools.build}/truffle-profiler.jar" />
+    </path>
+    
+    <path id="som.cp">
+        <path refid="boot.cp"/>
+        <path refid="common.cp"/>
+        <pathelement location="${unit.dir}" />
+
         <pathelement location="${sdk.build}/word-api.jar" />
         <pathelement location="${sdk.build}/polyglot-tck.jar" />
         <pathelement location="${lib.dir}/somns-deps-dev.jar" />
-        <pathelement location="${lib.dir}/somns-deps.jar" />
-        <pathelement location="${truffle.build}/truffle-api.jar" />
+        
+
         <pathelement location="${truffle.build}/truffle-debug.jar" />
         <pathelement location="${truffle.build}/truffle-dsl-processor.jar" />
         <pathelement location="${truffle.build}/truffle-tck.jar" />
-        <pathelement location="${tools.build}/truffle-profiler.jar" />
-        <pathelement location="${svm.build}/svm-core.jar" />
+    </path>
+    
+    <path id="image.cp">
+        <path refid="boot.cp"/>
+        <path refid="svm.cp"/>
+        <path refid="common.cp"/>
+        <pathelement location="${svm.build}/library-support.jar" />
     </path>
     
     <condition property="is.atLeastJava9" value="true" else="false">
@@ -56,10 +87,14 @@
         <matches string="${java.version}" pattern="^1[0-9]"/>
       </or>
     </condition>
+    <condition property="kernel" value="darwin-amd64" else="linux-amd64">
+        <os family="mac"/>
+    </condition>
     <echo>
         ant.java.version: ${ant.java.version}
         java.version:     ${java.version}
         is.atLeastJava9:  ${is.atLeastJava9}
+        kernel:           ${kernel}
     </echo>
 
     <target name="clean" description="Remove build directories and generated code">
@@ -92,7 +127,7 @@
       </exec>
     </target>
 
-    <target name="truffle-libs" unless="skip.truffle" depends="truffle-submodule,build-graal">
+    <target name="truffle-libs" unless="skip.truffle" depends="truffle-submodule">
         <exec executable="${mx.cmd}" dir="${truffle.dir}" failonerror="true">
             <arg value="build"/>
             <arg value="--no-native"/>
@@ -102,6 +137,7 @@
         </exec>
         <exec executable="${mx.cmd}" dir="${svm.dir}" failonerror="true">
             <arg value="build"/>
+            <env key="JAVA_HOME" value="${env.JVMCI_HOME}" />
         </exec>
     </target>
 
@@ -247,25 +283,25 @@
         <mkdir dir="${src_gen.dir}" />
         <javac includeantruntime="false" srcdir="${src.dir}" destdir="${classes.dir}" debug="true"> <!-- for debugging: fork="true"  -->
           <!-- for debugging: <compilerarg line="-J-Xdebug -J-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000" /> -->
-          <classpath refid="project.classpath" />
+          <classpath refid="som.cp" />
           <compilerarg line="-s ${src_gen.dir}" />
           <compilerarg line="-XDignore.symbol.file" />
           <compilerarg line="-Xlint:all" />
           <compilerarg line="--release 8" if:true="${is.atLeastJava9}" />
         </javac>
         <javac includeantruntime="false" srcdir="${src_gen.dir}" destdir="${classes.dir}" debug="true">
-          <classpath refid="project.classpath" />
+          <classpath refid="som.cp" />
           <compilerarg line="-s ${src_gen.dir}" />
           <compilerarg line="-Xlint:all" />
           <compilerarg line="--release 8" if:true="${is.atLeastJava9}" />
         </javac>
         <javac includeantruntime="false" srcdir="${unit.dir}" destdir="${classes.dir}" debug="true">
-          <classpath refid="project.classpath" />
+          <classpath refid="som.cp" />
           <compilerarg line="--release 8" if:true="${is.atLeastJava9}" />
         </javac>
     </target>
 
-    <target name="compile" depends="libs,compile-som,compile-test-extension" description="Compile SOMns and dependencies">
+    <target name="compile" depends="libs,compile-som,compile-test-extension,build-graal" description="Compile SOMns and dependencies">
     </target>
 
     <target name="compile-test-extension">
@@ -292,7 +328,7 @@
             outputtoformatters="true" fork="true" forkmode="once">
             <jvmarg value="-ea" />
             <jvmarg value="-esa" />
-            <classpath refid="project.classpath" />
+            <classpath refid="som.cp" />
             <batchtest fork="yes" filtertrace="false">
               <fileset dir="${unit.dir}">
                   <include name="**/*Test*.java"/>
@@ -305,7 +341,7 @@
 
      <jacoco:coverage>
         <java classname="som.Launcher" fork="true" failonerror="true">
-            <classpath refid="project.classpath" />
+            <classpath refid="som.cp" />
             <jvmarg value="-ea" />
             <jvmarg value="-esa" />
             <arg line="${corelib.dir}/TestSuite/TestRunner.ns" />
@@ -400,7 +436,7 @@
     <target name="send-somns-coverage">
         <!-- submit coverage data -->
         <java classname="coveralls.Report" fork="true" failonerror="true">
-            <classpath refid="project.classpath" />
+            <classpath refid="som.cp" />
             <arg value="${env.COVERALLS_REPO_TOKEN}" />
             <arg value="all.gcov" />
         </java>
@@ -409,5 +445,40 @@
     <target name="coverage" depends="send-java-coverage,send-somns-coverage" />
 
     <target name="tests" depends="core-tests,replay-tests,coverage">
+    </target>
+    
+    <target name="native" depends="libs,compile-som">
+      <java classname="com.oracle.svm.hosted.NativeImageGeneratorRunner" fork="true" failonerror="true"
+          jvm="${env.JVMCI_HOME}/bin/java">
+        <classpath refid="svm.cp" />
+        <jvmarg line="-Xbootclasspath/a:${ant.refid:boot.cp}" />
+        <jvmarg line="-Djvmci.Compiler=graal -Djvmci.class.path.append=${compiler.build}/graal.jar" />
+
+        <jvmarg line="-server -d64 -noverify" />
+        <jvmarg line="-Dgraal.EagerSnippets=true" />
+        <jvmarg line="-Xss10m -Xms1g -Xmx13743895344" />
+        <jvmarg line="-XX:+UnlockExperimentalVMOptions" />
+        <jvmarg line="-XX:+EnableJVMCI" />
+        <jvmarg line="-XX:-UseJVMCIClassLoader" />
+        
+        <jvmarg line="-Duser.country=US -Duser.language=en " />
+        <jvmarg line="-Dgraalvm.version=dev -Dorg.graalvm.version=dev -Dcom.oracle.graalvm.isaot=true" />
+        <jvmarg line="-Dgraalvm.locatorDisabled=true -Dtruffle.TrustAllTruffleRuntimeProviders=true" />
+        <!-- <jvmarg line="-Dsom.instrumentation=true -Dsom.truffleDebugger=true" /> -->
+
+        <arg line="-imagecp ${ant.refid:image.cp}" />
+        
+        <!-- <arg line="-H:+PrintRuntimeCompileMethods" /> -->
+        <!-- <arg line="-H:+PrintMethodHistogram" /> -->
+        
+        <arg line="-H:Path=${basedir}" />
+        <arg line="-H:-ThrowUnsafeOffsetErrors" />
+        <arg line="-H:+RuntimeAssertions" />
+        <arg line="-H:MaxRuntimeCompileMethods=800" />
+        <arg line="-H:CLibraryPath=${svm.dir}/clibraries/${kernel}" />
+        <arg line="-H:Features=com.oracle.svm.truffle.TruffleFeature" />
+        <arg line="-H:Class=som.Launcher -H:Name=som-native" />
+
+      </java>
     </target>
 </project>

--- a/build.xml
+++ b/build.xml
@@ -14,8 +14,10 @@
     <property name="truffle.dir" location="${lib.dir}/truffle/truffle" />
     <property name="sdk.dir"     location="${lib.dir}/truffle/sdk" />
     <property name="tools.dir"   location="${lib.dir}/truffle/tools" />
+    <property name="svm.dir"     location="${lib.dir}/truffle/substratevm" />
     <property name="sdk.build"   location="${sdk.dir}/mxbuild/dists" />
     <property name="tools.build" location="${tools.dir}/mxbuild/dists" />
+    <property name="svm.build"   location="${svm.dir}/mxbuild/dists" />
     <property name="truffle.build" location="${truffle.dir}/mxbuild/dists" />
     <property name="somns-deps.version" value="0.3.5" />
     <property name="checkstyle.version" value="8.11" />
@@ -45,6 +47,7 @@
         <pathelement location="${truffle.build}/truffle-dsl-processor.jar" />
         <pathelement location="${truffle.build}/truffle-tck.jar" />
         <pathelement location="${tools.build}/truffle-profiler.jar" />
+        <pathelement location="${svm.build}/svm-core.jar" />
     </path>
     
     <condition property="is.atLeastJava9" value="true" else="false">
@@ -97,6 +100,9 @@
         <exec executable="${mx.cmd}" dir="${tools.dir}" failonerror="true">
             <arg value="build"/>
         </exec>
+        <exec executable="${mx.cmd}" dir="${svm.dir}" failonerror="true">
+            <arg value="build"/>
+        </exec>
     </target>
 
     <target name="build-graal" description="Build the embedded Graal" unless="skip.graal">
@@ -130,6 +136,12 @@
             <arg value="eclipseinit"/>
         </exec>
         <exec executable="${mx.cmd}" dir="${sdk.dir}" failonerror="true">
+            <arg value="eclipseinit"/>
+        </exec>
+        <exec executable="${mx.cmd}" dir="${tools.dir}" failonerror="true">
+            <arg value="eclipseinit"/>
+        </exec>
+        <exec executable="${mx.cmd}" dir="${svm.dir}" failonerror="true">
             <arg value="eclipseinit"/>
         </exec>
     </target>

--- a/core-lib/TestSuite/extension/src/ext/Extension.java
+++ b/core-lib/TestSuite/extension/src/ext/Extension.java
@@ -3,17 +3,21 @@ package ext;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.oracle.truffle.api.dsl.NodeFactory;
-
+import bd.primitives.PrimitiveLoader;
+import bd.primitives.Specializer;
+import som.VM;
 import som.interpreter.nodes.ExpressionNode;
+import som.vmobjects.SSymbol;
 
 
 public class Extension implements som.vm.Extension {
 
   @Override
-  public List<NodeFactory<? extends ExpressionNode>> getFactories() {
-    ArrayList<NodeFactory<? extends ExpressionNode>> result = new ArrayList<>();
-    result.addAll(ExtensionPrimsFactory.getFactories());
-    return result;
+  public List<Specializer<VM, ExpressionNode, SSymbol>> getSpecializers() {
+    List<Specializer<VM, ExpressionNode, SSymbol>> specializers = new ArrayList<>();
+
+    PrimitiveLoader.addAll(specializers, ExtensionPrimsFactory.getFactories());
+
+    return specializers;
   }
 }

--- a/src/som/Launcher.java
+++ b/src/som/Launcher.java
@@ -8,6 +8,7 @@ import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 
 import som.interpreter.SomLanguage;
+import som.interpreter.objectstorage.StorageAccessor;
 import som.vm.VmSettings;
 import tools.concurrency.TracingActors.ReplayActor;
 import tools.concurrency.TracingBackend;
@@ -25,6 +26,8 @@ public final class Launcher {
   public static final int EXIT_WITH_ERROR = 1;
 
   public static void main(final String[] args) {
+    StorageAccessor.initAccessors();
+
     Builder builder = createContextBuilder(args);
     Context context = builder.build();
 

--- a/src/som/VM.java
+++ b/src/som/VM.java
@@ -334,13 +334,9 @@ public final class VM {
       truffleProfiler.setCollecting(true);
     }
 
-    Debugger debugger = null;
     if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
-      debugger = Debugger.find(env);
-    }
-
-    if (options.webDebuggerEnabled) {
-      assert VmSettings.TRUFFLE_DEBUGGER_ENABLED && debugger != null;
+      assert options.webDebuggerEnabled : "If debugging is enabled, we currently expect the web debugger to be used.";
+      Debugger debugger = Debugger.find(env);
 
       webDebugger = WebDebugger.find(env);
       webDebugger.startServer(debugger, this);

--- a/src/som/interpreter/actors/ReceivedMessage.java
+++ b/src/som/interpreter/actors/ReceivedMessage.java
@@ -2,6 +2,7 @@ package som.interpreter.actors;
 
 import java.util.concurrent.CompletableFuture;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -60,8 +61,13 @@ public class ReceivedMessage extends ReceivedRootNode {
     protected Object executeBody(final VirtualFrame frame, final EventualMessage msg,
         final boolean haltOnResolver, final boolean haltOnResolution) {
       Object result = onReceive.doPreEvaluated(frame, msg.args);
-      future.complete(result);
+      resolveFuture(result);
       return result;
+    }
+
+    @TruffleBoundary
+    private void resolveFuture(final Object result) {
+      future.complete(result);
     }
   }
 

--- a/src/som/interpreter/nodes/IsValueCheckNode.java
+++ b/src/som/interpreter/nodes/IsValueCheckNode.java
@@ -1,5 +1,6 @@
 package som.interpreter.nodes;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
@@ -42,6 +43,7 @@ public abstract class IsValueCheckNode extends UnaryExpressionNode {
 
     @Override
     public Object executeEvaluated(final VirtualFrame frame, final Object receiver) {
+      CompilerDirectives.transferToInterpreterAndInvalidate();
       return specialize(frame, receiver);
     }
 

--- a/src/som/interpreter/nodes/MessageSendNode.java
+++ b/src/som/interpreter/nodes/MessageSendNode.java
@@ -51,7 +51,7 @@ public final class MessageSendNode {
         prims.getParserSpecializer(selector, arguments);
     if (specializer != null) {
       EagerlySpecializableNode newNode = (EagerlySpecializableNode) specializer.create(null,
-          arguments, source, !specializer.noWrapper());
+          arguments, source, !specializer.noWrapper(), vm);
       if (specializer.noWrapper()) {
         return newNode;
       } else {
@@ -228,7 +228,7 @@ public final class MessageSendNode {
           boolean noWrapper = specializer.noWrapper();
           EagerlySpecializableNode newNode =
               (EagerlySpecializableNode) specializer.create(arguments, argumentNodes,
-                  sourceSection, !noWrapper);
+                  sourceSection, !noWrapper, vm);
           if (noWrapper) {
             return replace(newNode);
           } else {

--- a/src/som/interpreter/nodes/SOMNode.java
+++ b/src/som/interpreter/nodes/SOMNode.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.TruffleOptions;
 import com.oracle.truffle.api.dsl.TypeSystemReference;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.instrumentation.InstrumentableNode.WrapperNode;
@@ -98,6 +99,10 @@ public abstract class SOMNode extends Node implements ScopeReference, WithSource
   }
 
   private boolean assertNodeHasNoFrameSlots() {
+    if (TruffleOptions.AOT) {
+      return true;
+    }
+
     if (this.getClass().desiredAssertionStatus()) {
       for (Field f : getAllFields(getClass())) {
         assert f.getType() != FrameSlot.class;

--- a/src/som/interpreter/nodes/literals/BooleanLiteralNode.java
+++ b/src/som/interpreter/nodes/literals/BooleanLiteralNode.java
@@ -3,7 +3,6 @@ package som.interpreter.nodes.literals;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
 
-@SuppressWarnings("unchecked")
 public abstract class BooleanLiteralNode extends LiteralNode {
 
   public static final class TrueLiteralNode extends BooleanLiteralNode {

--- a/src/som/interpreter/nodes/specialized/AndMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/AndMessageNode.java
@@ -35,14 +35,13 @@ public abstract class AndMessageNode extends BinaryComplexOperation {
     protected final NodeFactory<ExpressionNode> boolFact;
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public AndOrSplzr(final Primitive prim,
-        final NodeFactory<ExpressionNode> fact, final VM vm) {
-      this(prim, fact, (NodeFactory) AndBoolMessageNodeFactory.getInstance(), vm);
+    public AndOrSplzr(final Primitive prim, final NodeFactory<ExpressionNode> fact) {
+      this(prim, fact, (NodeFactory) AndBoolMessageNodeFactory.getInstance());
     }
 
     protected AndOrSplzr(final Primitive prim, final NodeFactory<ExpressionNode> msgFact,
-        final NodeFactory<ExpressionNode> boolFact, final VM vm) {
-      super(prim, msgFact, vm);
+        final NodeFactory<ExpressionNode> boolFact) {
+      super(prim, msgFact);
       this.boolFact = boolFact;
     }
 
@@ -61,7 +60,7 @@ public abstract class AndMessageNode extends BinaryComplexOperation {
     @Override
     public final BinaryExpressionNode create(final Object[] arguments,
         final ExpressionNode[] argNodes, final SourceSection section,
-        final boolean eagerWrapper) {
+        final boolean eagerWrapper, final VM vm) {
       BinaryExpressionNode node;
       if (unwrapIfNecessary(argNodes[1]) instanceof BlockNode) {
         node = (BinaryExpressionNode) fact.createNode(

--- a/src/som/interpreter/nodes/specialized/IntToDoMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/IntToDoMessageNode.java
@@ -26,9 +26,8 @@ import tools.dym.Tags.LoopNode;
     specializer = ToDoSplzr.class, inParser = false)
 public abstract class IntToDoMessageNode extends TernaryExpressionNode {
   public static class ToDoSplzr extends Specializer<VM, ExpressionNode, SSymbol> {
-    public ToDoSplzr(final Primitive prim, final NodeFactory<ExpressionNode> fact,
-        final VM vm) {
-      super(prim, fact, vm);
+    public ToDoSplzr(final Primitive prim, final NodeFactory<ExpressionNode> fact) {
+      super(prim, fact);
     }
 
     @Override

--- a/src/som/interpreter/nodes/specialized/OrMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/OrMessageNode.java
@@ -9,7 +9,6 @@ import com.oracle.truffle.api.nodes.DirectCallNode;
 
 import bd.primitives.Primitive;
 import bd.tools.nodes.Operation;
-import som.VM;
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.BinaryBasicOperation;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
@@ -28,8 +27,8 @@ import tools.dym.Tags.OpComparison;
 public abstract class OrMessageNode extends BinaryComplexOperation {
   public static final class OrSplzr extends AndOrSplzr {
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public OrSplzr(final Primitive prim, final NodeFactory<ExpressionNode> fact, final VM vm) {
-      super(prim, fact, (NodeFactory) OrBoolMessageNodeFactory.getInstance(), vm);
+    public OrSplzr(final Primitive prim, final NodeFactory<ExpressionNode> fact) {
+      super(prim, fact, (NodeFactory) OrBoolMessageNodeFactory.getInstance());
     }
   }
 

--- a/src/som/interpreter/nodes/specialized/whileloops/WhileWithStaticBlocksNode.java
+++ b/src/som/interpreter/nodes/specialized/whileloops/WhileWithStaticBlocksNode.java
@@ -26,8 +26,8 @@ public final class WhileWithStaticBlocksNode extends AbstractWhileNode {
     private final boolean whileTrueOrFalse;
 
     protected WhileSplzr(final Primitive prim, final NodeFactory<ExpressionNode> fact,
-        final VM vm, final boolean whileTrueOrFalse) {
-      super(prim, fact, vm);
+        final boolean whileTrueOrFalse) {
+      super(prim, fact);
       this.whileTrueOrFalse = whileTrueOrFalse;
     }
 
@@ -40,7 +40,7 @@ public final class WhileWithStaticBlocksNode extends AbstractWhileNode {
     @Override
     public WhileWithStaticBlocksNode create(final Object[] arguments,
         final ExpressionNode[] argNodes, final SourceSection section,
-        final boolean eagerWrapper) {
+        final boolean eagerWrapper, final VM vm) {
       assert !eagerWrapper;
       BlockNode argBlockNode = (BlockNode) unwrapIfNecessary(argNodes[1]);
       SBlock argBlock = (SBlock) arguments[1];
@@ -51,16 +51,14 @@ public final class WhileWithStaticBlocksNode extends AbstractWhileNode {
   }
 
   public static final class WhileTrueSplzr extends WhileSplzr {
-    public WhileTrueSplzr(final Primitive prim, final NodeFactory<ExpressionNode> fact,
-        final VM vm) {
-      super(prim, fact, vm, true);
+    public WhileTrueSplzr(final Primitive prim, final NodeFactory<ExpressionNode> fact) {
+      super(prim, fact, true);
     }
   }
 
   public static final class WhileFalseSplzr extends WhileSplzr {
-    public WhileFalseSplzr(final Primitive prim, final NodeFactory<ExpressionNode> fact,
-        final VM vm) {
-      super(prim, fact, vm, false);
+    public WhileFalseSplzr(final Primitive prim, final NodeFactory<ExpressionNode> fact) {
+      super(prim, fact, false);
     }
   }
 

--- a/src/som/interpreter/objectstorage/ObjectAddresses.java
+++ b/src/som/interpreter/objectstorage/ObjectAddresses.java
@@ -1,0 +1,69 @@
+package som.interpreter.objectstorage;
+
+import java.lang.reflect.Field;
+
+import org.graalvm.nativeimage.Feature;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+
+import som.vmobjects.SObject.SImmutableObject;
+import som.vmobjects.SObject.SMutableObject;
+
+
+public final class ObjectAddresses {
+
+  public static long field1Offset;
+  public static long field2Offset;
+  public static long field3Offset;
+  public static long field4Offset;
+  public static long field5Offset;
+
+  public static long prim1Offset;
+  public static long prim2Offset;
+  public static long prim3Offset;
+  public static long prim4Offset;
+  public static long prim5Offset;
+
+  public static long field1OffsetImm;
+  public static long field2OffsetImm;
+  public static long field3OffsetImm;
+  public static long field4OffsetImm;
+  public static long field5OffsetImm;
+
+  public static long prim1OffsetImm;
+  public static long prim2OffsetImm;
+  public static long prim3OffsetImm;
+  public static long prim4OffsetImm;
+  public static long prim5OffsetImm;
+
+  @AutomaticFeature
+  private static class AotFeature implements Feature {
+    @Override
+    public void beforeAnalysis(final BeforeAnalysisAccess baa) {
+      try {
+        for (int i = 1; i <= 5; i += 1) {
+          Field f = SMutableObject.class.getDeclaredField("field" + i);
+          baa.registerAsUnsafeAccessed(f);
+        }
+
+        for (int i = 1; i <= 5; i += 1) {
+          Field f = SMutableObject.class.getDeclaredField("primField" + i);
+          baa.registerAsUnsafeAccessed(f);
+        }
+
+        for (int i = 1; i <= 5; i += 1) {
+          Field f = SImmutableObject.class.getDeclaredField("field" + i);
+          baa.registerAsUnsafeAccessed(f);
+        }
+
+        for (int i = 1; i <= 5; i += 1) {
+          Field f = SImmutableObject.class.getDeclaredField("primField" + i);
+          baa.registerAsUnsafeAccessed(f);
+        }
+      } catch (NoSuchFieldException | SecurityException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+}

--- a/src/som/interpreter/objectstorage/TargetObjectAddresses.java
+++ b/src/som/interpreter/objectstorage/TargetObjectAddresses.java
@@ -1,0 +1,52 @@
+package som.interpreter.objectstorage;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.RecomputeFieldValue.Kind;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import som.vmobjects.SObject.SMutableObject;
+
+
+@TargetClass(ObjectAddresses.class)
+public final class TargetObjectAddresses {
+  @RecomputeFieldValue(kind = Kind.FieldOffset, declClass = SMutableObject.class,
+      name = "field1") //
+  @Alias public static long field1Offset;
+
+  @RecomputeFieldValue(kind = Kind.FieldOffset, declClass = SMutableObject.class,
+      name = "field2") //
+  @Alias public static long field2Offset;
+
+  @RecomputeFieldValue(kind = Kind.FieldOffset, declClass = SMutableObject.class,
+      name = "field3") //
+  @Alias public static long field3Offset;
+
+  @RecomputeFieldValue(kind = Kind.FieldOffset, declClass = SMutableObject.class,
+      name = "field4") //
+  @Alias public static long field4Offset;
+
+  @RecomputeFieldValue(kind = Kind.FieldOffset, declClass = SMutableObject.class,
+      name = "field5") //
+  @Alias public static long field5Offset;
+
+  @RecomputeFieldValue(kind = Kind.FieldOffset, declClass = SMutableObject.class,
+      name = "primField1") //
+  @Alias public static long prim1Offset;
+
+  @RecomputeFieldValue(kind = Kind.FieldOffset, declClass = SMutableObject.class,
+      name = "primField2") //
+  @Alias public static long prim2Offset;
+
+  @RecomputeFieldValue(kind = Kind.FieldOffset, declClass = SMutableObject.class,
+      name = "primField3") //
+  @Alias public static long prim3Offset;
+
+  @RecomputeFieldValue(kind = Kind.FieldOffset, declClass = SMutableObject.class,
+      name = "primField4") //
+  @Alias public static long prim4Offset;
+
+  @RecomputeFieldValue(kind = Kind.FieldOffset, declClass = SMutableObject.class,
+      name = "primField5") //
+  @Alias public static long prim5Offset;
+}

--- a/src/som/primitives/BlockPrims.java
+++ b/src/som/primitives/BlockPrims.java
@@ -1,5 +1,6 @@
 package som.primitives;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
@@ -103,11 +104,16 @@ public abstract class BlockPrims {
 
   private static void checkArguments(final SBlock receiver, final int expectedNumArgs,
       final ExceptionSignalingNode argumentError) {
-    if (receiver.getMethod().getNumberOfArguments() != expectedNumArgs) {
-      argumentError.signal(
-          "Incorrect number of Block arguments: " + expectedNumArgs + ", expected: "
-              + (receiver.getMethod().getNumberOfArguments() - 1));
+    int numArgs = receiver.getMethod().getNumberOfArguments();
+    if (numArgs != expectedNumArgs) {
+      argumentError.signal(errorMsg(expectedNumArgs, numArgs));
     }
+  }
+
+  @TruffleBoundary
+  private static String errorMsg(final int expectedNumArgs, final int numArgs) {
+    return "Incorrect number of Block arguments: " + expectedNumArgs + ", expected: "
+        + (numArgs - 1);
   }
 
   @GenerateNodeFactory

--- a/src/som/primitives/DoublePrims.java
+++ b/src/som/primitives/DoublePrims.java
@@ -58,9 +58,8 @@ public abstract class DoublePrims {
   }
 
   public static class IsDoubleClass extends Specializer<VM, ExpressionNode, SSymbol> {
-    public IsDoubleClass(final Primitive prim, final NodeFactory<ExpressionNode> fact,
-        final VM vm) {
-      super(prim, fact, vm);
+    public IsDoubleClass(final Primitive prim, final NodeFactory<ExpressionNode> fact) {
+      super(prim, fact);
     }
 
     @Override

--- a/src/som/primitives/FilePrims.java
+++ b/src/som/primitives/FilePrims.java
@@ -2,6 +2,7 @@ package som.primitives;
 
 import java.util.Objects;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.ImportStatic;
@@ -132,10 +133,14 @@ public final class FilePrims {
 
     @Fallback
     public final Object setWithUnsupportedValue(final Object file, final Object mode) {
-      argumentError.signal("File access mode invalid, was: "
-          + Objects.toString(mode) + " " + SFileDescriptor.getValidAccessModes());
-
+      argumentError.signal(errorMsg(mode));
       return file;
+    }
+
+    @TruffleBoundary
+    private String errorMsg(final Object mode) {
+      return "File access mode invalid, was: " + Objects.toString(mode) + " "
+          + SFileDescriptor.getValidAccessModes();
     }
   }
 

--- a/src/som/primitives/MirrorPrims.java
+++ b/src/som/primitives/MirrorPrims.java
@@ -154,6 +154,7 @@ public abstract class MirrorPrims {
   @Primitive(primitive = "classDefFilePath:")
   public abstract static class ClassDefFilePathPrim extends UnaryExpressionNode {
     @Specialization
+    @TruffleBoundary
     public final String getFilePath(final Object mixinHandle) {
       assert mixinHandle instanceof MixinDefinition;
       MixinDefinition def = (MixinDefinition) mixinHandle;

--- a/src/som/primitives/StringPrims.java
+++ b/src/som/primitives/StringPrims.java
@@ -194,12 +194,16 @@ public class StringPrims {
           sb.append(((SSymbol) o).getString());
         } else {
           // TODO: there should be a Smalltalk asString message here, I think
-          argumentError.signal(
-              "Array can't contain non-string objects, but has " + o.toString());
+          argumentError.signal(errorMsg(o));
         }
       }
 
       return sb.toString();
+    }
+
+    @TruffleBoundary
+    private static String errorMsg(final Object o) {
+      return "Array can't contain non-string objects, but has " + o.toString();
     }
 
     @Fallback

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -315,9 +315,8 @@ public final class SystemPrims {
   }
 
   public static class IsSystemModule extends Specializer<VM, ExpressionNode, SSymbol> {
-    public IsSystemModule(final Primitive prim, final NodeFactory<ExpressionNode> fact,
-        final VM vm) {
-      super(prim, fact, vm);
+    public IsSystemModule(final Primitive prim, final NodeFactory<ExpressionNode> fact) {
+      super(prim, fact);
     }
 
     @Override

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -289,6 +289,7 @@ public final class SystemPrims {
   @Primitive(primitive = "systemGC:")
   public abstract static class FullGCPrim extends UnaryExpressionNode {
     @Specialization
+    @TruffleBoundary
     public final Object doSObject(final Object receiver) {
       System.gc();
       return true;

--- a/src/som/primitives/actors/ActorClasses.java
+++ b/src/som/primitives/actors/ActorClasses.java
@@ -1,6 +1,7 @@
 package som.primitives.actors;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
@@ -25,6 +26,7 @@ public final class ActorClasses {
   @Primitive(primitive = "actorsFarReferenceClass:")
   public abstract static class SetFarReferenceClassPrim extends UnaryExpressionNode {
     @Specialization
+    @TruffleBoundary
     public final SClass setClass(final SClass value) {
       SFarReference.setSOMClass(value);
       FarRefId = value.getMixinDefinition().getMixinId();
@@ -36,6 +38,7 @@ public final class ActorClasses {
   @Primitive(primitive = "actorsPromiseClass:")
   public abstract static class SetPromiseClassPrim extends UnaryExpressionNode {
     @Specialization
+    @TruffleBoundary
     public final SClass setClass(final SClass value) {
       SPromise.setSOMClass(value);
       return value;
@@ -46,6 +49,7 @@ public final class ActorClasses {
   @Primitive(primitive = "actorsPairClass:")
   public abstract static class SetPairClassPrim extends UnaryExpressionNode {
     @Specialization
+    @TruffleBoundary
     public final SClass setClass(final SClass value) {
       SPromise.setPairClass(value);
       return value;
@@ -56,6 +60,7 @@ public final class ActorClasses {
   @Primitive(primitive = "actorsResolverClass:")
   public abstract static class SetResolverClassPrim extends UnaryExpressionNode {
     @Specialization
+    @TruffleBoundary
     public final SClass setClass(final SClass value) {
       SResolver.setSOMClass(value);
       return value;
@@ -66,6 +71,7 @@ public final class ActorClasses {
   @Primitive(primitive = "actorsModule:")
   public abstract static class SetModulePrim extends UnarySystemOperation {
     @Specialization
+    @TruffleBoundary
     public final SImmutableObject setClass(final SImmutableObject value) {
       ActorModule = value;
       TimerPrim.initializeTimer(vm);

--- a/src/som/primitives/actors/PromisePrims.java
+++ b/src/som/primitives/actors/PromisePrims.java
@@ -50,9 +50,8 @@ import tools.debugger.session.Breakpoints;
 public final class PromisePrims {
 
   public static class IsActorModule extends Specializer<VM, ExpressionNode, SSymbol> {
-    public IsActorModule(final Primitive prim, final NodeFactory<ExpressionNode> fact,
-        final VM vm) {
-      super(prim, fact, vm);
+    public IsActorModule(final Primitive prim, final NodeFactory<ExpressionNode> fact) {
+      super(prim, fact);
     }
 
     @Override

--- a/src/som/primitives/arrays/AtPrim.java
+++ b/src/som/primitives/arrays/AtPrim.java
@@ -31,16 +31,15 @@ import tools.dym.Tags.ArrayRead;
     inParser = false, specializer = TxAtPrim.class)
 public abstract class AtPrim extends BinaryBasicOperation {
   protected static final class TxAtPrim extends Specializer<VM, ExpressionNode, SSymbol> {
-    public TxAtPrim(final Primitive prim, final NodeFactory<ExpressionNode> fact,
-        final VM vm) {
-      super(prim, fact, vm);
+    public TxAtPrim(final Primitive prim, final NodeFactory<ExpressionNode> fact) {
+      super(prim, fact);
     }
 
     @Override
     public ExpressionNode create(final Object[] arguments,
         final ExpressionNode[] argNodes, final SourceSection section,
-        final boolean eagerWrapper) {
-      ExpressionNode node = super.create(arguments, argNodes, section, eagerWrapper);
+        final boolean eagerWrapper, final VM vm) {
+      ExpressionNode node = super.create(arguments, argNodes, section, eagerWrapper, vm);
 
       // TODO: seems a bit expensive,
       // might want to optimize for interpreter first iteration speed

--- a/src/som/primitives/arrays/AtPutPrim.java
+++ b/src/som/primitives/arrays/AtPutPrim.java
@@ -37,16 +37,15 @@ import tools.dym.Tags.BasicPrimitiveOperation;
     receiverType = SArray.class, inParser = false, specializer = TxAtPutPrim.class)
 public abstract class AtPutPrim extends TernaryExpressionNode {
   protected static final class TxAtPutPrim extends Specializer<VM, ExpressionNode, SSymbol> {
-    public TxAtPutPrim(final Primitive prim, final NodeFactory<ExpressionNode> fact,
-        final VM vm) {
-      super(prim, fact, vm);
+    public TxAtPutPrim(final Primitive prim, final NodeFactory<ExpressionNode> fact) {
+      super(prim, fact);
     }
 
     @Override
     public ExpressionNode create(final Object[] arguments,
         final ExpressionNode[] argNodes, final SourceSection section,
-        final boolean eagerWrapper) {
-      ExpressionNode node = super.create(arguments, argNodes, section, eagerWrapper);
+        final boolean eagerWrapper, final VM vm) {
+      ExpressionNode node = super.create(arguments, argNodes, section, eagerWrapper, vm);
       // TODO: seems a bit expensive,
       // might want to optimize for interpreter first iteration speed
       // TODO: clone in UnitializedDispatchNode.AbstractUninitialized.forAtomic()

--- a/src/som/primitives/arrays/NewImmutableArrayNode.java
+++ b/src/som/primitives/arrays/NewImmutableArrayNode.java
@@ -31,9 +31,8 @@ import som.vmobjects.SSymbol;
     specializer = NewImmutableArrayNode.IsValueArrayClass.class)
 public abstract class NewImmutableArrayNode extends TernaryExpressionNode {
   public static class IsValueArrayClass extends Specializer<VM, ExpressionNode, SSymbol> {
-    public IsValueArrayClass(final Primitive prim, final NodeFactory<ExpressionNode> fact,
-        final VM vm) {
-      super(prim, fact, vm);
+    public IsValueArrayClass(final Primitive prim, final NodeFactory<ExpressionNode> fact) {
+      super(prim, fact);
     }
 
     @Override

--- a/src/som/primitives/arrays/NewPrim.java
+++ b/src/som/primitives/arrays/NewPrim.java
@@ -24,9 +24,8 @@ import tools.dym.Tags.NewArray;
     specializer = NewPrim.IsArrayClass.class)
 public abstract class NewPrim extends BinaryExpressionNode {
   public static class IsArrayClass extends Specializer<VM, ExpressionNode, SSymbol> {
-    public IsArrayClass(final Primitive prim, final NodeFactory<ExpressionNode> fact,
-        final VM vm) {
-      super(prim, fact, vm);
+    public IsArrayClass(final Primitive prim, final NodeFactory<ExpressionNode> fact) {
+      super(prim, fact);
     }
 
     @Override

--- a/src/som/vm/Extension.java
+++ b/src/som/vm/Extension.java
@@ -2,9 +2,10 @@ package som.vm;
 
 import java.util.List;
 
-import com.oracle.truffle.api.dsl.NodeFactory;
-
+import bd.primitives.Specializer;
+import som.VM;
 import som.interpreter.nodes.ExpressionNode;
+import som.vmobjects.SSymbol;
 
 
 /**
@@ -14,5 +15,5 @@ import som.interpreter.nodes.ExpressionNode;
  * extension. These are then used to create a Newspeak class, similar to {@code vmMirror}.
  */
 public interface Extension {
-  List<NodeFactory<? extends ExpressionNode>> getFactories();
+  List<Specializer<VM, ExpressionNode, SSymbol>> getSpecializers();
 }

--- a/src/som/vm/ExtensionLoader.java
+++ b/src/som/vm/ExtensionLoader.java
@@ -11,11 +11,9 @@ import java.util.Properties;
 import org.graalvm.collections.EconomicMap;
 
 import com.oracle.truffle.api.CompilerAsserts;
-import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 
-import bd.primitives.Primitive;
 import bd.primitives.PrimitiveLoader;
 import bd.primitives.Specializer;
 import som.VM;
@@ -40,7 +38,7 @@ public final class ExtensionLoader extends PrimitiveLoader<VM, ExpressionNode, S
   private final Extension      extension;
 
   public ExtensionLoader(final String moduleName, final SomLanguage lang) {
-    super(Symbols.PROVIDER, lang.getVM());
+    super(Symbols.PROVIDER);
     primitives = EconomicMap.create();
     this.lang = lang;
     this.moduleName = moduleName;
@@ -90,14 +88,14 @@ public final class ExtensionLoader extends PrimitiveLoader<VM, ExpressionNode, S
   }
 
   @Override
-  protected List<NodeFactory<? extends ExpressionNode>> getFactories() {
-    return extension.getFactories();
+  protected List<Specializer<VM, ExpressionNode, SSymbol>> getSpecializers() {
+    return extension.getSpecializers();
   }
 
   @Override
-  protected void registerPrimitive(final Primitive prim,
+  protected void registerPrimitive(
       final Specializer<VM, ExpressionNode, SSymbol> specializer) {
-    String name = prim.primitive();
+    String name = specializer.getPrimitive().primitive();
 
     assert !("".equals(name));
     SSymbol signature = Symbols.symbolFor(name);

--- a/src/som/vm/ExtensionLoader.java
+++ b/src/som/vm/ExtensionLoader.java
@@ -124,7 +124,7 @@ public final class ExtensionLoader extends PrimitiveLoader<VM, ExpressionNode, S
       args[i] = new LocalArgumentReadNode(true, i).initialize(source);
     }
 
-    ExpressionNode primNode = specializer.create(null, args, source, false);
+    ExpressionNode primNode = specializer.create(null, args, source, false, lang.getVM());
 
     String name = moduleName + ">>" + signature.toString();
 

--- a/src/som/vm/ObjectSystem.java
+++ b/src/som/vm/ObjectSystem.java
@@ -48,6 +48,11 @@ import tools.language.StructuralProbe;
 
 public final class ObjectSystem {
 
+  static {
+    inlinableNodes = new InlinableNodes<>(Symbols.PROVIDER,
+        Primitives.getInlinableNodes(), Primitives.getInlinableFactories());
+  }
+
   private final EconomicMap<URI, MixinDefinition> loadedModules;
 
   @CompilationFinal private MixinDefinition platformModule;
@@ -63,7 +68,7 @@ public final class ObjectSystem {
 
   private final Primitives primitives;
 
-  private final InlinableNodes<SSymbol> inlinableNodes;
+  private static final InlinableNodes<SSymbol> inlinableNodes;
 
   private CompletableFuture<Object> mainThreadCompleted;
 
@@ -72,8 +77,6 @@ public final class ObjectSystem {
   public ObjectSystem(final SourcecodeCompiler compiler,
       final StructuralProbe probe, final VM vm) {
     this.primitives = new Primitives(compiler.getLanguage());
-    this.inlinableNodes = new InlinableNodes<>(Symbols.PROVIDER,
-        Primitives.getInlinableNodes(), Primitives.getInlinableFactories());
     this.compiler = compiler;
     structuralProbe = probe;
     loadedModules = EconomicMap.create();

--- a/src/som/vm/Primitives.java
+++ b/src/som/vm/Primitives.java
@@ -177,7 +177,6 @@ public class Primitives extends PrimitiveLoader<VM, ExpressionNode, SSymbol> {
     return specializer;
   }
 
-  @SuppressWarnings({"rawtypes", "unchecked"})
   private static List<Specializer<VM, ExpressionNode, SSymbol>> initSpecializers() {
     List<Specializer<VM, ExpressionNode, SSymbol>> allFactories = new ArrayList<>();
     addAll(allFactories, ActorClassesFactory.getFactories());

--- a/src/som/vm/Primitives.java
+++ b/src/som/vm/Primitives.java
@@ -107,11 +107,14 @@ import som.vmobjects.SSymbol;
 
 public class Primitives extends PrimitiveLoader<VM, ExpressionNode, SSymbol> {
 
+  private static List<Specializer<VM, ExpressionNode, SSymbol>> specializer =
+      initSpecializers();
+
   private EconomicMap<SSymbol, Dispatchable> vmMirrorPrimitives;
   private final SomLanguage                  lang;
 
   public Primitives(final SomLanguage lang) {
-    super(Symbols.PROVIDER, lang.getVM());
+    super(Symbols.PROVIDER);
     vmMirrorPrimitives = EconomicMap.create();
     this.lang = lang;
     initialize();
@@ -156,9 +159,9 @@ public class Primitives extends PrimitiveLoader<VM, ExpressionNode, SSymbol> {
   }
 
   @Override
-  protected void registerPrimitive(final bd.primitives.Primitive prim,
+  protected void registerPrimitive(
       final Specializer<VM, ExpressionNode, SSymbol> specializer) {
-    String vmMirrorName = prim.primitive();
+    String vmMirrorName = specializer.getPrimitive().primitive();
 
     if (!("".equals(vmMirrorName))) {
       SSymbol signature = Symbols.symbolFor(vmMirrorName);
@@ -169,85 +172,89 @@ public class Primitives extends PrimitiveLoader<VM, ExpressionNode, SSymbol> {
     }
   }
 
-  @SuppressWarnings({"rawtypes", "unchecked"})
   @Override
-  protected List<NodeFactory<? extends ExpressionNode>> getFactories() {
-    List<NodeFactory<? extends ExpressionNode>> allFactories = new ArrayList<>();
-    allFactories.addAll(ActorClassesFactory.getFactories());
-    allFactories.addAll(BlockPrimsFactory.getFactories());
-    allFactories.addAll(ClassPrimsFactory.getFactories());
-    allFactories.addAll(DoublePrimsFactory.getFactories());
-    allFactories.addAll(ExceptionsPrimsFactory.getFactories());
-    allFactories.addAll(FilePrimsFactory.getFactories());
-    allFactories.addAll(IfMessageNodeGen.getFactories());
-    allFactories.addAll(IntegerPrimsFactory.getFactories());
-    allFactories.addAll(MethodPrimsFactory.getFactories());
-    allFactories.addAll(MirrorPrimsFactory.getFactories());
-    allFactories.addAll(ObjectPrimsFactory.getFactories());
-    allFactories.addAll(ObjectSystemPrimsFactory.getFactories());
-    allFactories.addAll(PathPrimsFactory.getFactories());
-    allFactories.addAll((List) PromisePrimsFactory.getFactories());
-    allFactories.addAll(StringPrimsFactory.getFactories());
-    allFactories.addAll(SystemPrimsFactory.getFactories());
-    allFactories.addAll(WhilePrimitiveNodeFactory.getFactories());
+  protected List<Specializer<VM, ExpressionNode, SSymbol>> getSpecializers() {
+    return specializer;
+  }
 
-    allFactories.addAll((List) ActivitySpawnFactory.getFactories());
-    allFactories.addAll(ThreadingModuleFactory.getFactories());
-    allFactories.addAll(ConditionPrimitivesFactory.getFactories());
-    allFactories.addAll(DelayPrimitivesFactory.getFactories());
-    allFactories.addAll(MutexPrimitivesFactory.getFactories());
-    allFactories.addAll(ActivityJoinFactory.getFactories());
-    allFactories.addAll(ThreadPrimitivesFactory.getFactories());
-    allFactories.addAll(ChannelPrimitivesFactory.getFactories());
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static List<Specializer<VM, ExpressionNode, SSymbol>> initSpecializers() {
+    List<Specializer<VM, ExpressionNode, SSymbol>> allFactories = new ArrayList<>();
+    addAll(allFactories, ActorClassesFactory.getFactories());
+    addAll(allFactories, BlockPrimsFactory.getFactories());
+    addAll(allFactories, ClassPrimsFactory.getFactories());
+    addAll(allFactories, DoublePrimsFactory.getFactories());
+    addAll(allFactories, ExceptionsPrimsFactory.getFactories());
+    addAll(allFactories, FilePrimsFactory.getFactories());
+    addAll(allFactories, IfMessageNodeGen.getFactories());
+    addAll(allFactories, IntegerPrimsFactory.getFactories());
+    addAll(allFactories, MethodPrimsFactory.getFactories());
+    addAll(allFactories, MirrorPrimsFactory.getFactories());
+    addAll(allFactories, ObjectPrimsFactory.getFactories());
+    addAll(allFactories, ObjectSystemPrimsFactory.getFactories());
+    addAll(allFactories, PathPrimsFactory.getFactories());
+    addAll(allFactories, PromisePrimsFactory.getFactories());
+    addAll(allFactories, StringPrimsFactory.getFactories());
+    addAll(allFactories, SystemPrimsFactory.getFactories());
+    addAll(allFactories, WhilePrimitiveNodeFactory.getFactories());
 
-    allFactories.add(AdditionPrimFactory.getInstance());
-    allFactories.add(AndMessageNodeFactory.getInstance());
-    allFactories.add(AsStringPrimFactory.getInstance());
-    allFactories.add(AtomicPrimFactory.getInstance());
-    allFactories.add(AtPrimFactory.getInstance());
-    allFactories.add(AtPutPrimFactory.getInstance());
-    allFactories.add(BitAndPrimFactory.getInstance());
-    allFactories.add(BitOrPrimFactory.getInstance());
-    allFactories.add(BitXorPrimFactory.getInstance());
-    allFactories.add(CopyPrimFactory.getInstance());
-    allFactories.add(CosPrimFactory.getInstance());
-    allFactories.add(DividePrimFactory.getInstance());
-    allFactories.add(DoIndexesPrimFactory.getInstance());
-    allFactories.add(DoPrimFactory.getInstance());
-    allFactories.add(DoubleDivPrimFactory.getInstance());
-    allFactories.add(EqualsEqualsPrimFactory.getInstance());
-    allFactories.add(EqualsPrimFactory.getInstance());
-    allFactories.add(ExpPrimFactory.getInstance());
-    allFactories.add(GreaterThanOrEqualPrimFactory.getInstance());
-    allFactories.add(GreaterThanPrimFactory.getInstance());
-    allFactories.add(HashPrimFactory.getInstance());
-    allFactories.add(IfTrueIfFalseMessageNodeFactory.getInstance());
-    allFactories.add(IntToDoMessageNodeFactory.getInstance());
-    allFactories.add(IntDownToDoMessageNodeFactory.getInstance());
-    allFactories.add(IntToByDoMessageNodeFactory.getInstance());
-    allFactories.add(LessThanOrEqualPrimFactory.getInstance());
-    allFactories.add(LessThanPrimFactory.getInstance());
-    allFactories.add(LogPrimFactory.getInstance());
-    allFactories.add(PowPrimFactory.getInstance());
-    allFactories.add(ModuloPrimFactory.getInstance());
-    allFactories.add(MultiplicationPrimFactory.getInstance());
-    allFactories.add(NewPrimFactory.getInstance());
-    allFactories.add(NewImmutableArrayNodeFactory.getInstance());
-    allFactories.add(NotMessageNodeFactory.getInstance());
-    allFactories.add(OrMessageNodeFactory.getInstance());
-    allFactories.add(PutAllNodeFactory.getInstance());
-    allFactories.add(RemainderPrimFactory.getInstance());
-    allFactories.add(SinPrimFactory.getInstance());
-    allFactories.add(SizeAndLengthPrimFactory.getInstance());
-    allFactories.add(SqrtPrimFactory.getInstance());
-    allFactories.add(SubtractionPrimFactory.getInstance());
-    allFactories.add(UnequalsPrimFactory.getInstance());
-    allFactories.add(new WhileWithStaticBlocksNodeFactory());
-    allFactories.add(TimerPrimFactory.getInstance());
+    addAll(allFactories, ActivitySpawnFactory.getFactories());
+    addAll(allFactories, ThreadingModuleFactory.getFactories());
+    addAll(allFactories, ConditionPrimitivesFactory.getFactories());
+    addAll(allFactories, DelayPrimitivesFactory.getFactories());
+    addAll(allFactories, MutexPrimitivesFactory.getFactories());
+    addAll(allFactories, ActivityJoinFactory.getFactories());
+    addAll(allFactories, ThreadPrimitivesFactory.getFactories());
+    addAll(allFactories, ChannelPrimitivesFactory.getFactories());
 
-    allFactories.add(CreateActorPrimFactory.getInstance());
-    allFactories.add(ResolvePromiseNodeFactory.getInstance());
-    allFactories.add(ErrorPromiseNodeFactory.getInstance());
+    add(allFactories, AdditionPrimFactory.getInstance());
+    add(allFactories, AndMessageNodeFactory.getInstance());
+    add(allFactories, AsStringPrimFactory.getInstance());
+    add(allFactories, AtomicPrimFactory.getInstance());
+    add(allFactories, AtPrimFactory.getInstance());
+    add(allFactories, AtPutPrimFactory.getInstance());
+    add(allFactories, BitAndPrimFactory.getInstance());
+    add(allFactories, BitOrPrimFactory.getInstance());
+    add(allFactories, BitXorPrimFactory.getInstance());
+    add(allFactories, CopyPrimFactory.getInstance());
+    add(allFactories, CosPrimFactory.getInstance());
+    add(allFactories, DividePrimFactory.getInstance());
+    add(allFactories, DoIndexesPrimFactory.getInstance());
+    add(allFactories, DoPrimFactory.getInstance());
+    add(allFactories, DoubleDivPrimFactory.getInstance());
+    add(allFactories, EqualsEqualsPrimFactory.getInstance());
+    add(allFactories, EqualsPrimFactory.getInstance());
+    add(allFactories, ExpPrimFactory.getInstance());
+    add(allFactories, GreaterThanOrEqualPrimFactory.getInstance());
+    add(allFactories, GreaterThanPrimFactory.getInstance());
+    add(allFactories, HashPrimFactory.getInstance());
+    add(allFactories, IfTrueIfFalseMessageNodeFactory.getInstance());
+    add(allFactories, IntToDoMessageNodeFactory.getInstance());
+    add(allFactories, IntDownToDoMessageNodeFactory.getInstance());
+    add(allFactories, IntToByDoMessageNodeFactory.getInstance());
+    add(allFactories, LessThanOrEqualPrimFactory.getInstance());
+    add(allFactories, LessThanPrimFactory.getInstance());
+    add(allFactories, LogPrimFactory.getInstance());
+    add(allFactories, PowPrimFactory.getInstance());
+    add(allFactories, ModuloPrimFactory.getInstance());
+    add(allFactories, MultiplicationPrimFactory.getInstance());
+    add(allFactories, NewPrimFactory.getInstance());
+    add(allFactories, NewImmutableArrayNodeFactory.getInstance());
+    add(allFactories, NotMessageNodeFactory.getInstance());
+    add(allFactories, OrMessageNodeFactory.getInstance());
+    add(allFactories, PutAllNodeFactory.getInstance());
+    add(allFactories, RemainderPrimFactory.getInstance());
+    add(allFactories, SinPrimFactory.getInstance());
+    add(allFactories, SizeAndLengthPrimFactory.getInstance());
+    add(allFactories, SqrtPrimFactory.getInstance());
+    add(allFactories, SubtractionPrimFactory.getInstance());
+    add(allFactories, UnequalsPrimFactory.getInstance());
+    add(allFactories, new WhileWithStaticBlocksNodeFactory());
+    add(allFactories, TimerPrimFactory.getInstance());
+
+    add(allFactories, CreateActorPrimFactory.getInstance());
+    add(allFactories, ResolvePromiseNodeFactory.getInstance());
+    add(allFactories, ErrorPromiseNodeFactory.getInstance());
 
     return allFactories;
   }

--- a/src/som/vm/Primitives.java
+++ b/src/som/vm/Primitives.java
@@ -137,7 +137,7 @@ public class Primitives extends PrimitiveLoader<VM, ExpressionNode, SSymbol> {
       args[i] = new LocalArgumentReadNode(true, i + 1).initialize(source);
     }
 
-    ExpressionNode primNode = specializer.create(null, args, source, false);
+    ExpressionNode primNode = specializer.create(null, args, source, false, lang.getVM());
 
     String name = "vmMirror>>" + signature.toString();
 

--- a/src/som/vm/VmOptions.java
+++ b/src/som/vm/VmOptions.java
@@ -96,7 +96,7 @@ public class VmOptions {
     }
   }
 
-  public boolean configUsable() {
+  public boolean isConfigUsable() {
     if (!showUsage) {
       return true;
     }
@@ -118,6 +118,7 @@ public class VmOptions {
     Output.println("  --si-candidates        Enable the Super-instruction candidate tool");
     Output.println(
         "  --coveralls REPO_TOKEN Enable the Coverage tool and reporting to Coveralls.io");
+
     return false;
   }
 }

--- a/src/som/vmobjects/SObject.java
+++ b/src/som/vmobjects/SObject.java
@@ -81,11 +81,11 @@ public abstract class SObject extends SObjectWithClass {
       this.isValue = old.isValue;
     }
 
-    @CompilationFinal protected long primField1;
-    @CompilationFinal protected long primField2;
-    @CompilationFinal protected long primField3;
-    @CompilationFinal protected long primField4;
-    @CompilationFinal protected long primField5;
+    @CompilationFinal public long primField1;
+    @CompilationFinal public long primField2;
+    @CompilationFinal public long primField3;
+    @CompilationFinal public long primField4;
+    @CompilationFinal public long primField5;
 
     @CompilationFinal public Object field1;
     @CompilationFinal public Object field2;
@@ -114,17 +114,17 @@ public abstract class SObject extends SObjectWithClass {
   }
 
   public static final class SMutableObject extends SObject {
-    private long primField1;
-    private long primField2;
-    private long primField3;
-    private long primField4;
-    private long primField5;
+    public long primField1;
+    public long primField2;
+    public long primField3;
+    public long primField4;
+    public long primField5;
 
-    private Object field1;
-    private Object field2;
-    private Object field3;
-    private Object field4;
-    private Object field5;
+    public Object field1;
+    public Object field2;
+    public Object field3;
+    public Object field4;
+    public Object field5;
 
     // this field exists because HotSpot reorders fields, and we need to keep
     // the layouts in sync to avoid having to manage different offsets for

--- a/src/tools/ObjectBuffer.java
+++ b/src/tools/ObjectBuffer.java
@@ -3,6 +3,8 @@ package tools;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import com.oracle.truffle.api.CompilerDirectives;
+
 
 /**
  * Simple buffer class to efficiently record objects with minimal possible
@@ -128,6 +130,7 @@ public class ObjectBuffer<T> implements Iterable<T> {
     @Override
     public T next() {
       if (current == null || (current.next == null && currentIdx > lastIdxInLastEntry)) {
+        CompilerDirectives.transferToInterpreter();
         throw new NoSuchElementException();
       }
 

--- a/src/tools/SourceCoordinate.java
+++ b/src/tools/SourceCoordinate.java
@@ -51,6 +51,10 @@ public class SourceCoordinate {
       this.uri = uri;
     }
 
+    protected FullSourceCoordinate() {
+      this(null, 0, 0, 0, 0);
+    }
+
     @Override
     public int hashCode() {
       // ignore charIndex, not always set

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -93,7 +93,7 @@ public class TracingBackend {
   private static FrontendConnector front = null;
 
   private static long              collectedMemory = 0;
-  private static TraceWorkerThread workerThread    = new TraceWorkerThread();
+  private static TraceWorkerThread workerThread;
 
   static {
     if (VmSettings.MEMORY_TRACING) {
@@ -263,6 +263,10 @@ public class TracingBackend {
   }
 
   public static final long[] getStatistics() {
+    if (workerThread == null) {
+      return new long[] {0, 0};
+    }
+
     long[] stats = new long[] {workerThread.traceBytes, workerThread.externalBytes};
 
     workerThread.traceBytes = 0;
@@ -278,6 +282,7 @@ public class TracingBackend {
 
   public static void startTracingBackend() {
     // start worker thread for trace processing
+    workerThread = new TraceWorkerThread();
     workerThread.start();
   }
 
@@ -295,6 +300,10 @@ public class TracingBackend {
   }
 
   public static void waitForTrace() {
+    if (workerThread == null) {
+      return;
+    }
+
     workerThread.cont = false;
     try {
       workerThread.join(TRACE_TIMEOUT);

--- a/src/tools/debugger/FrontendConnector.java
+++ b/src/tools/debugger/FrontendConnector.java
@@ -267,7 +267,10 @@ public class FrontendConnector {
     log("[DEBUGGER] Waiting for debugger to connect.");
     try {
       messageSocket = clientConnected.get();
+      assert messageSocket != null;
+
       traceSocket = traceHandler.getConnection().get();
+      assert traceSocket != null;
     } catch (InterruptedException | ExecutionException ex) {
       throw new RuntimeException(ex);
     }

--- a/src/tools/debugger/RuntimeReflectionRegistration.java
+++ b/src/tools/debugger/RuntimeReflectionRegistration.java
@@ -1,0 +1,203 @@
+package tools.debugger;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
+
+import org.graalvm.nativeimage.Feature;
+import org.graalvm.nativeimage.RuntimeReflection;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.oracle.svm.core.annotate.AutomaticFeature;
+
+import tools.debugger.message.InitializationResponse;
+import tools.debugger.message.InitializeConnection;
+import tools.debugger.message.Message.IncommingMessage;
+import tools.debugger.message.Message.OutgoingMessage;
+import tools.debugger.message.ProgramInfoRequest;
+import tools.debugger.message.ProgramInfoResponse;
+import tools.debugger.message.ScopesRequest;
+import tools.debugger.message.ScopesResponse;
+import tools.debugger.message.SourceMessage;
+import tools.debugger.message.StackTraceRequest;
+import tools.debugger.message.StackTraceResponse;
+import tools.debugger.message.StepMessage;
+import tools.debugger.message.StoppedMessage;
+import tools.debugger.message.SymbolMessage;
+import tools.debugger.message.TraceDataRequest;
+import tools.debugger.message.UpdateBreakpoint;
+import tools.debugger.message.VariablesRequest;
+import tools.debugger.message.VariablesResponse;
+import tools.debugger.session.BreakpointInfo;
+import tools.debugger.session.LineBreakpoint;
+import tools.debugger.session.SectionBreakpoint;
+
+
+/**
+ * Registers classes that are necessary for Gson serialization/deserialization.
+ * The classes are registered with SubstrateVM, and also provided as JsonProcessor.
+ */
+@AutomaticFeature
+public class RuntimeReflectionRegistration implements Feature {
+
+  private static class ClassGroup {
+    private final Class<?> baseClass;
+    private final String   typeMarker;
+
+    private final boolean needInstantiation;
+
+    private final LinkedHashMap<String, Class<?>> relevantSubclasses;
+
+    ClassGroup(final Class<?> baseClass, final String typeMarker,
+        final boolean needInstantiation) {
+      this.baseClass = baseClass;
+      this.typeMarker = typeMarker;
+      this.needInstantiation = needInstantiation;
+      this.relevantSubclasses = new LinkedHashMap<>();
+    }
+
+    public void register(final Class<?> klass) {
+      relevantSubclasses.put(klass.getSimpleName(), klass);
+    }
+
+    public void register(final String name, final Class<?> klass) {
+      relevantSubclasses.put(name, klass);
+    }
+  }
+
+  private static final ClassGroup[] groups;
+
+  static {
+    ClassGroup outMsgs = new ClassGroup(OutgoingMessage.class, "type", false);
+    outMsgs.register("source", SourceMessage.class);
+    outMsgs.register(InitializationResponse.class);
+    outMsgs.register(StoppedMessage.class);
+    outMsgs.register(SymbolMessage.class);
+    outMsgs.register(StackTraceResponse.class);
+    outMsgs.register(ScopesResponse.class);
+    outMsgs.register(VariablesResponse.class);
+    outMsgs.register(ProgramInfoResponse.class);
+
+    ClassGroup inMsgs = new ClassGroup(IncommingMessage.class, "action", true);
+    inMsgs.register(InitializeConnection.class);
+    inMsgs.register("updateBreakpoint", UpdateBreakpoint.class);
+    inMsgs.register(StepMessage.class);
+    inMsgs.register(StackTraceRequest.class);
+    inMsgs.register(ScopesRequest.class);
+    inMsgs.register(VariablesRequest.class);
+    inMsgs.register(ProgramInfoRequest.class);
+    inMsgs.register(TraceDataRequest.class);
+
+    ClassGroup bps = new ClassGroup(BreakpointInfo.class, "type", true);
+    bps.register(LineBreakpoint.class);
+    bps.register(SectionBreakpoint.class);
+
+    groups = new ClassGroup[3];
+    groups[0] = outMsgs;
+    groups[1] = inMsgs;
+    groups[2] = bps;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public static Gson createJsonProcessor() {
+    GsonBuilder builder = new GsonBuilder();
+
+    for (ClassGroup group : groups) {
+      ClassHierarchyAdapterFactory<?> af =
+          new ClassHierarchyAdapterFactory<>(group.baseClass, group.typeMarker);
+
+      for (Entry<String, Class<?>> e : group.relevantSubclasses.entrySet()) {
+        af.register(e.getKey(), (Class) e.getValue());
+      }
+
+      builder.registerTypeAdapterFactory(af);
+    }
+
+    return builder.create();
+  }
+
+  private final HashSet<Class<?>> registeredClasses;
+
+  public RuntimeReflectionRegistration() {
+    registeredClasses = new HashSet<>();
+  }
+
+  public HashSet<Class<?>> getRegisteredClasses() {
+    return registeredClasses;
+  }
+
+  public void register(final Class<?> klass, final boolean instantiable,
+      final BeforeAnalysisAccess access) {
+    if (registeredClasses.contains(klass)) {
+      return;
+    }
+
+    registeredClasses.add(klass);
+
+    // In unit tests, access is null
+    if (access != null) {
+      if (instantiable && !Modifier.isAbstract(klass.getModifiers()) && !klass.isEnum()) {
+        RuntimeReflection.registerForReflectiveInstantiation(klass);
+      }
+      RuntimeReflection.register(klass);
+      RuntimeReflection.register(klass.getDeclaredConstructors());
+    }
+
+    Class<?> superClass = klass.getSuperclass();
+    if (isRelevant(superClass)) {
+      register(superClass, false, access);
+    }
+
+    Field[] fields = klass.getDeclaredFields();
+    if (access != null) {
+      RuntimeReflection.register(fields);
+    }
+
+    if (!klass.isEnum()) {
+      for (Field f : fields) {
+        Class<?> fieldType = f.getType();
+
+        if (isRelevant(fieldType)) {
+          register(fieldType, instantiable, access);
+          if (fieldType.isArray()) {
+            register(fieldType.getComponentType(), instantiable, access);
+          }
+        }
+      }
+    }
+  }
+
+  private boolean isRelevant(final Class<?> klass) {
+    if (klass == null || klass == Object.class || klass == Enum.class || klass == URI.class) {
+      return false;
+    }
+
+    if (klass.isPrimitive() || klass.isArray() && klass.getComponentType().isPrimitive()) {
+      return false;
+    }
+
+    return !isJavaLang(klass);
+  }
+
+  private boolean isJavaLang(final Class<?> klass) {
+    if (klass.isArray()) {
+      return isJavaLang(klass.getComponentType());
+    }
+    return klass.getPackage() != null && "java.lang".equals(klass.getPackage().getName());
+  }
+
+  @Override
+  public void beforeAnalysis(final BeforeAnalysisAccess access) {
+    for (ClassGroup group : groups) {
+      register(group.baseClass, group.needInstantiation, access);
+
+      for (Class<?> klass : group.relevantSubclasses.values()) {
+        register(klass, group.needInstantiation, access);
+      }
+    }
+  }
+}

--- a/src/tools/debugger/WebDebugger.java
+++ b/src/tools/debugger/WebDebugger.java
@@ -9,7 +9,6 @@ import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.Instrument;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.InstrumentInfo;
 import com.oracle.truffle.api.TruffleLanguage;
@@ -30,28 +29,7 @@ import tools.SourceCoordinate;
 import tools.TraceData;
 import tools.concurrency.TracingActivityThread;
 import tools.debugger.frontend.Suspension;
-import tools.debugger.message.InitializationResponse;
-import tools.debugger.message.InitializeConnection;
-import tools.debugger.message.Message.IncommingMessage;
-import tools.debugger.message.Message.OutgoingMessage;
-import tools.debugger.message.ProgramInfoRequest;
-import tools.debugger.message.ProgramInfoResponse;
-import tools.debugger.message.ScopesRequest;
-import tools.debugger.message.ScopesResponse;
-import tools.debugger.message.SourceMessage;
-import tools.debugger.message.StackTraceRequest;
-import tools.debugger.message.StackTraceResponse;
-import tools.debugger.message.StepMessage;
-import tools.debugger.message.StoppedMessage;
-import tools.debugger.message.SymbolMessage;
-import tools.debugger.message.TraceDataRequest;
-import tools.debugger.message.UpdateBreakpoint;
-import tools.debugger.message.VariablesRequest;
-import tools.debugger.message.VariablesResponse;
-import tools.debugger.session.BreakpointInfo;
 import tools.debugger.session.Breakpoints;
-import tools.debugger.session.LineBreakpoint;
-import tools.debugger.session.SectionBreakpoint;
 
 
 /**
@@ -191,8 +169,7 @@ public class WebDebugger extends TruffleInstrument implements SuspendedCallback 
     assert vm != null;
     this.vm = vm;
     breakpoints = new Breakpoints(dbg, this);
-    connector = new FrontendConnector(breakpoints, instrumenter, this,
-        createJsonProcessor());
+    connector = new FrontendConnector(breakpoints, instrumenter, this, jsonProcessor);
     connector.awaitClient();
   }
 
@@ -200,36 +177,5 @@ public class WebDebugger extends TruffleInstrument implements SuspendedCallback 
     return breakpoints;
   }
 
-  public static Gson createJsonProcessor() {
-    ClassHierarchyAdapterFactory<OutgoingMessage> outMsgAF =
-        new ClassHierarchyAdapterFactory<>(OutgoingMessage.class, "type");
-    outMsgAF.register("source", SourceMessage.class);
-    outMsgAF.register(InitializationResponse.class);
-    outMsgAF.register(StoppedMessage.class);
-    outMsgAF.register(SymbolMessage.class);
-    outMsgAF.register(StackTraceResponse.class);
-    outMsgAF.register(ScopesResponse.class);
-    outMsgAF.register(VariablesResponse.class);
-    outMsgAF.register(ProgramInfoResponse.class);
-
-    ClassHierarchyAdapterFactory<IncommingMessage> inMsgAF =
-        new ClassHierarchyAdapterFactory<>(IncommingMessage.class, "action");
-    inMsgAF.register(InitializeConnection.class);
-    inMsgAF.register("updateBreakpoint", UpdateBreakpoint.class);
-    inMsgAF.register(StepMessage.class);
-    inMsgAF.register(StackTraceRequest.class);
-    inMsgAF.register(ScopesRequest.class);
-    inMsgAF.register(VariablesRequest.class);
-    inMsgAF.register(ProgramInfoRequest.class);
-    inMsgAF.register(TraceDataRequest.class);
-
-    ClassHierarchyAdapterFactory<BreakpointInfo> breakpointAF =
-        new ClassHierarchyAdapterFactory<>(BreakpointInfo.class, "type");
-    breakpointAF.register(LineBreakpoint.class);
-    breakpointAF.register(SectionBreakpoint.class);
-
-    return new GsonBuilder().registerTypeAdapterFactory(outMsgAF)
-                            .registerTypeAdapterFactory(inMsgAF)
-                            .registerTypeAdapterFactory(breakpointAF).create();
-  }
+  private static Gson jsonProcessor = RuntimeReflectionRegistration.createJsonProcessor();
 }

--- a/src/tools/debugger/WebResourceHandler.java
+++ b/src/tools/debugger/WebResourceHandler.java
@@ -10,6 +10,7 @@ import java.nio.charset.Charset;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
+import som.Output;
 import som.vm.NotYetImplementedException;
 
 
@@ -24,7 +25,17 @@ class WebResourceHandler implements HttpHandler {
 
   @Override
   public void handle(final HttpExchange exchange) throws IOException {
-    String rootFolder = System.getProperty("som.tools") + "/kompos";
+    String toolsFolder = System.getProperty("som.tools");
+    if (toolsFolder == null) {
+      Output.errorPrintln(
+          "The som.tools property with the path to the tools folder is not set. "
+              + "It should be set, for instance with -Dsom.tools=/my/path");
+      exchange.sendResponseHeaders(500, 0);
+      exchange.close();
+      return;
+    }
+
+    String rootFolder = toolsFolder + "/kompos";
 
     String requestedFile = exchange.getRequestURI().getPath();
     if ("/".equals(requestedFile)) {

--- a/src/tools/debugger/WebSocketHandler.java
+++ b/src/tools/debugger/WebSocketHandler.java
@@ -70,6 +70,7 @@ public abstract class WebSocketHandler extends WebSocketServer {
 
     @Override
     public void onMessage(final WebSocket conn, final String message) {
+      assert conn != null;
       try {
         IncommingMessage respond = gson.fromJson(message, IncommingMessage.class);
         respond.process(connector, conn);

--- a/src/tools/debugger/message/InitializeConnection.java
+++ b/src/tools/debugger/message/InitializeConnection.java
@@ -8,10 +8,15 @@ import tools.debugger.session.BreakpointInfo;
 
 
 public class InitializeConnection extends IncommingMessage {
+
   private final BreakpointInfo[] breakpoints;
 
   public InitializeConnection(final BreakpointInfo[] breakpoints) {
     this.breakpoints = breakpoints;
+  }
+
+  InitializeConnection() {
+    this.breakpoints = null;
   }
 
   public BreakpointInfo[] getBreakpoints() {
@@ -20,8 +25,10 @@ public class InitializeConnection extends IncommingMessage {
 
   @Override
   public void process(final FrontendConnector connector, final WebSocket conn) {
-    for (BreakpointInfo bp : breakpoints) {
-      bp.registerOrUpdate(connector);
+    if (breakpoints != null) {
+      for (BreakpointInfo bp : breakpoints) {
+        bp.registerOrUpdate(connector);
+      }
     }
     connector.completeConnection(conn);
   }

--- a/src/tools/debugger/message/Message.java
+++ b/src/tools/debugger/message/Message.java
@@ -14,10 +14,14 @@ public abstract class Message {
    * With id to connect request and response.
    */
   public abstract static class Request extends IncommingMessage {
-    protected int requestId;
+    protected final int requestId;
 
     public Request(final int requestId) {
       this.requestId = requestId;
+    }
+
+    protected Request() {
+      this.requestId = 0;
     }
   }
 

--- a/src/tools/debugger/message/ScopesRequest.java
+++ b/src/tools/debugger/message/ScopesRequest.java
@@ -15,6 +15,10 @@ public final class ScopesRequest extends Request {
     this.frameId = frameId;
   }
 
+  ScopesRequest() {
+    frameId = 0;
+  }
+
   @Override
   public void process(final FrontendConnector connector, final WebSocket conn) {
     Suspension suspension = connector.getSuspensionForGlobalId(frameId);

--- a/src/tools/debugger/message/SourceMessage.java
+++ b/src/tools/debugger/message/SourceMessage.java
@@ -41,7 +41,7 @@ public class SourceMessage extends OutgoingMessage {
     }
   }
 
-  protected static class MethodData {
+  private static class MethodData {
     private final String             name;
     private final SourceCoordinate[] definition;
     private final SourceCoordinate   sourceSection;

--- a/src/tools/debugger/message/StackTraceRequest.java
+++ b/src/tools/debugger/message/StackTraceRequest.java
@@ -9,17 +9,17 @@ import tools.debugger.message.Message.Request;
 
 
 public class StackTraceRequest extends Request {
-  private long activityId;
+  private final long activityId;
 
   /**
    * Index of the first frame to return.
    */
-  private int startFrame;
+  private final int startFrame;
 
   /**
    * Maximum number of frames to return, or all for 0.
    */
-  private int levels;
+  private final int levels;
 
   public StackTraceRequest(final long activityId, final int startFrame,
       final int levels, final int requestId) {
@@ -28,6 +28,12 @@ public class StackTraceRequest extends Request {
     this.activityId = activityId;
     this.startFrame = startFrame;
     this.levels = levels;
+  }
+
+  StackTraceRequest() {
+    activityId = 0;
+    startFrame = 0;
+    levels = 0;
   }
 
   @Override

--- a/src/tools/debugger/message/StackTraceResponse.java
+++ b/src/tools/debugger/message/StackTraceResponse.java
@@ -47,7 +47,7 @@ public final class StackTraceResponse extends Response {
     }
   }
 
-  static class StackFrame {
+  private static class StackFrame {
     /**
      * Id for the frame, unique across all threads.
      */

--- a/src/tools/debugger/message/StepMessage.java
+++ b/src/tools/debugger/message/StepMessage.java
@@ -15,7 +15,7 @@ public class StepMessage extends IncommingMessage {
   /**
    * Note: meant for serialization.
    */
-  public StepMessage() {
+  StepMessage() {
     activityId = -1;
     step = null;
   }

--- a/src/tools/debugger/message/UpdateBreakpoint.java
+++ b/src/tools/debugger/message/UpdateBreakpoint.java
@@ -14,6 +14,10 @@ public class UpdateBreakpoint extends IncommingMessage {
     this.breakpoint = breakpoint;
   }
 
+  UpdateBreakpoint() {
+    this.breakpoint = null;
+  }
+
   public BreakpointInfo getBreakpoint() {
     return breakpoint;
   }

--- a/src/tools/debugger/message/UpdateSourceSections.java
+++ b/src/tools/debugger/message/UpdateSourceSections.java
@@ -21,11 +21,11 @@ public class UpdateSourceSections extends OutgoingMessage {
     this.updates = updates;
   }
 
-  public static class SourceInfo {
+  private static final class SourceInfo {
     private final String                   sourceUri;
     private final TaggedSourceCoordinate[] sections;
 
-    public SourceInfo(final String sourceUri,
+    private SourceInfo(final String sourceUri,
         final TaggedSourceCoordinate[] sections) {
       this.sourceUri = sourceUri;
       this.sections = sections;

--- a/src/tools/debugger/message/VariablesRequest.java
+++ b/src/tools/debugger/message/VariablesRequest.java
@@ -11,7 +11,6 @@ import tools.debugger.message.Message.Request;
 
 
 public final class VariablesRequest extends Request {
-
   private final long variablesReference;
 
   private final FilterType filter;
@@ -33,6 +32,13 @@ public final class VariablesRequest extends Request {
     this.filter = filter;
     this.start = start;
     this.count = count;
+  }
+
+  VariablesRequest() {
+    variablesReference = 0;
+    filter = null;
+    start = null;
+    count = null;
   }
 
   @Override

--- a/src/tools/dym/nodes/OperationProfilingNode.java
+++ b/src/tools/dym/nodes/OperationProfilingNode.java
@@ -1,5 +1,6 @@
 package tools.dym.nodes;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.EventContext;
 import com.oracle.truffle.api.nodes.Node;
@@ -47,6 +48,7 @@ public final class OperationProfilingNode extends CountingNode<OperationProfile>
     if (e instanceof ReturnException) {
       counter.profileReturn(((ReturnException) e).result());
     } else {
+      CompilerDirectives.transferToInterpreter();
       throw new NotYetImplementedException();
     }
   }

--- a/src/tools/dym/profiles/OperationProfile.java
+++ b/src/tools/dym/profiles/OperationProfile.java
@@ -34,6 +34,7 @@ public final class OperationProfile extends Counter {
         new Arguments(args), 1, Integer::sum);
   }
 
+  @TruffleBoundary
   public void enterMainNode() {
     argumentsForExecutions.push(new Object[numArgsAndResult]);
   }

--- a/src/tools/superinstructions/TypeCounter.java
+++ b/src/tools/superinstructions/TypeCounter.java
@@ -3,6 +3,7 @@ package tools.superinstructions;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.source.SourceSection;
 
 
@@ -23,6 +24,7 @@ final class TypeCounter {
     return source;
   }
 
+  @TruffleBoundary
   public void recordType(final Object result) {
     Class<?> type = result.getClass();
     activations.merge(type, 1L, Long::sum);

--- a/src/tools/superinstructions/TypeCountingNode.java
+++ b/src/tools/superinstructions/TypeCountingNode.java
@@ -1,5 +1,6 @@
 package tools.superinstructions;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.ExecutionEventNode;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
@@ -37,6 +38,7 @@ final class TypeCountingNode extends ExecutionEventNode {
       // If the SOMns code throws an exception, we should just ignore this.
       return;
     } else {
+      CompilerDirectives.transferToInterpreter();
       throw new NotYetImplementedException();
     }
   }

--- a/tests/java/debugger/JsonTests.java
+++ b/tests/java/debugger/JsonTests.java
@@ -16,7 +16,7 @@ import com.google.gson.Gson;
 
 import tools.SourceCoordinate;
 import tools.SourceCoordinate.FullSourceCoordinate;
-import tools.debugger.WebDebugger;
+import tools.debugger.RuntimeReflectionRegistration;
 import tools.debugger.entities.ActivityType;
 import tools.debugger.entities.BreakpointType;
 import tools.debugger.entities.DynamicScopeType;
@@ -37,7 +37,7 @@ import tools.debugger.session.SectionBreakpoint;
 
 
 public class JsonTests {
-  private final Gson gson = WebDebugger.createJsonProcessor();
+  private final Gson gson = RuntimeReflectionRegistration.createJsonProcessor();
 
   private static final String               FULL_COORD     =
       "{\"uri\":\"file:/test\",\"startLine\":2,\"startColumn\":3,\"charLength\":55}";

--- a/tests/java/debugger/ReflectionRegistrationTests.java
+++ b/tests/java/debugger/ReflectionRegistrationTests.java
@@ -1,0 +1,22 @@
+package debugger;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+
+import org.junit.Test;
+
+import tools.debugger.RuntimeReflectionRegistration;
+
+
+public class ReflectionRegistrationTests {
+
+  @Test
+  public void runtimeRegistration() {
+    RuntimeReflectionRegistration rrr = new RuntimeReflectionRegistration();
+    rrr.beforeAnalysis(null);
+
+    HashSet<Class<?>> registeredClasses = rrr.getRegisteredClasses();
+    assertEquals(56, registeredClasses.size());
+  }
+}

--- a/tests/java/som/tests/BasicInterpreterTests.java
+++ b/tests/java/som/tests/BasicInterpreterTests.java
@@ -41,6 +41,7 @@ import org.junit.runners.Parameterized.Parameters;
 import som.Launcher;
 import som.VM;
 import som.interpreter.Types;
+import som.interpreter.objectstorage.StorageAccessor;
 import som.vmobjects.SClass;
 import som.vmobjects.SSymbol;
 
@@ -179,6 +180,10 @@ public class BasicInterpreterTests {
   private final Class<?> resultType;
 
   private final String ignoreForParallelExecutionReason;
+
+  static {
+    StorageAccessor.initAccessors();
+  }
 
   public BasicInterpreterTests(final String testClass,
       final String testSelector,

--- a/tests/java/som/tests/SomTests.java
+++ b/tests/java/som/tests/SomTests.java
@@ -37,6 +37,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import som.Launcher;
 import som.VM;
+import som.interpreter.objectstorage.StorageAccessor;
 
 
 @RunWith(Parameterized.class)
@@ -74,6 +75,10 @@ public class SomTests {
 
   private final String testName;
   private final String ignoreReason;
+
+  static {
+    StorageAccessor.initAccessors();
+  }
 
   public SomTests(final String testName, final String ignoreReason) {
     this.testName = testName;


### PR DESCRIPTION
These changes allow us to use SubstrateVM.
Thus, SOMns is ahead-of-time compiled, and only user code itself is subject to just-in-time compilation.

This has a major impact on startup time:

```
$ time ./som core-lib/Hello.ns
Hello World!
2.41s user 0.38s system 123% cpu 2.256 total

$ ./som-native core-lib/Hello.ns
Hello World!
0.06s user 0.03s system 72% cpu 0.121 total
```

The main changes necessary are:
 - move all use of reflection to image-generation time
 - ensure that we use SubstrateVM-compatible offsets for unsafe field accesses
