### PR TITLE
Avoid block splitting when not necessary

### DIFF
--- a/src/som/compiler/MethodBuilder.java
+++ b/src/som/compiler/MethodBuilder.java
@@ -76,6 +76,7 @@ public final class MethodBuilder {
   private boolean throwsNonLocalReturn;       // does directly or indirectly a non-local return
 
   private boolean accessesVariablesOfOuterScope;
+  private boolean accessesLocalOfOuterScope;
 
   private final LinkedHashMap<String, Argument> arguments = new LinkedHashMap<>();
   private final LinkedHashMap<String, Local>    locals    = new LinkedHashMap<>();
@@ -215,8 +216,8 @@ public final class MethodBuilder {
     ctx.needsToCatchNonLocalReturn = true;
   }
 
-  public boolean accessesVariablesOfOuterScope() {
-    return accessesVariablesOfOuterScope;
+  public boolean accessesLocalOfOuterScope() {
+    return accessesLocalOfOuterScope;
   }
 
   public boolean requiresContext() {
@@ -421,6 +422,9 @@ public final class MethodBuilder {
       Variable outerVar = outerBuilder.getVariable(varName);
       if (outerVar != null) {
         accessesVariablesOfOuterScope = true;
+        if (outerVar instanceof Local) {
+          accessesLocalOfOuterScope = true;
+        }
       }
       return outerVar;
     }
@@ -530,6 +534,7 @@ public final class MethodBuilder {
       Local outerLocal = outerBuilder.getLocal(varName);
       if (outerLocal != null) {
         accessesVariablesOfOuterScope = true;
+        accessesLocalOfOuterScope = true;
       }
       return outerLocal;
     }

--- a/src/som/compiler/MethodBuilder.java
+++ b/src/som/compiler/MethodBuilder.java
@@ -247,7 +247,7 @@ public final class MethodBuilder {
       final ExpressionNode body, final AccessModifier accessModifier,
       final SourceSection sourceSection) {
     MethodScope splitScope = currentScope.split();
-    ExpressionNode splitBody = InliningVisitor.doInline(body, splitScope, 0);
+    ExpressionNode splitBody = InliningVisitor.doInline(body, splitScope, 0, false);
     Method truffleMeth = assembleInvokable(splitBody, splitScope, sourceSection);
 
     // TODO: not sure whether it is safe to use the embeddedBlockMethods here,

--- a/src/som/compiler/MethodBuilder.java
+++ b/src/som/compiler/MethodBuilder.java
@@ -215,6 +215,10 @@ public final class MethodBuilder {
     ctx.needsToCatchNonLocalReturn = true;
   }
 
+  public boolean accessesVariablesOfOuterScope() {
+    return accessesVariablesOfOuterScope;
+  }
+
   public boolean requiresContext() {
     return throwsNonLocalReturn || accessesVariablesOfOuterScope;
   }

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -1148,10 +1148,10 @@ public class Parser {
 
         if (bgenc.requiresContext() || VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
           return new BlockNodeWithContext(blockMethod,
-              bgenc.accessesVariablesOfOuterScope(), lastMethodsSourceSection);
+              bgenc.accessesLocalOfOuterScope(), lastMethodsSourceSection);
         } else {
           return new BlockNode(blockMethod,
-              bgenc.accessesVariablesOfOuterScope(), lastMethodsSourceSection);
+              bgenc.accessesLocalOfOuterScope(), lastMethodsSourceSection);
         }
       }
       case LCurly: {

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -1147,9 +1147,11 @@ public class Parser {
         builder.addEmbeddedBlockMethod(blockMethod);
 
         if (bgenc.requiresContext() || VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
-          return new BlockNodeWithContext(blockMethod, lastMethodsSourceSection);
+          return new BlockNodeWithContext(blockMethod,
+              bgenc.accessesVariablesOfOuterScope(), lastMethodsSourceSection);
         } else {
-          return new BlockNode(blockMethod, lastMethodsSourceSection);
+          return new BlockNode(blockMethod,
+              bgenc.accessesVariablesOfOuterScope(), lastMethodsSourceSection);
         }
       }
       case LCurly: {

--- a/src/som/interpreter/InliningVisitor.java
+++ b/src/som/interpreter/InliningVisitor.java
@@ -18,14 +18,16 @@ public final class InliningVisitor implements NodeVisitor {
 
   public static ExpressionNode doInline(
       final ExpressionNode body,
-      final MethodScope inlinedCurrentScope, final int appliesTo) {
+      final MethodScope inlinedCurrentScope, final int appliesTo,
+      final boolean someOuterScopeIsMerged) {
     ExpressionNode inlinedBody = NodeUtil.cloneNode(body);
 
     return NodeVisitorUtil.applyVisitor(inlinedBody,
-        new InliningVisitor(inlinedCurrentScope, appliesTo));
+        new InliningVisitor(inlinedCurrentScope, appliesTo, someOuterScopeIsMerged));
   }
 
   protected final MethodScope scope;
+  protected final boolean someOuterScopeIsMerged;
 
   /**
    * This inliner refers to the block at the contextLevel given here, and
@@ -34,9 +36,15 @@ public final class InliningVisitor implements NodeVisitor {
    */
   public final int contextLevel;
 
-  private InliningVisitor(final MethodScope scope, final int appliesTo) {
+  private InliningVisitor(final MethodScope scope, final int appliesTo,
+      final boolean someOuterScopeIsMerged) {
     this.scope = scope;
     this.contextLevel = appliesTo;
+    this.someOuterScopeIsMerged = someOuterScopeIsMerged;
+  }
+
+  public boolean someOuterScopeIsMerged() {
+    return someOuterScopeIsMerged;
   }
 
   public static final class ScopeElement {

--- a/src/som/interpreter/Method.java
+++ b/src/som/interpreter/Method.java
@@ -84,7 +84,7 @@ public final class Method extends Invokable {
   public ExpressionNode inline(final MethodBuilder builder, final SInvokable outer) {
     builder.mergeIntoScope(methodScope, outer);
     return InliningVisitor.doInline(
-        uninitializedBody, builder.getCurrentMethodScope(), 0);
+        uninitializedBody, builder.getCurrentMethodScope(), 0, true);
   }
 
   @Override
@@ -96,9 +96,10 @@ public final class Method extends Invokable {
   }
 
   public Method cloneAndAdaptAfterScopeChange(final MethodScope adaptedScope,
-      final int appliesTo, final boolean cloneAdaptedAsUninitialized) {
+      final int appliesTo, final boolean cloneAdaptedAsUninitialized,
+      final boolean someOuterScopeIsMerged) {
     ExpressionNode adaptedBody = InliningVisitor.doInline(
-        uninitializedBody, adaptedScope, appliesTo);
+        uninitializedBody, adaptedScope, appliesTo, someOuterScopeIsMerged);
 
     ExpressionNode uninit;
     if (cloneAdaptedAsUninitialized) {
@@ -118,7 +119,7 @@ public final class Method extends Invokable {
     MethodScope splitScope = methodScope.split();
     assert methodScope != splitScope;
     assert splitScope.isFinalized();
-    return cloneAndAdaptAfterScopeChange(splitScope, 0, false);
+    return cloneAndAdaptAfterScopeChange(splitScope, 0, false, false);
   }
 
   @Override
@@ -127,7 +128,7 @@ public final class Method extends Invokable {
     assert !isAtomic : "We should only ask non-atomic invokables for their atomic version";
 
     MethodScope splitScope = methodScope.split();
-    ExpressionNode body = InliningVisitor.doInline(uninitializedBody, splitScope, 0);
+    ExpressionNode body = InliningVisitor.doInline(uninitializedBody, splitScope, 0, true);
     ExpressionNode uninit = NodeUtil.cloneNode(body);
 
     Method atomic = new Method(name, getSourceSection(), definition, body,

--- a/src/som/interpreter/SNodeFactory.java
+++ b/src/som/interpreter/SNodeFactory.java
@@ -17,12 +17,9 @@ import som.interpreter.nodes.ResolvingImplicitReceiverSend;
 import som.interpreter.nodes.ReturnNonLocalNode;
 import som.interpreter.nodes.ReturnNonLocalNode.CatchNonLocalReturnNode;
 import som.interpreter.nodes.SequenceNode;
-import som.interpreter.nodes.literals.BlockNode;
-import som.interpreter.nodes.literals.BlockNode.BlockNodeWithContext;
 import som.interpreter.nodes.literals.NilLiteralNode;
 import som.interpreter.objectstorage.InitializerFieldWrite;
 import som.interpreter.objectstorage.InitializerFieldWriteNodeGen;
-import som.vmobjects.SInvokable;
 import som.vmobjects.SSymbol;
 
 
@@ -50,15 +47,6 @@ public final class SNodeFactory {
       return expressions.get(0);
     }
     return new SequenceNode(expressions.toArray(new ExpressionNode[0]), source);
-  }
-
-  public static BlockNode createBlockNode(final SInvokable blockMethod,
-      final boolean withContext, final SourceSection source) {
-    if (withContext) {
-      return new BlockNodeWithContext(blockMethod, source);
-    } else {
-      return new BlockNode(blockMethod, source);
-    }
   }
 
   public static ExpressionNode createMessageSend(final SSymbol msg,

--- a/src/som/interpreter/nodes/literals/BlockNode.java
+++ b/src/som/interpreter/nodes/literals/BlockNode.java
@@ -104,10 +104,6 @@ public class BlockNode extends LiteralNode {
       super(blockMethod, needsAdjustmentOnScopeChange, source);
     }
 
-    public BlockNodeWithContext(final BlockNodeWithContext node) {
-      this(node.blockMethod, node.needsAdjustmentOnScopeChange, node.sourceSection);
-    }
-
     @Override
     public SBlock executeSBlock(final VirtualFrame frame) {
       return new SBlock(blockMethod, frame.materialize(), blockClass);

--- a/src/som/interpreter/nodes/literals/BlockNode.java
+++ b/src/som/interpreter/nodes/literals/BlockNode.java
@@ -76,11 +76,12 @@ public class BlockNode extends LiteralNode {
 
   @Override
   public void replaceAfterScopeChange(final InliningVisitor inliner) {
-    if (!needsAdjustmentOnScopeChange) { return; }
+    if (!needsAdjustmentOnScopeChange && !inliner.someOuterScopeIsMerged()) { return; }
 
     Method blockIvk = (Method) blockMethod.getInvokable();
     Method adapted = blockIvk.cloneAndAdaptAfterScopeChange(
-        inliner.getScope(blockIvk), inliner.contextLevel + 1, true);
+        inliner.getScope(blockIvk), inliner.contextLevel + 1, true,
+        inliner.someOuterScopeIsMerged());
     SInvokable adaptedIvk = new SInvokable(blockMethod.getSignature(),
         AccessModifier.BLOCK_METHOD,
         adapted, blockMethod.getEmbeddedBlocks());

--- a/src/som/interpreter/nodes/literals/BlockNode.java
+++ b/src/som/interpreter/nodes/literals/BlockNode.java
@@ -22,11 +22,13 @@ public class BlockNode extends LiteralNode {
 
   protected final SInvokable blockMethod;
   protected final SClass  blockClass;
+  protected final boolean needsAdjustmentOnScopeChange;
 
-  public BlockNode(final SInvokable blockMethod,
+  public BlockNode(final SInvokable blockMethod, final boolean needsAdjustmentOnScopeChange,
       final SourceSection source) {
     super(source);
-    this.blockMethod  = blockMethod;
+    this.blockMethod = blockMethod;
+    this.needsAdjustmentOnScopeChange = needsAdjustmentOnScopeChange;
     switch (blockMethod.getNumberOfArguments()) {
       case 1: { this.blockClass = Classes.blockClass1; break; }
       case 2: { this.blockClass = Classes.blockClass2; break; }
@@ -74,6 +76,8 @@ public class BlockNode extends LiteralNode {
 
   @Override
   public void replaceAfterScopeChange(final InliningVisitor inliner) {
+    if (!needsAdjustmentOnScopeChange) { return; }
+
     Method blockIvk = (Method) blockMethod.getInvokable();
     Method adapted = blockIvk.cloneAndAdaptAfterScopeChange(
         inliner.getScope(blockIvk), inliner.contextLevel + 1, true);
@@ -84,7 +88,7 @@ public class BlockNode extends LiteralNode {
   }
 
   protected BlockNode createNode(final SInvokable adapted) {
-    return new BlockNode(adapted, getSourceSection());
+    return new BlockNode(adapted, needsAdjustmentOnScopeChange, sourceSection);
   }
 
   @Override
@@ -95,12 +99,12 @@ public class BlockNode extends LiteralNode {
   public static final class BlockNodeWithContext extends BlockNode {
 
     public BlockNodeWithContext(final SInvokable blockMethod,
-        final SourceSection source) {
-      super(blockMethod, source);
+        final boolean needsAdjustmentOnScopeChange, final SourceSection source) {
+      super(blockMethod, needsAdjustmentOnScopeChange, source);
     }
 
     public BlockNodeWithContext(final BlockNodeWithContext node) {
-      this(node.blockMethod, node.getSourceSection());
+      this(node.blockMethod, node.needsAdjustmentOnScopeChange, node.sourceSection);
     }
 
     @Override
@@ -110,7 +114,8 @@ public class BlockNode extends LiteralNode {
 
     @Override
     protected BlockNode createNode(final SInvokable adapted) {
-      return new BlockNodeWithContext(adapted, getSourceSection());
+      return new BlockNodeWithContext(adapted, needsAdjustmentOnScopeChange,
+          sourceSection);
     }
   }
 }


### PR DESCRIPTION
Blocks were split unconditionally, even when there was no obvious benefit or need to split them.
This can lead to excessive code duplication, especially since Truffle splitting applies to block methods in addition to the lexical splitting.

A few more details are documented here: http://markmail.org/thread/dg42ud652xr5rupf

Generally, splitting is needed to make sure that lexically nested blocks access the correct frame slots when they access outer variables.
Since this is only critical to get right if we merged an outer scope, or when there are actually variable accesses, we can avoid the splitting in all other cases.

@richard-roberts, this is a special gift to you. Yet another condition you'll have to consider for object literals 😁. Thought it might be too easy, or you get bored with them :stuck_out_tongue_winking_eye: 

Please review.