### PR TITLE
Improve Newspeak compatibility

### DIFF
--- a/core-lib/TestSuite/LanguageTests.som
+++ b/core-lib/TestSuite/LanguageTests.som
@@ -796,4 +796,35 @@ class LanguageTests usingPlatform: platform testFramework: minitest = Value (
       assert: setter runCascadeForValue equals: 42.
     )
   ) : ( TEST_CONTEXT = () )
+
+  public class OperatorSequences = TestContext ()(
+    class Op = (
+    | public operator
+      public operand
+    |)(
+      public -> op = (
+        operator:: #arrowRight.
+        operand:: op
+      )
+
+      public <- op = (
+        operator:: #arrowLeft.
+        operand:: op
+      )
+    )
+
+    public testArrows = (
+      | o = Op new. |
+
+      o <- 4.
+
+      assert: #arrowLeft equals: o operator.
+      assert: 4          equals: o operand.
+
+      o -> 54.
+
+      assert: #arrowRight equals: o operator.
+      assert: 54          equals: o operand.
+    )
+  ) : ( TEST_CONTEXT = () )
 )

--- a/core-lib/TestSuite/LanguageTests.som
+++ b/core-lib/TestSuite/LanguageTests.som
@@ -760,6 +760,11 @@ class LanguageTests usingPlatform: platform testFramework: minitest = Value (
       )
     )
 
+    class InlinedScopes = (
+    | public if = true ifTrue: [ Cnt new inc; inc; inc ].
+      public if2 = [ true ifTrue: [ Cnt new inc; inc; inc ] ] value.
+    |)()
+
     public testCascadeOnFieldRead = (
       | c = Cnt new. |
       assert: c v equals: 0.
@@ -794,6 +799,20 @@ class LanguageTests usingPlatform: platform testFramework: minitest = Value (
       assert: setter slot1 equals: 23.
       assert: setter slot2 equals: 42.
       assert: setter runCascadeForValue equals: 42.
+    )
+
+    public testCascadeInInlinedBlocks = (
+      | i   = InlinedScopes new.
+        if  = true ifTrue: [ Cnt new inc; inc; inc ].
+        if2 = [ true ifTrue: [ Cnt new inc; inc; inc ] ] value. |
+      assert: i if v  equals: 3.
+      assert: i if2 v equals: 3.
+
+      assert: if v  equals: 3.
+      assert: if2 v equals: 3.
+
+      assert: (true ifTrue: [ Cnt new inc; inc; inc ]) v         equals: 3.
+      assert: [ true ifTrue: [ Cnt new inc; inc; inc ] ] value v equals: 3.
     )
   ) : ( TEST_CONTEXT = () )
 

--- a/core-lib/TestSuite/StringTests.som
+++ b/core-lib/TestSuite/StringTests.som
@@ -27,19 +27,19 @@ class StringTests usingPlatform: platform testFramework: minitest = (
       | str1 str2 |
       str1:: 'foo'.
       str2:: 'bar'.
-    
+
       self assert: str1 = str1.
       self assert: str1 = 'foo'.
       self assert: str1 = ('f' + 'oo').
       self deny:   str1 = str2.
       self assert: str2 = str2.
     )
-  
+
     public testLength = (
       self assert: 1 equals: 't' length.
-      self assert: 6 equals: ('foo' + 'bar') length.  
+      self assert: 6 equals: ('foo' + 'bar') length.
     )
