### PR TITLE
Ensure correct node parent in eager primitives, and minor cleanup

### DIFF
--- a/src/som/interpreter/nodes/MessageSendNode.java
+++ b/src/som/interpreter/nodes/MessageSendNode.java
@@ -43,7 +43,7 @@ public final class MessageSendNode {
       if (specializer.noWrapper()) {
         return newNode;
       } else {
-        return newNode.wrapInEagerWrapper(newNode, selector, arguments);
+        return newNode.wrapInEagerWrapper(selector, arguments);
       }
     } else {
       return new UninitializedMessageSendNode(selector, arguments, source, vm);
@@ -206,7 +206,7 @@ public final class MessageSendNode {
       VM.insertInstrumentationWrapper(this);
       assert prim.getSourceSection() != null;
 
-      PreevaluatedExpression result = replace(prim.wrapInEagerWrapper(prim, selector, argumentNodes));
+      PreevaluatedExpression result = replace(prim.wrapInEagerWrapper(selector, argumentNodes));
 
       VM.insertInstrumentationWrapper((Node) result);
 

--- a/src/som/interpreter/nodes/MessageSendNode.java
+++ b/src/som/interpreter/nodes/MessageSendNode.java
@@ -113,10 +113,6 @@ public final class MessageSendNode {
       return super.isTaggedWith(tag);
     }
 
-    public boolean isSpecialSend() {
-      return unwrapIfNecessary(argumentNodes[0]) instanceof ISpecialSend;
-    }
-
     @Override
     public Object executeGeneric(final VirtualFrame frame) {
       Object[] arguments = evaluateArguments(frame);
@@ -253,11 +249,6 @@ public final class MessageSendNode {
     protected UninitializedSymbolSendNode(final SSymbol selector,
         final SourceSection source, final VM vm) {
       super(selector, new ExpressionNode[0], source, vm);
-    }
-
-    @Override
-    public boolean isSpecialSend() {
-      return false;
     }
 
     @Override

--- a/src/som/interpreter/nodes/MessageSendNode.java
+++ b/src/som/interpreter/nodes/MessageSendNode.java
@@ -179,8 +179,9 @@ public final class MessageSendNode {
 
       synchronized (getLock()) {
         if (specializer != null) {
-          EagerlySpecializableNode newNode = specializer.create(arguments, argumentNodes, getSourceSection(), !specializer.noWrapper());
-          if (specializer.noWrapper()) {
+          boolean noWrapper = specializer.noWrapper();
+          EagerlySpecializableNode newNode = specializer.create(arguments, argumentNodes, sourceSection, !noWrapper);
+          if (noWrapper) {
             return replace(newNode);
           } else {
             return makeEagerPrim(newNode);

--- a/src/som/interpreter/nodes/nary/BinaryExpressionNode.java
+++ b/src/som/interpreter/nodes/nary/BinaryExpressionNode.java
@@ -38,10 +38,9 @@ public abstract class BinaryExpressionNode extends EagerlySpecializableNode {
   }
 
   @Override
-  public EagerPrimitive wrapInEagerWrapper(
-      final EagerlySpecializableNode prim, final SSymbol selector,
+  public EagerPrimitive wrapInEagerWrapper(final SSymbol selector,
       final ExpressionNode[] arguments) {
-    return new EagerBinaryPrimitiveNode(getSourceSection(), selector,
+    return new EagerBinaryPrimitiveNode(sourceSection, selector,
         arguments[0], arguments[1], this);
   }
 }

--- a/src/som/interpreter/nodes/nary/EagerBinaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerBinaryPrimitiveNode.java
@@ -30,9 +30,9 @@ public final class EagerBinaryPrimitiveNode extends EagerPrimitive {
       final BinaryExpressionNode primitive) {
     super(source);
     assert source == primitive.getSourceSection();
-    this.receiver  = receiver;
-    this.argument  = argument;
-    this.primitive = primitive;
+    this.receiver  = insert(receiver);
+    this.argument  = insert(argument);
+    this.primitive = insert(primitive);
     this.selector = selector;
   }
 

--- a/src/som/interpreter/nodes/nary/EagerTernaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerTernaryPrimitiveNode.java
@@ -34,10 +34,10 @@ public final class EagerTernaryPrimitiveNode extends EagerPrimitive {
       final TernaryExpressionNode primitive) {
     super(source);
     assert source == primitive.getSourceSection();
-    this.receiver  = receiver;
-    this.argument1 = argument1;
-    this.argument2 = argument2;
-    this.primitive = primitive;
+    this.receiver  = insert(receiver);
+    this.argument1 = insert(argument1);
+    this.argument2 = insert(argument2);
+    this.primitive = insert(primitive);
     this.selector = selector;
   }
 

--- a/src/som/interpreter/nodes/nary/EagerUnaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerUnaryPrimitiveNode.java
@@ -26,8 +26,8 @@ public final class EagerUnaryPrimitiveNode extends EagerPrimitive {
       final ExpressionNode receiver, final UnaryExpressionNode primitive) {
     super(source);
     assert source == primitive.getSourceSection();
-    this.receiver  = receiver;
-    this.primitive = primitive;
+    this.receiver  = insert(receiver);
+    this.primitive = insert(primitive);
     this.selector = selector;
   }
 

--- a/src/som/interpreter/nodes/nary/EagerlySpecializableNode.java
+++ b/src/som/interpreter/nodes/nary/EagerlySpecializableNode.java
@@ -56,6 +56,6 @@ public abstract class EagerlySpecializableNode extends ExprWithTagsNode
   /**
    * Create an eager primitive wrapper, which wraps this node.
    */
-  public abstract EagerPrimitive wrapInEagerWrapper(
-      EagerlySpecializableNode prim, SSymbol selector, ExpressionNode[] arguments);
+  public abstract EagerPrimitive wrapInEagerWrapper(SSymbol selector,
+      ExpressionNode[] arguments);
 }

--- a/src/som/interpreter/nodes/nary/QuaternaryExpressionNode.java
+++ b/src/som/interpreter/nodes/nary/QuaternaryExpressionNode.java
@@ -40,8 +40,7 @@ public abstract class QuaternaryExpressionNode extends EagerlySpecializableNode 
   }
 
   @Override
-  public EagerPrimitive wrapInEagerWrapper(
-      final EagerlySpecializableNode prim, final SSymbol selector,
+  public EagerPrimitive wrapInEagerWrapper(final SSymbol selector,
       final ExpressionNode[] arguments) {
     throw new NotYetImplementedException(); // wasn't needed so far
   }

--- a/src/som/interpreter/nodes/nary/TernaryExpressionNode.java
+++ b/src/som/interpreter/nodes/nary/TernaryExpressionNode.java
@@ -39,8 +39,7 @@ public abstract class TernaryExpressionNode extends EagerlySpecializableNode {
   }
 
   @Override
-  public EagerPrimitive wrapInEagerWrapper(
-      final EagerlySpecializableNode prim, final SSymbol selector,
+  public EagerPrimitive wrapInEagerWrapper(final SSymbol selector,
       final ExpressionNode[] arguments) {
     return new EagerTernaryPrimitiveNode(getSourceSection(), selector,
         arguments[0], arguments[1], arguments[2], this);

--- a/src/som/interpreter/nodes/nary/UnaryExpressionNode.java
+++ b/src/som/interpreter/nodes/nary/UnaryExpressionNode.java
@@ -34,8 +34,7 @@ public abstract class UnaryExpressionNode extends EagerlySpecializableNode {
   }
 
   @Override
-  public EagerPrimitive wrapInEagerWrapper(
-      final EagerlySpecializableNode prim, final SSymbol selector,
+  public EagerPrimitive wrapInEagerWrapper(final SSymbol selector,
       final ExpressionNode[] arguments) {
     return new EagerUnaryPrimitiveNode(getSourceSection(), selector,
         arguments[0], this);


### PR DESCRIPTION
In TruffleSOM, I found that eager primitive nodes didn't have the correct parent.
To be sure, I am using now `insert(.)` to have the parent set correctly in all cases.
This was not a problem in SOMns, as far as I am aware, because some specialization patterns did not occur for eager primitive children.