### PR TITLE
Fix turn stepping operations, and introduce better actor testing framework

### DIFF
--- a/core-lib/demos/ActorDemo.som
+++ b/core-lib/demos/ActorDemo.som
@@ -9,23 +9,7 @@ class ActorDemo usingPlatform: platform = Value (
     )
   )
 
-  public woResolver = (
-    | p |
-    p:: (actors createActorFromValue: Result) <-: new.
-    p <-: get.
-    'after get send, sequential' println.
-    ^ 0
-  )
-
-  public wResolverNoCallback = (
-    | p p2 |
-    p:: (actors createActorFromValue: Result) <-: new.
-    p2:: p <-: get.
-    'after get send, sequential' println.
-    ^ 0
-  )
-
-  public wResolverAndCallback = (
+  public createActorSendMessageAndProcessResult = (
     | p p2 |
     p:: (actors createActorFromValue: Result) <-: new.
     p2:: p <-: get.
@@ -44,9 +28,7 @@ class ActorDemo usingPlatform: platform = Value (
 
     1 halt.
 
-    woResolver.
-    wResolverNoCallback.
-    wResolverAndCallback.
+    createActorSendMessageAndProcessResult.
 
     ^ completionPP promise
   )

--- a/src/som/primitives/actors/CreateActorPrim.java
+++ b/src/som/primitives/actors/CreateActorPrim.java
@@ -16,7 +16,6 @@ import som.vm.VmSettings;
 import som.vm.constants.KernelObj;
 import som.vmobjects.SClass;
 import tools.concurrency.ActorExecutionTrace;
-import tools.concurrency.Tags.ActivityCreation;
 import tools.concurrency.Tags.ExpressionBreakpoint;
 import tools.debugger.entities.ActivityType;
 
@@ -56,7 +55,7 @@ public abstract class CreateActorPrim extends BinaryComplexOperation {
 
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
-    if (tag == ActivityCreation.class || tag == ExpressionBreakpoint.class) {
+    if (tag == ExpressionBreakpoint.class) {
       return true;
     }
     return super.isTaggedWith(tag);

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -179,7 +179,7 @@ public enum SteppingType {
       Group.ACTOR_STEPPING, "msg-close", null, new ActivityType[] {ActivityType.ACTOR}) {
     @Override
     public void process(final Suspension susp) {
-      susp.getEvent().prepareStepOver(1);
+      susp.getEvent().prepareContinue();
       susp.getActivityThread().setSteppingStrategy(this);
     }
   },
@@ -189,7 +189,7 @@ public enum SteppingType {
       "Return from Turn to Promise Resolution", Group.ACTOR_STEPPING, "msg-embedded",
       null, new ActivityType[] {ActivityType.ACTOR}) {
     @Override public void process(final Suspension susp) {
-      susp.getEvent().prepareStepOver(1);
+      susp.getEvent().prepareContinue();
       susp.getActivityThread().setSteppingStrategy(this);
     }
   };

--- a/tools/kompos/tests/actor.som
+++ b/tools/kompos/tests/actor.som
@@ -1,0 +1,56 @@
+class Actor usingPlatform: platform = Value (
+| private actors = platform actors.
+  private system = platform system.
+  private Exception = platform kernel Exception.
+|)(
+
+  private class MyActor = ()(
+    public foo = (
+      'Start #foo' println.
+
+      'Done with #foo' println.
+      ^ self
+    )
+  )
+
+  public msgAndPromiseCallback: completionPP = (
+    | a |
+    a:: (actors createActorFromValue: MyActor) <-: new.
+
+    (a <-: foo) whenResolved: [:r |
+      'Callback after #foo' println.
+      'Got as result: ' print.
+      r println.
+
+      (* End Program *)
+      completionPP resolve: 0.
+    ].
+
+    'msgAndPromiseCallback returning' println.
+  )
+
+  public multipleTurns: completionPP = (
+    | a |
+    a:: (actors createActorFromValue: MyActor) <-: new.
+    a <-: foo.
+    a <-: foo.
+    a <-: foo whenResolved: [:r |
+      completionPP resolve: 0
+    ].
+  )
+
+  public main: args = (
+    | completionPP a test |
+    'Actor breakpoint tests' println.
+
+    completionPP:: actors createPromisePair.
+    test:: args at: 2.
+    ('Run test: ' + test) println.
+
+    test = 'msgAndPromiseCallback' ifTrue: [ msgAndPromiseCallback: completionPP ].
+    test = 'multipleTurns'         ifTrue: [ multipleTurns: completionPP ].
+
+
+    ^ completionPP promise
+  )
+)

--- a/tools/kompos/tests/actor.ts
+++ b/tools/kompos/tests/actor.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { createSectionBreakpointData, createLineBreakpointData } from "../src/messages";
-import { PING_PONG_URI, TestConnection, ACTOR_URI, TestController, ACTOR_FILE, HandleStoppedAndGetStackTrace, expectStack, PING_PONG_FILE } from "./test-setup";
+import { PING_PONG_URI, TestConnection, ACTOR_URI, TestController, ACTOR_FILE, PING_PONG_FILE } from "./test-setup";
 import { BreakpointType as BT, SteppingType as ST } from "./somns-support";
 import { Test, Stop, expectStops } from "./stepping";
 
@@ -10,308 +10,6 @@ const closeConnectionAfterSuite = (done) => {
   conn.fullyConnected.then(_ => { conn.close(done); });
   conn.fullyConnected.catch(reason => done(reason));
 };
-
-describe("Actor Stepping, pingpong.som", () => {
-  const steppingTests = {
-    "stepping to message receiver":
-    [{
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 26, 19, 3, BT.MSG_SENDER, true),
-      stopLine: 26,
-      stopMethod: "Ping>>#ping",
-      numOp: 4,
-      length: 2
-    },
-    {
-      test: "step to message receiver",
-      type: ST.STEP_TO_MESSAGE_RECEIVER,
-      length: 2,
-      methodName: "Ping>>#ping",
-      line: 27,
-      stackIndex: 1
-    },
-    {
-      test: "resume after step to message receiver",
-      type: ST.RESUME,
-      length: 1,
-      methodName: "Ping>>#validate:",
-      line: 33,
-      stackIndex: 2
-    }],
-
-    "stepping to promise resolution":
-    [{
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 33, 19, 3, BT.MSG_SENDER, true),
-      stopLine: 33,
-      stopMethod: "Ping>>#validate:",
-      numOp: 4,
-      length: 1
-    },
-    {
-      test: "step to promise resolution",
-      type: ST.STEP_TO_PROMISE_RESOLUTION,
-      length: 1,
-      methodName: "Ping>>#validate:",
-      line: 34,
-      stackIndex: 1
-    },
-    {
-      test: "resume after step to promise resolution",
-      type: ST.RESUME,
-      length: 1,
-      methodName: "Ping>>#validate:",
-      line: 33,
-      stackIndex: 2
-    }],
-
-    "stepping to next turn":
-    [{
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 23, 14, 3, BT.MSG_SENDER, true),
-      stopLine: 23,
-      stopMethod: "Ping>>#ping",
-      numOp: 4,
-      length: 2
-    },
-    {
-      test: "step to next turn",
-      type: ST.STEP_TO_NEXT_TURN,
-      length: 1,
-      methodName: "Ping>>#pong:",
-      line: 56,
-      stackIndex: 1
-    },
-    {
-      test: "resume after stepping to next turn",
-      type: ST.RESUME,
-      length: 1,
-      methodName: "Ping>>#ping",
-      line: 23,
-      stackIndex: 2
-    }],
-
-    "stepping to promise resolver":
-    [{
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 26, 19, 3, BT.MSG_SENDER, true),
-      stopLine: 26,
-      stopMethod: "Ping>>#ping",
-      numOp: 4,
-      length: 2
-    },
-    {
-      test: "step to promise resolver",
-      type: ST.STEP_TO_PROMISE_RESOLVER,
-      length: 2,
-      methodName: "Ping>>#ping",
-      line: 27,
-      stackIndex: 1
-    },
-    {
-      test: "resume after step to promise resolver",
-      type: ST.RESUME,
-      length: 1,
-      methodName: "Ping>>#validate:",
-      line: 33,
-      stackIndex: 2
-    }],
-
-    "stepping to promise resolution for explicit promise":
-    [{
-      breakpoint: createLineBreakpointData(PING_PONG_URI, 92, true),
-      stopLine: 92,
-      stopMethod: "PingPong>>#benchmark",
-      numOp: 4,
-      length: 6
-    },
-    {
-      test: "step over",
-      type: ST.STEP_OVER,
-      length: 6,
-      methodName: "PingPong>>#benchmark",
-      line: 92,
-      stackIndex: 1
-    },
-    {
-      test: "step to promise resolution",
-      type: ST.STEP_TO_PROMISE_RESOLUTION,
-      length: 6,
-      methodName: "PingPong>>#benchmark",
-      line: 93,
-      stackIndex: 2
-    },
-    {
-      test: "resume after step to promise resolution",
-      type: ST.RESUME,
-      length: 1,
-      methodName: "PingPong>>#λbenchmark@97@44:",
-      line: 98,
-      stackIndex: 3
-    }],
-
-    "stepping to promise resolution for whenResolved":
-    [{
-      breakpoint: createLineBreakpointData(PING_PONG_URI, 27, true),
-      stopLine: 27,
-      stopMethod: "Ping>>#ping",
-      numOp: 5,
-      length: 2
-    },
-    {
-      test: "step over",
-      type: ST.STEP_OVER,
-      length: 2,
-      methodName: "Ping>>#ping",
-      line: 27,
-      stackIndex: 1
-    },
-    {
-      test: "should step to promise resolution",
-      type: ST.STEP_TO_PROMISE_RESOLUTION,
-      length: 2,
-      methodName: "Ping>>#ping",
-      line: 28,
-      stackIndex: 2
-    },
-    {
-      test: "should resume after step to promise resolution",
-      type: ST.RESUME,
-      length: 1,
-      methodName: "Ping>>#ping",
-      line: 27,
-      stackIndex: 3
-    },
-    {
-      test: "should resume again to get to resolution",
-      type: ST.RESUME,
-      length: 1,
-      methodName: "Ping>>#ping",
-      line: 27,
-      stackIndex: 4
-    }],
-
-    "stepping to promise resolution for whenResolvedOnError":
-    [{
-      breakpoint: createLineBreakpointData(PING_PONG_URI, 34, true),
-      stopLine: 34,
-      stopMethod: "Ping>>#validate:",
-      numOp: 5,
-      length: 1
-    },
-    {
-      test: "step over",
-      type: ST.STEP_OVER,
-      length: 1,
-      methodName: "Ping>>#validate:",
-      line: 34,
-      stackIndex: 1
-    },
-    {
-      test: "step to promise resolution",
-      type: ST.STEP_TO_PROMISE_RESOLUTION,
-      length: 1,
-      methodName: "Ping>>#validate:",
-      line: 35,
-      stackIndex: 2
-    },
-    {
-      test: "resume after step to promise resolution",
-      type: ST.RESUME,
-      length: 1,
-      methodName: "Ping>>#validate:",
-      line: 34,
-      stackIndex: 3
-    },
-    {
-      test: "resume again to get to resolution",
-      type: ST.RESUME,
-      length: 1,
-      methodName: "Ping>>#validate:",
-      line: 34,
-      stackIndex: 4
-    }],
-
-    "stepping to promise resolution for onError":
-    [{
-      breakpoint: createLineBreakpointData(PING_PONG_URI, 78, true),
-      stopLine: 78,
-      stopMethod: "Pong>>#stop",
-      numOp: 5,
-      length: 1
-    },
-    {
-      test: "step over",
-      type: ST.STEP_OVER,
-      length: 1,
-      methodName: "Pong>>#stop",
-      line: 78,
-      stackIndex: 1
-    },
-    {
-      test: "step to promise resolution",
-      type: ST.STEP_TO_PROMISE_RESOLUTION,
-      length: 1,
-      methodName: "Pong>>#stop",
-      line: 79,
-      stackIndex: 2
-    },
-    {
-      test: "resume after step to promise resolution",
-      type: ST.RESUME,
-      length: 1,
-      methodName: "Pong>>#λstop@78@27:",
-      line: 78,
-      stackIndex: 3
-    },
-    {
-      test: "resume again to get to resolution",
-      type: ST.RESUME,
-      length: 1,
-      methodName: "Thing>>#println",
-      line: 71,
-      stackIndex: 4
-    }]
-  };
-
-  for (const suiteName in steppingTests) {
-    const suite = steppingTests[suiteName];
-    const stopData = suite[0];
-
-    describe(suiteName, () => {
-      let ctrl: HandleStoppedAndGetStackTrace;
-
-      before("Start SOMns and Connect", () => {
-        conn = new TestConnection();
-        ctrl = new HandleStoppedAndGetStackTrace(
-          [stopData.breakpoint], conn, conn.fullyConnected, stopData.numOp);
-      });
-
-      after(closeConnectionAfterSuite);
-
-      it("should stop initially at breakpoint", () => {
-        return ctrl.stackPs[0].then(msg => {
-          expectStack(msg.stackFrames, stopData.length, stopData.stopMethod, stopData.stopLine);
-        });
-      });
-
-      describe("should", () => {
-        suite.forEach((testDesc, index) => {
-          if (index > 0) { // evaluate all stepping data except the first one that corresponds to the breakpoint
-            it(testDesc.test, () => {
-              ctrl.stackPs[testDesc.stackIndex - 1].then(_ => {
-                conn.sendDebuggerAction(testDesc.type, ctrl.stoppedActivities[0]);
-              });
-
-              return new Promise((resolve, _reject) => {
-                const p = ctrl.stackPs[testDesc.stackIndex].then(msgAfterStep => {
-                  expectStack(msgAfterStep.stackFrames, testDesc.length, testDesc.methodName, testDesc.line);
-                });
-                resolve(p);
-              });
-            });
-          }
-        });
-      });
-    });
-  }
-});
 
 describe("Actor Stepping", () => {
   const MAPWhenResolved: Stop = {
@@ -335,6 +33,13 @@ describe("Actor Stepping", () => {
     activity: "main"
   };
 
+  const PingPing: Stop = {
+    line: 23,
+    methodName: "Ping>>#ping",
+    stackHeight: 2,
+    activity: "ping"
+  };
+
   const MTFooLine: Stop = {
     line: 11,
     methodName: "MyActor>>#foo",
@@ -343,6 +48,40 @@ describe("Actor Stepping", () => {
   };
 
   const steppingTests: Test[] = [
+    {
+      title: "stepping to message receiver",
+      test: PING_PONG_FILE,
+      initialBreakpoints: [
+        createSectionBreakpointData(PING_PONG_URI, 26, 19, 3, BT.MSG_SENDER, true)],
+      initialStop: {
+        line: 26,
+        methodName: "Ping>>#ping",
+        stackHeight: 2,
+        activity: "ping"
+      },
+      steps: [
+        {
+          type: ST.STEP_TO_MESSAGE_RECEIVER,
+          activity: "ping",
+          stops: [{
+            line: 27,
+            methodName: "Ping>>#ping",
+            stackHeight: 2,
+            activity: "ping"
+          }]
+        },
+        {
+          type: ST.RESUME,
+          activity: "ping",
+          stops: [{
+            line: 33,
+            methodName: "Ping>>#validate:",
+            stackHeight: 1,
+            activity: "ping"
+          }]
+        }
+      ]
+    },
     {
       title: "stepping to promise resolution",
       test: ACTOR_FILE,
@@ -464,6 +203,281 @@ describe("Actor Stepping", () => {
         {
           type: ST.RESUME,
           activity: "MyActor"
+        }
+      ]
+    },
+    {
+      title: "stepping to next turn",
+      test: PING_PONG_FILE,
+      initialBreakpoints: [
+        createSectionBreakpointData(PING_PONG_URI, 23, 14, 3, BT.MSG_SENDER, true)
+      ],
+      initialStop: PingPing,
+      steps: [
+        {
+          type: ST.STEP_TO_NEXT_TURN,
+          activity: "ping",
+          stops: [{
+            line: 56,
+            methodName: "Ping>>#pong:",
+            stackHeight: 1,
+            activity: "ping"
+          }]
+        },
+        {
+          type: ST.RESUME,
+          activity: "ping",
+          stops: [{
+            line: 23,
+            methodName: "Ping>>#ping",
+            stackHeight: 1,
+            activity: "ping"
+          }]
+        }
+      ]
+    },
+    {
+      title: "stepping to promise resolution",
+      test: PING_PONG_FILE,
+      initialBreakpoints: [
+        createSectionBreakpointData(PING_PONG_URI, 33, 19, 3, BT.MSG_SENDER, true)],
+      initialStop: PingValidate,
+      steps: [
+        {
+          type: ST.STEP_TO_PROMISE_RESOLUTION,
+          activity: "main",
+          stops: [{
+            line: 34,
+            methodName: "Ping>>#validate:",
+            stackHeight: 1,
+            activity: "main"
+          }]
+        },
+        {
+          type: ST.RESUME,
+          activity: "main",
+          stops: [PingValidate]
+        }
+      ]
+    },
+    {
+      title: "stepping to promise resolver",
+      test: PING_PONG_FILE,
+      initialBreakpoints: [
+        createSectionBreakpointData(PING_PONG_URI, 26, 19, 3, BT.MSG_SENDER, true)],
+      initialStop: {
+        line: 26,
+        methodName: "Ping>>#ping",
+        stackHeight: 2,
+        activity: "main"
+      },
+      steps: [
+        {
+          type: ST.STEP_TO_PROMISE_RESOLVER,
+          activity: "main",
+          stops: [{
+            line: 27,
+            methodName: "Ping>>#ping",
+            stackHeight: 2,
+            activity: "main"
+          }]
+        },
+        {
+          type: ST.RESUME,
+          activity: "main",
+          stops: [PingValidate]
+        }
+      ]
+    },
+    {
+      title: "stepping to promise resolution for explicit promise",
+      test: PING_PONG_FILE,
+      initialBreakpoints: [createLineBreakpointData(PING_PONG_URI, 92, true)],
+      initialStop: {
+        line: 92,
+        methodName: "PingPong>>#benchmark",
+        stackHeight: 6,
+        activity: "main"
+      },
+      steps: [
+        {
+          type: ST.STEP_OVER,
+          activity: "main",
+          stops: [{
+            line: 92,
+            methodName: "PingPong>>#benchmark",
+            stackHeight: 6,
+            activity: "main"
+          }]
+        },
+        {
+          type: ST.STEP_TO_PROMISE_RESOLUTION,
+          activity: "main",
+          stops: [{
+            line: 93,
+            methodName: "PingPong>>#benchmark",
+            stackHeight: 6,
+            activity: "main"
+          }]
+        },
+        {
+          type: ST.RESUME,
+          activity: "main",
+          stops: [{
+            line: 98,
+            methodName: "PingPong>>#λbenchmark@97@44:",
+            stackHeight: 1,
+            activity: "main"
+          }]
+        }
+      ]
+    },
+    {
+      title: "stepping to promise resolution for whenResolved",
+      test: PING_PONG_FILE,
+      initialBreakpoints: [createLineBreakpointData(PING_PONG_URI, 27, true)],
+      initialStop: {
+        line: 27,
+        methodName: "Ping>>#ping",
+        activity: "ping",
+        stackHeight: 2
+      },
+      steps: [
+        {
+          type: ST.STEP_OVER,
+          activity: "ping",
+          stops: [{
+            line: 27,
+            methodName: "Ping>>#ping",
+            activity: "ping",
+            stackHeight: 2
+          }]
+        },
+        {
+          type: ST.STEP_TO_PROMISE_RESOLUTION,
+          activity: "ping",
+          stops: [{
+            line: 28,
+            methodName: "Ping>>#ping",
+            activity: "ping",
+            stackHeight: 2
+          }]
+        },
+        {
+          type: ST.RESUME,
+          activity: "ping",
+          stops: [{
+            line: 27,
+            methodName: "Ping>>#ping",
+            stackHeight: 1,
+            activity: "ping"
+          }]
+        }
+      ]
+    },
+    {
+      title: "stepping to promise resolution for whenResolvedOnError",
+      test: PING_PONG_FILE,
+      initialBreakpoints: [createLineBreakpointData(PING_PONG_URI, 34, true)],
+      initialStop: {
+        line: 34,
+        methodName: "Ping>>#validate:",
+        stackHeight: 1,
+        activity: "ping"
+      },
+      steps: [
+        {
+          type: ST.STEP_OVER,
+          activity: "ping",
+          stops: [{
+            line: 34,
+            methodName: "Ping>>#validate:",
+            stackHeight: 1,
+            activity: "ping"
+          }]
+        },
+        {
+          type: ST.STEP_TO_PROMISE_RESOLUTION,
+          activity: "ping",
+          stops: [{
+            line: 35,
+            methodName: "Ping>>#validate:",
+            stackHeight: 1,
+            activity: "ping"
+          }]
+        },
+        {
+          type: ST.RESUME,
+          activity: "ping",
+          stops: [{
+            line: 34,
+            methodName: "Ping>>#validate:",
+            stackHeight: 1,
+            activity: "ping"
+          }]
+        },
+        {
+          type: ST.RESUME,
+          activity: "ping",
+          stops: [{
+            line: 34,
+            methodName: "Ping>>#validate:",
+            stackHeight: 1,
+            activity: "ping"
+          }]
+        }
+      ]
+    },
+    {
+      title: "stepping to promise resolution for onError",
+      test: PING_PONG_FILE,
+      initialBreakpoints: [createLineBreakpointData(PING_PONG_URI, 78, true)],
+      initialStop: {
+        line: 78,
+        methodName: "Pong>>#stop",
+        stackHeight: 1,
+        activity: "pong"
+      },
+      steps: [
+        {
+          type: ST.STEP_OVER,
+          activity: "pong",
+          stops: [{
+            methodName: "Pong>>#stop",
+            line: 78,
+            stackHeight: 1,
+            activity: "pong"
+          }]
+        },
+        {
+          type: ST.STEP_TO_PROMISE_RESOLUTION,
+          activity: "pong",
+          stops: [{
+            methodName: "Pong>>#stop",
+            line: 79,
+            stackHeight: 1,
+            activity: "pong"
+          }]
+        },
+        {
+          type: ST.RESUME,
+          activity: "pong",
+          stops: [{
+            methodName: "Pong>>#λstop@78@27:",
+            line: 78,
+            stackHeight: 1,
+            activity: "pong"
+          }]
+        },
+        {
+          type: ST.RESUME,
+          activity: "pong",
+          stops: [{
+            line: 71,
+            methodName: "Thing>>#println",
+            stackHeight: 1,
+            activity: "pong"
+          }]
         }
       ]
     }

--- a/tools/kompos/tests/actor.ts
+++ b/tools/kompos/tests/actor.ts
@@ -484,6 +484,16 @@ describe("Actor Stepping", () => {
   ];
 
   for (const suite of steppingTests) {
+    if (suite.skip) {
+      describe.skip(suite.title, () => {
+        if (!suite.steps) { return; }
+        suite.steps.forEach(step => {
+          const desc = step.desc ? step.desc : `do ${step.type} on ${step.activity}.`;
+          it.skip(desc, () => { });
+        });
+      });
+      continue;
+    }
 
     describe(suite.title, () => {
       let ctrl: TestController;

--- a/tools/kompos/tests/actor.ts
+++ b/tools/kompos/tests/actor.ts
@@ -73,17 +73,17 @@ describe("Actor Stepping", () => {
       test: "return from turn to promise resolution",
       type: ST.RETURN_FROM_TURN_TO_PROMISE_RESOLUTION,
       length: 1,
-      methodName: "Ping>>#validate:",
-      line: 34,
-      stackIndex: 1
+      methodName: "Ping>>#λping@27@31:",
+      line: 27,
+      stackIndex: 2
     },
     {
       test: "resume after returning from turn",
       type: ST.RESUME,
       length: 1,
-      methodName: "Ping>>#λping@27@31:",
-      line: 27,
-      stackIndex: 2
+      methodName: "Ping>>#validate:",
+      line: 33,
+      stackIndex: 1
     }],
 
     "stepping to next turn":
@@ -97,17 +97,17 @@ describe("Actor Stepping", () => {
     {
       test: "step to next turn",
       type: ST.STEP_TO_NEXT_TURN,
-      length: 2,
-      methodName: "Ping>>#ping",
-      line: 24,
+      length: 1,
+      methodName: "Ping>>#pong:",
+      line: 56,
       stackIndex: 1
     },
     {
       test: "resume after stepping to next turn",
       type: ST.RESUME,
       length: 1,
-      methodName: "Ping>>#validate:",
-      line: 33,
+      methodName: "Ping>>#ping",
+      line: 23,
       stackIndex: 2
     }],
 
@@ -197,7 +197,7 @@ describe("Actor Stepping", () => {
       test: "should resume after step to promise resolution",
       type: ST.RESUME,
       length: 1,
-      methodName: "Ping>>#λping@27@31:",
+      methodName: "Ping>>#ping",
       line: 27,
       stackIndex: 3
     },
@@ -205,8 +205,8 @@ describe("Actor Stepping", () => {
       test: "should resume again to get to resolution",
       type: ST.RESUME,
       length: 1,
-      methodName: "Thing>>#println",
-      line: 71,
+      methodName: "Ping>>#ping",
+      line: 27,
       stackIndex: 4
     }],
 
@@ -238,7 +238,7 @@ describe("Actor Stepping", () => {
       test: "resume after step to promise resolution",
       type: ST.RESUME,
       length: 1,
-      methodName: "Ping>>#λvalidate@34@77:",
+      methodName: "Ping>>#validate:",
       line: 34,
       stackIndex: 3
     },
@@ -246,8 +246,8 @@ describe("Actor Stepping", () => {
       test: "resume again to get to resolution",
       type: ST.RESUME,
       length: 1,
-      methodName: "Thing>>#println",
-      line: 71,
+      methodName: "Ping>>#validate:",
+      line: 34,
       stackIndex: 4
     }],
 

--- a/tools/kompos/tests/stepping.ts
+++ b/tools/kompos/tests/stepping.ts
@@ -1,0 +1,113 @@
+import { expect } from "chai";
+
+import { BreakpointData } from "../src/messages";
+
+export interface Step {
+  /** Type of the stepping operation to be performed. */
+  type: string;
+
+  /** Description, shown in the test. If not given, the type is used. */
+  desc?: string;
+
+  /**
+   * Test specific handle for the activity.
+   * Handles are matched to activity ids on first use.
+   */
+  activity: string;
+
+  /** All execution stops that are a result of this step. */
+  stops?: Stop[];
+}
+
+export interface Stop {
+  /** Line at which execution stops. */
+  line: number;
+
+  /** Method in which execution stops. */
+  methodName: string;
+
+  /** Height of the stack when execution stops. */
+  stackHeight: number;
+
+  /**
+   * Test specific handle for the activity.
+   * Handles are matched to activity ids on first use.
+   */
+  activity: string;
+}
+
+export interface Test {
+  title: string;
+
+  /** Test file to be executed on SOMns. */
+  test: string;
+
+  /** Argument given to the test. */
+  testArg?: string;
+
+  initialBreakpoints?: BreakpointData[];
+
+  initialStop: Stop;
+
+  steps?: Step[];
+}
+
+export function numberOfStops(test: Test) {
+  let cnt = 0;
+
+  console.assert(test.initialStop);
+  cnt += 1;
+
+  if (test.steps) {
+    for (const step of test.steps) {
+      if (step.stops) {
+        for (const _ of step.stops) {
+          cnt += 1;
+        }
+      }
+    }
+  }
+
+  return cnt;
+}
+
+function removeMatching(actual: Stop[], match: Stop) {
+  for (const aIdx in actual) {
+    const a = actual[aIdx];
+
+    // remove matching
+    if (match.activity === a.activity && match.line === a.line &&
+      match.methodName === a.methodName &&
+      match.stackHeight === a.stackHeight) {
+      delete actual[aIdx];
+      return true;
+    }
+  }
+  return false;
+}
+
+export function expectStops(actual?: Stop[], expected?: Stop[]) {
+  if (expected === undefined || expected === null) {
+    expect(actual).to.be.empty;
+    return;
+  }
+
+  expect(actual).to.be.an("array");
+  expect(expected).to.be.an("array");
+  // expect(actual).to.have.lengthOf(expect.length);
+
+  const expectedCopy = expected.slice();
+  const copy = actual.slice();
+
+  for (const e of expected) {
+    const removed = removeMatching(copy, e);
+    if (removed) {
+      removeMatching(expectedCopy, e);
+    }
+  }
+
+  const e = expectedCopy.filter(v => { return v !== undefined });
+  const c = copy.filter(v => { return v !== undefined });
+  expect(c).to.deep.equal(e);
+  expect(c).to.be.empty;
+}

--- a/tools/kompos/tests/stepping.ts
+++ b/tools/kompos/tests/stepping.ts
@@ -50,6 +50,9 @@ export interface Test {
   initialStop: Stop;
 
   steps?: Step[];
+
+  /** Mark test to be skipped. */
+  skip?: boolean;
 }
 
 export function numberOfStops(test: Test) {

--- a/tools/kompos/tests/test-setup.ts
+++ b/tools/kompos/tests/test-setup.ts
@@ -64,7 +64,7 @@ export class TestConnection extends VmConnection {
 
   private startSom(extraArgs?: string[], triggerDebugger?: boolean, testFile?: string) {
     if (!testFile) { testFile = "tests/pingpong.som"; }
-    let args = ["-G", "-t1", "-wd", testFile];
+    let args = ["-G", "-wd", testFile];
     if (triggerDebugger) { args = ["-d"].concat(args); };
     if (extraArgs) { args = args.concat(extraArgs); }
 


### PR DESCRIPTION
#### Turn Stepping Operations

Actor turn stepping operations needs to resume execution of current actor.
This includes step to next turn, and return from turn to resolution.
Without resuming execution of the current actor, the behavior in the debugger is really unintuitive. It says 'step to next turn', but it doesn't actually do that. It just did a step-over, which I don't understand why that would be desirable.

#### Add new way of writting stepping tests

The main benefit of this approach is that we can handle non-deterministic stepping results easily and don’t need to do it in the assertions manually.

This new stepping.ts introduces the data format for the tests, and it is currently used in actor.ts to generate tests.

The basic idea is that an initial set of breakpoints results in a single stop, from which we then can take separate steps, which each lead to n predetermined stops at given positions.

Note that the system uses aliases for the actors instead of ids which are fragile. It determines the activity id by matching it against the expected names used in the steps. So, it discovers the mapping at run time automatically. This works, as long as we introduce activities only gradually.

#### Other changes

- make Kompos tests run on more than one thread
- simplify actor demo for presentation
- don't allow stepping into creation of actors, doesn't make sense, they are second-class entities only

@ctrlpz please add this PR on your todo list for after you're done with your current work.
This is stuff that's relevant for you, and I want you to have a look at it.
But, I'll already merge the changes to be able to make progress on other things.