-  
+
     public testCharAt = (
       | str |
       str:: 'foobar'.
@@ -50,7 +50,7 @@ class StringTests usingPlatform: platform testFramework: minitest = (
       self assert: 'a' equals: (str charAt: 5).
       self assert: 'r' equals: (str charAt: 6).
     )
-  
+
     public testPrimSubstringFrom = (
       | str |
       str:: 'foobar'.
@@ -59,64 +59,64 @@ class StringTests usingPlatform: platform testFramework: minitest = (
       self assert: 'foobar' equals: (str substringFrom: 1 to: 6).
       self assert: 'oob' equals: ('foobar' substringFrom: 2 to: 4).
     )
-  
+
     public testBeginsWith = (
       self deny:   ('foo' beginsWith: 'oo').
       self assert: ('foo' beginsWith: 'foo').
     )
-  
+
     public testEndsWith = (
       self assert: ('foo' endsWith: 'foo').
       self assert: ('foo' endsWith: 'oo').
       self deny: ('f' endsWith: 'bar').
       self deny: ('f' endsWith: 'foo').
     )
-    
+
     public testIncludes = (
       assert: ('foo' includes: 'o').
       assert: ('foobar:' includes: ':').
       assert: ('foobar:' includes: 'foo').
       assert: ('foobar:' includes: 'foobar:').
       assert: ('foobar:' includes: 'bar:').
-      
+
       deny: ('foobar' includes: 'baz').
       deny: ('foobar' includes: '1').
     )
-    
+
     public testSplit = (
       | r |
       r:: 'foo.bar' split: '.'.
       assert: 2     equals: r size.
       assert: 'foo' equals: (r at: 1).
       assert: 'bar' equals: (r at: 2).
-      
+
       r:: 'foo..bar' split: '.'.
       assert: 3     equals: r size.
       assert: 'foo' equals: (r at: 1).
       assert: ''    equals: (r at: 2).
       assert: 'bar' equals: (r at: 3).
-      
+
       r:: 'foo..bar' split: '..'.
       assert: 2     equals: r size.
       assert: 'foo' equals: (r at: 1).
       assert: 'bar' equals: (r at: 2).
-      
+
       r:: 'foo' split: 'bar'.
       assert: 1     equals: r size.
       assert: 'foo' equals: (r at: 1).
     )
-    
+
     public testIndexOf = (
       assert: 0   equals: ('foo' indexOf: 'b').
       assert: 1   equals: ('foo' indexOf: 'f').
       assert: 2   equals: ('foo' indexOf: 'o').
       assert: 3   equals: ('foo' indexOf: 'o' startingAt: 3).
-      
+
       assert: 0   equals: ('foo' indexOf: 'b' startingAt: 4).
 
       assert: 2   equals: ('foo' indexOf: 'oo').
     )
-  
+
     public testMultiLineString = (
       (* Test whether the parser will parse multi-line strings correctly. *)
       self assert: '
@@ -153,7 +153,7 @@ class StringTests usingPlatform: platform testFramework: minitest = (
       (* Tests for escape sequences, not all of them are reliable represented
          as proper strings. So, we do a simple equality test, and check
          substring or length.
-    
+
          \t	  a tab character
          \b	  a backspace character
          \n	  a newline character
@@ -176,18 +176,18 @@ class StringTests usingPlatform: platform testFramework: minitest = (
       self assert: '\r' equals: '\r'.
       self assert: 1 equals: '\n' length.
       self deny: ('\r' endsWith: 'r').
-    
+
       self assert: '\f' equals: '\f'.
       self assert: 1 equals: '\f' length.
       self deny: ('\f' endsWith: 'f').
-    
+
       self assert: '\'' equals: '\''.
       self assert: 1 equals: '\'' length.
 
       self assert: '\\' equals: '\\'.
       self assert: 1 equals: '\\' length.
     )
-  
+
     public testHash = (
       | str |
       (* Hash should be identical for strings that are identical,
@@ -195,11 +195,11 @@ class StringTests usingPlatform: platform testFramework: minitest = (
       self assert: 'foobar' hashcode equals: 'foobar' hashcode.
       self assert: 'ssdf aksdf; kasd;fk a;dfk a;dfk a;d' hashcode
            equals: 'ssdf aksdf; kasd;fk a;dfk a;dfk a;d' hashcode.
-    
+
       str:: 'foo' + 'bar'.
       str:: str + str.
       self assert: 'foobarfoobar' hashcode equals: str hashcode.
-    
+
       str:: 'dfadf fgsfg sfg sdfg sfg sfg' + '345243n 24n5 kwertlw erltnwrtln'.
       self assert: 'dfadf fgsfg sfg sdfg sfg sfg345243n 24n5 kwertlw erltnwrtln' hashcode
            equals: str hashcode.

--- a/core-lib/TestSuite/StringTests.som
+++ b/core-lib/TestSuite/StringTests.som
@@ -204,5 +204,13 @@ class StringTests usingPlatform: platform testFramework: minitest = (
       self assert: 'dfadf fgsfg sfg sdfg sfg sfg345243n 24n5 kwertlw erltnwrtln' hashcode
            equals: str hashcode.
     )
+
+    public testLiteralChars = (
+      self assert: "f" equals: 'f'.
+      self assert: """" equals: '"'.
+      self assert: "1" equals: '1'.
+      self assert: " " equals: ' '.
+      self assert: "{" equals: '{'.
+    )
   ) : ( TEST_CONTEXT = () )
 )

--- a/core-lib/TestSuite/StringTests.som
+++ b/core-lib/TestSuite/StringTests.som
@@ -139,7 +139,16 @@ class StringTests usingPlatform: platform testFramework: minitest = (
       assert: '\n' equals: (str charAt: 4).
       assert: 7 equals: str length.
     )
-  
+
+    public testNewspeakTwoQuoteEscape = (
+      assert: '''' equals: '\''.
+      assert: 1    equals: '''' length.
+
+      assert: '123''456' equals: '123\'456'.
+      assert: '123''''456' equals: '123\'\'456'.
+      assert: '123''''456''' equals: '123\'\'456\''.
+    )
+
     public testEscapeSequences = (
       (* Tests for escape sequences, not all of them are reliable represented
          as proper strings. So, we do a simple equality test, and check

--- a/core-lib/TestSuite/SymbolTests.som
+++ b/core-lib/TestSuite/SymbolTests.som
@@ -31,14 +31,31 @@ class SymbolTests usingPlatform: platform testFramework: minitest = (
       self assert: 'gunk' equals: 'gunk' asSymbol asString.
       self assert: 'oink' equals: #oink asString.
     )
-  
+
     public testEquality = (
       self assert: #oink equals: 'oink' asSymbol.
     )
-  
+
     public testSymbolIsString = (
       self assert: (#oink beginsWith: 'oink').
       self assert: 100 equals: #'100' asInteger.
+    )
+
+    public testSymbolsWithOperators = (
+      assert: #! asString   equals: '!'.
+      assert: #!- asString  equals: '!-'.
+      assert: #-! asString  equals: '-!'.
+      assert: #!!! asString equals: '!!!'.
+
+      assert: #+> asString  equals: '+>'.
+      assert: #<- asString  equals: '<-'.
+      assert: #<-> asString equals: '<->'.
+      assert: #-> asString  equals: '->'.
+
+      (* Not supported by Newspeak either:
+      assert: #<: asString  equals: '<:'.
+      assert: #:> asString  equals: ':>'.
+      *)
     )
   ) : ( TEST_CONTEXT = () )
 )

--- a/src/som/compiler/Lexer.java
+++ b/src/som/compiler/Lexer.java
@@ -351,6 +351,8 @@ public final class Lexer {
       match(Symbol.Per);
     } else if (currentChar() == '-') {
       match(Symbol.Minus);
+    } else if (currentChar() == '!') {
+      match(Symbol.OperatorSequence);
     }
   }
 
@@ -454,7 +456,7 @@ public final class Lexer {
   private static boolean isOperator(final char c) {
     return c == '~' || c == '&' || c == '|' || c == '*' || c == '/'
         || c == '\\' || c == '+' || c == '=' || c == '>' || c == '<'
-        || c == ',' || c == '@' || c == '%' || c == '-';
+        || c == ',' || c == '@' || c == '%' || c == '-' || c == '!';
   }
 
   protected static boolean isDigit(final char c) {

--- a/src/som/compiler/Lexer.java
+++ b/src/som/compiler/Lexer.java
@@ -435,7 +435,7 @@ public final class Lexer {
   private static boolean isOperator(final char c) {
     return c == '~' || c == '&' || c == '|' || c == '*' || c == '/'
         || c == '\\' || c == '+' || c == '=' || c == '>' || c == '<'
-        || c == ',' || c == '@' || c == '%';
+        || c == ',' || c == '@' || c == '%' || c == '-';
   }
 
   protected static boolean isDigit(final char c) {

--- a/src/som/compiler/Lexer.java
+++ b/src/som/compiler/Lexer.java
@@ -270,7 +270,10 @@ public final class Lexer {
 
   private void lexStringChar() {
     char cur = currentChar();
-    if (cur == '\\') {
+    if (cur == '\'' && nextChar() == '\'') {
+      state.text.append('\'');
+      state.incPtr(2);
+    } else if (cur == '\\') {
       state.incPtr();
       lexEscapeChar();
     } else {
@@ -288,7 +291,7 @@ public final class Lexer {
     state.set(Symbol.STString);
     state.incPtr();
 
-    while (currentChar() != '\'') {
+    while (currentChar() != '\'' || nextChar() == '\'') {
       lexStringChar();
     }
 

--- a/src/som/compiler/Lexer.java
+++ b/src/som/compiler/Lexer.java
@@ -152,6 +152,8 @@ public final class Lexer {
 
     if (currentChar() == '\'') {
       lexString();
+    } else if (currentChar() == '"') {
+      lexCharacterLiteral();
     } else if (currentChar() == '[') {
       match(Symbol.NewBlock);
     } else if (currentChar() == ']') {
@@ -296,6 +298,23 @@ public final class Lexer {
     }
 
     state.incPtr();
+  }
+
+  private void lexCharacterLiteral() {
+    state.set(Symbol.Char);
+    state.incPtr();
+
+    char c = currentChar();
+    if (c == '"' && nextChar() == '"') {
+      state.text.append('"');
+      state.incPtr(2);
+    } else {
+      acceptChar();
+    }
+
+    if (currentChar() == '"') {
+      state.incPtr();
+    }
   }
 
   private void lexOperator() {

--- a/src/som/compiler/MethodBuilder.java
+++ b/src/som/compiler/MethodBuilder.java
@@ -349,7 +349,9 @@ public final class MethodBuilder {
   public Local addMessageCascadeTemp(final SourceSection source) throws MethodDefinitionError {
     cascadeId += 1;
     Local l = addLocal("$cascadeTmp" + cascadeId, true, source);
-    currentScope.addVariable(l);
+    if (currentScope.hasVariables()) {
+      currentScope.addVariable(l);
+    }
     return l;
   }
 

--- a/src/som/compiler/MethodBuilder.java
+++ b/src/som/compiler/MethodBuilder.java
@@ -348,7 +348,9 @@ public final class MethodBuilder {
 
   public Local addMessageCascadeTemp(final SourceSection source) throws MethodDefinitionError {
     cascadeId += 1;
-    return addLocal("$cascadeTmp" + cascadeId, true, source);
+    Local l = addLocal("$cascadeTmp" + cascadeId, true, source);
+    currentScope.addVariable(l);
+    return l;
   }
 
   public Local addLocal(final String name, final boolean immutable,

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -141,7 +141,7 @@ public class Parser {
   private final StructuralProbe     structuralProbe;
 
   private static final Symbol[] singleOpSyms = new Symbol[] {Not, And, Or, Star,
-    Div, Mod, Plus, Equal, More, Less, Comma, At, Per, NONE};
+    Div, Mod, Plus, Equal, More, Less, Comma, At, Per, Minus, NONE};
 
   private static final Symbol[] binaryOpSyms = new Symbol[] {Or, Comma, Minus,
     Equal, Not, And, Or, Star, Div, Mod, Plus, Equal, More, Less, Comma, At,

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -28,6 +28,7 @@ package som.compiler;
 import static som.compiler.Symbol.And;
 import static som.compiler.Symbol.At;
 import static som.compiler.Symbol.BeginComment;
+import static som.compiler.Symbol.Char;
 import static som.compiler.Symbol.Colon;
 import static som.compiler.Symbol.Comma;
 import static som.compiler.Symbol.Div;
@@ -150,7 +151,7 @@ public class Parser {
     KeywordSequence};
 
   private static final Symbol[] literalSyms = new Symbol[] {Pound, STString,
-    Numeral};
+    Numeral, Char};
 
   private static boolean arrayContains(final Symbol[] arr, final Symbol sym) {
     for (Symbol s : arr) {
@@ -1472,6 +1473,7 @@ public class Parser {
     switch (sym) {
       case Pound:     return literalSymbol();
       case STString:  return literalString();
+      case Char:      return literalChar();
       default:        return literalNumber();
     }
   }
@@ -1538,6 +1540,13 @@ public class Parser {
     return new StringLiteralNode(s, getSource(coord));
   }
 
+  private LiteralNode literalChar() throws ParseError {
+    SourceCoordinate coord = getCoordinate();
+    String s = character();
+
+    return new StringLiteralNode(s, getSource(coord));
+  }
+
   private LiteralNode literalArray(final MethodBuilder builder) throws ProgramDefinitionError {
     SourceCoordinate coord = getCoordinate();
     List<ExpressionNode> expressions = new ArrayList<ExpressionNode>();
@@ -1581,6 +1590,12 @@ public class Parser {
   private String string() throws ParseError {
     String s = text;
     expect(STString, null);
+    return s;
+  }
+
+  private String character() throws ParseError {
+    String s = text;
+    expect(Char, null);
     return s;
   }
 

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -1398,6 +1398,9 @@ public class Parser {
           return new IfInlinedLiteralNode(condition, false, inlinedBody,
               arguments.get(1), source);
         } else if ("whileTrue:".equals(msgStr)) {
+          if (!(arguments.get(0) instanceof LiteralNode) || !(arguments.get(1) instanceof LiteralNode)) {
+            return null;
+          }
           ExpressionNode inlinedCondition = ((LiteralNode) arguments.get(0)).inline(builder);
           inlinedCondition.markAsControlFlowCondition();
           ExpressionNode inlinedBody      = ((LiteralNode) arguments.get(1)).inline(builder);
@@ -1405,6 +1408,9 @@ public class Parser {
           return new WhileInlinedLiteralsNode(inlinedCondition, inlinedBody,
               true, arguments.get(0), arguments.get(1), source);
         } else if ("whileFalse:".equals(msgStr)) {
+          if (!(arguments.get(0) instanceof LiteralNode) || !(arguments.get(1) instanceof LiteralNode)) {
+            return null;
+          }
           ExpressionNode inlinedCondition = ((LiteralNode) arguments.get(0)).inline(builder);
           inlinedCondition.markAsControlFlowCondition();
           ExpressionNode inlinedBody      = ((LiteralNode) arguments.get(1)).inline(builder);

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -338,6 +338,8 @@ public class Parser {
     }
     mxnBuilder.setupInitializerBasedOnPrimaryFactory(getSource(coord));
 
+    comments();
+
     expect(Equal, "Unexpected symbol %(found)s."
         + " Tried to parse the class declaration of " + mixinName
         + " and expect '=' before the (optional) inheritance declaration.",
@@ -624,7 +626,12 @@ public class Parser {
   private String slotDecl() throws ParseError {
     String id = identifier();
 
+    comments();
+
     new TypeParser(this).parseType();
+
+    comments();
+
     return id;
   }
 
@@ -773,10 +780,18 @@ public class Parser {
     MethodBuilder builder = new MethodBuilder(
         mxnBuilder, mxnBuilder.getScopeForCurrentParserPosition());
 
+    comments();
+
     messagePattern(builder);
+
+    comments();
+
     expect(Equal,
         "Unexpected symbol %(found)s. Tried to parse method declaration and expect '=' between message pattern, and method body.",
         KeywordTag.class);
+
+    comments();
+
     ExpressionNode body = methodBlock(builder);
     builder.finalizeMethodScope();
     SInvokable meth = builder.assemble(body, accessModifier, getSource(coord));
@@ -800,6 +815,8 @@ public class Parser {
         binaryPattern(builder);
         break;
     }
+
+    comments();
 
     new TypeParser(this).parseReturnType();
   }
@@ -892,7 +909,11 @@ public class Parser {
     SourceCoordinate coord = getCoordinate();
     String id = identifier();
 
+    comments();
+
     new TypeParser(this).parseType();
+
+    comments();
 
     language.getVM().reportSyntaxElement(ArgumentTag.class, getSource(coord));
     return id;
@@ -970,6 +991,8 @@ public class Parser {
           expect(Period, null);
         }
         expressions.add(result(builder));
+
+        comments();
         return createSequence(expressions, getSource(coord));
       } else if (sym == EndBlock) {
         return createSequence(expressions, getSource(coord));
@@ -1040,6 +1063,8 @@ public class Parser {
 
   private ExpressionNode evaluation(final MethodBuilder builder)
       throws ProgramDefinitionError {
+    comments();
+
     ExpressionNode exp;
     if (sym == Keyword) {
       exp = keywordMessage(builder, builder.getSelfRead(getEmptySource()), false, false, null);
@@ -1057,6 +1082,9 @@ public class Parser {
         exp = msgCascade(exp, lastReceiver[0], builder, coord);
       }
     }
+
+    comments();
+
     return exp;
   }
 
@@ -1083,6 +1111,8 @@ public class Parser {
 
     while (sym == Semicolon) {
       expect(Semicolon, KeywordTag.class);
+
+      comments();
 
       ExpressionNode exp;
       if (sym == Keyword) {
@@ -1263,6 +1293,9 @@ public class Parser {
       final SourceSection sendOperator) throws ProgramDefinitionError {
     SourceCoordinate coord = getCoordinate();
     SSymbol msg = binarySelector();
+
+    comments();
+
     ExpressionNode operand = binaryOperand(builder);
 
     if (!eventualSend) {
@@ -1272,6 +1305,9 @@ public class Parser {
         return node;
       }
     }
+
+    comments();
+
     return createMessageSend(msg, new ExpressionNode[] {receiver, operand},
         eventualSend, getSource(coord), sendOperator, language);
   }
@@ -1466,6 +1502,9 @@ public class Parser {
     expect(NewTerm, DelimiterOpeningTag.class);
     ExpressionNode exp = expression(builder);
     expect(EndTerm, DelimiterClosingTag.class);
+
+    comments();
+
     return exp;
   }
 

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -1072,10 +1072,10 @@ public class Parser {
     Local tmp = builder.addMessageCascadeTemp(tmpSource);
 
     // evaluate last receiver, and write value to temp
-    cascade.add(tmp.getWriteNode(0, lastReceiver, tmpSource));
+    cascade.add(builder.getWriteNode(tmp.name, lastReceiver, tmpSource));
 
     // replace receiver with read from temp
-    lastReceiver.replace(tmp.getReadNode(0, tmpSource));
+    lastReceiver.replace(builder.getReadNode(tmp.name, tmpSource));
 
     // add the initial message of the cascade, it is now send to the temp read
     cascade.add(nonEmptyMessage);
@@ -1085,12 +1085,12 @@ public class Parser {
 
       ExpressionNode exp;
       if (sym == Keyword) {
-        exp = keywordMessage(builder, tmp.getReadNode(0, tmpSource), false, false, null);
+        exp = keywordMessage(builder, builder.getReadNode(tmp.name, tmpSource), false, false, null);
       } else if (sym == OperatorSequence || symIn(binaryOpSyms)) {
-        exp = binaryMessage(builder, tmp.getReadNode(0, tmpSource), false, null);
+        exp = binaryMessage(builder, builder.getReadNode(tmp.name, tmpSource), false, null);
       } else {
         assert sym == Identifier;
-        exp = unaryMessage(tmp.getReadNode(0, tmpSource), false, null);
+        exp = unaryMessage(builder.getReadNode(tmp.name, tmpSource), false, null);
       }
       cascade.add(exp);
     }

--- a/src/som/compiler/Symbol.java
+++ b/src/som/compiler/Symbol.java
@@ -27,7 +27,7 @@ package som.compiler;
 enum Symbol {
   NONE, Numeral, Not, And, Or, Star, Div, Mod, Plus, Minus, Equal, More, Less,
   Comma, At, Per, NewBlock, EndBlock, LCurly, RCurly, Colon, Semicolon, Period, Exit, NewTerm,
-  EndTerm, Pound, STString,
+  EndTerm, Pound, STString, Char,
   BeginComment, EndComment, SlotMutableAssign, EventualSend, MixinOperator,
   Identifier, Keyword, SetterKeyword,
   KeywordSequence, OperatorSequence

--- a/src/som/compiler/TypeParser.java
+++ b/src/som/compiler/TypeParser.java
@@ -13,6 +13,7 @@ import static som.compiler.Symbol.More;
 import static som.compiler.Symbol.NewBlock;
 import static som.compiler.Symbol.NewTerm;
 import static som.compiler.Symbol.Or;
+import static som.compiler.Symbol.Period;
 import static som.compiler.Symbol.RCurly;
 
 import som.compiler.Parser.ParseError;
@@ -111,8 +112,8 @@ public class TypeParser {
       while (true) {
         typeExpr();
 
-        if (parser.sym == Comma) {
-          parser.expect(Comma, null);
+        if (parser.sym == Period) {
+          parser.expect(Period, null);
         } else {
           break;
         }

--- a/src/som/interpreter/LexicalScope.java
+++ b/src/som/interpreter/LexicalScope.java
@@ -131,6 +131,15 @@ public abstract class LexicalScope {
       this.variables = variables;
     }
 
+    /**
+     * During parsing of locals, variables are not set yet.
+     * So, we don't need to set them explicitly.
+     * They will be set later automatically.
+     */
+    public boolean hasVariables() {
+      return variables != null;
+    }
+
     public void addVariable(final Variable var) {
       int length = variables.length;
       variables = Arrays.copyOf(variables, length + 1);

--- a/tests/java/som/compiler/TypeGrammarParserTest.java
+++ b/tests/java/som/compiler/TypeGrammarParserTest.java
@@ -30,7 +30,7 @@ public class TypeGrammarParserTest {
         "<[:String :ObjectMirror]>", "<List[Promise[V, E]]>",
         "<WeakMap[FarReference, InternalFarReference]>",
         "<[:V | V2 def]>", "<[:Promise | R def] | [R def]>",
-        "<{String, Foobar}>"};
+        "<{String. Foobar}>"};
   }
 
   @Test


### PR DESCRIPTION
With these changes, the Newspeak source in the [main repository](https://bitbucket.org/newspeaklanguage/newspeak/src) can be parsed with only minor [cheating](https://gist.github.com/smarr/46a26570f63e9b00954055b779437edb), i.e., adaptations for silly parser incompatibilities.
There are still various things in the parser that could use fixing, but it is good enough for now.

- Support two single quotes as escape sequence
- Make sure minus can be parsed as part of operator sequence
- Make sure - and ! can be part of symbols
- Fix issues with cascades
   - Register cascade temps in scope
   - Fix cascades in local initializers
   - Don't do AST-level inlining while parsing slots/locals
   - Add tests for cascades in inlined scopes
- Added parser support for literal characters
- Support comments in more places
- Add guards for inlining on things that are not supported
- Fix syntax for tupleType to use dot as separator
- Parse simSlot decls like normal ones and accept empty slot/local declarations
- Refactor handling of nested classes and methods parsing to be able to accept method named class
