### PR TITLE
Implement message cascade

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ the specifications are as follows:
 
  - local variables in methods do not yet support the full slotDeclartion style
 
- - as in SOM method chains are not supported
-
  - as in SOM, blocks can only have 3 arguments (counting `self`)
 
 Obtaining and Running SOMns

--- a/core-lib/TestSuite/LanguageTests.som
+++ b/core-lib/TestSuite/LanguageTests.som
@@ -739,4 +739,61 @@ class LanguageTests usingPlatform: platform testFramework: minitest = Value (
       assert: o is: self.
     )
   ) : ( TEST_CONTEXT = () )
+
+  public class MessageCascades = TestContext ()(
+    class Cnt = (| public v ::= 0. |)(
+      public inc = ( v:: v + 1 )
+    )
+
+    class Setters = (|
+      public slot1
+      public slot2
+    |)(
+	    public runCascadeForEffect = (
+        self slot1: 23;
+             slot2: 42
+      )
+
+      public runCascadeForValue = (
+        ^ self slot1;
+               slot2
+      )
+    )
+
+    public testCascadeOnFieldRead = (
+      | c = Cnt new. |
+      assert: c v equals: 0.
+      c inc; inc; inc.
+      assert: c v equals: 3.
+    )
+
+    public testCascadeOnMultipleSends = (
+      | c = Cnt new. |
+      assert: c v equals: 0.
+      c inc inc inc;
+        inc;
+        inc;
+        inc.
+      assert: c v equals: 6.
+    )
+
+    public testKeywordCascade = (
+      | arr = Array new: 3. |
+
+      arr at: 1 put: 2;
+          at: 2 put: 3;
+          at: 3 put: 4.
+      assert: (arr at: 1) equals: 2.
+      assert: (arr at: 2) equals: 3.
+      assert: (arr at: 3) equals: 4.
+    )
+
+    public testSetter = (
+      | setter = Setters new. |
+      setter runCascadeForEffect.
+      assert: setter slot1 equals: 23.
+      assert: setter slot2 equals: 42.
+      assert: setter runCascadeForValue equals: 42.
+    )
+  ) : ( TEST_CONTEXT = () )
 )

--- a/src/som/compiler/Lexer.java
+++ b/src/som/compiler/Lexer.java
@@ -182,6 +182,8 @@ public final class Lexer {
     } else if (currentChar() == '*' && nextChar() == ')') {
       state.incPtr(2);
       state.set(Symbol.EndComment, '\0', "*)");
+    } else if (currentChar() == ';') {
+      match(Symbol.Semicolon);
     } else if (currentChar() == ')') {
       match(Symbol.EndTerm);
     } else if (currentChar() == '#') {

--- a/src/som/compiler/MethodBuilder.java
+++ b/src/som/compiler/MethodBuilder.java
@@ -85,6 +85,8 @@ public final class MethodBuilder {
 
   private final List<SInvokable> embeddedBlockMethods;
 
+  private int cascadeId;
+
 
   public MethodBuilder(final MixinBuilder holder, final MixinScope clsScope) {
     this(holder, clsScope, null, false, holder.getLanguage());
@@ -337,6 +339,11 @@ public final class MethodBuilder {
 
     Argument argument = new Argument(arg, arguments.size(), source);
     arguments.put(arg, argument);
+  }
+
+  public Local addMessageCascadeTemp(final SourceSection source) throws MethodDefinitionError {
+    cascadeId += 1;
+    return addLocal("$cascadeTmp" + cascadeId, true, source);
   }
 
   public Local addLocal(final String name, final boolean immutable,

--- a/src/som/compiler/Symbol.java
+++ b/src/som/compiler/Symbol.java
@@ -26,7 +26,7 @@ package som.compiler;
 
 enum Symbol {
   NONE, Numeral, Not, And, Or, Star, Div, Mod, Plus, Minus, Equal, More, Less,
-  Comma, At, Per, NewBlock, EndBlock, LCurly, RCurly, Colon, Period, Exit, NewTerm,
+  Comma, At, Per, NewBlock, EndBlock, LCurly, RCurly, Colon, Semicolon, Period, Exit, NewTerm,
   EndTerm, Pound, STString,
   BeginComment, EndComment, SlotMutableAssign, EventualSend, MixinOperator,
   Identifier, Keyword, SetterKeyword,


### PR DESCRIPTION
This change introduces support for Smalltalk message cascades, i.e., syntax to send multiple messages to the same receiver by listing them with `;` as separator.

- add lexing of semicolon
- includes basic tests
- uses a normal immutable local to store the receiver, should perhaps become an internal variable instead. Benefit of local is that we see it in the debugger

I decided against an implementation with a separate node, because it would require introducing an executeWithReceiver method, which seems a more substantial change than simply desugaring into existing constructs.
Replacing the lastReceiver is a bit of a hack, and requires the previous message to adopt its children during parsing. However, this seems to be a simpler solution than delaying the assembly of those expressions.