### PR TITLE
Replace node constructors with explicit initialization

### DIFF
--- a/src/som/compiler/MethodBuilder.java
+++ b/src/som/compiler/MethodBuilder.java
@@ -25,7 +25,6 @@
 package som.compiler;
 
 import static som.interpreter.SNodeFactory.createCatchNonLocalReturn;
-import static som.interpreter.SNodeFactory.createNonLocalReturn;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -643,11 +642,10 @@ public final class MethodBuilder {
     return null;
   }
 
-  public ReturnNonLocalNode getNonLocalReturn(final ExpressionNode expr,
-      final SourceSection source) {
+  public ReturnNonLocalNode getNonLocalReturn(final ExpressionNode expr) {
     makeCatchNonLocalReturn();
-    return createNonLocalReturn(expr, getFrameOnStackMarkerVar(),
-        getOuterSelfContextLevel(), source);
+    return new ReturnNonLocalNode(expr, getFrameOnStackMarkerVar(),
+        getOuterSelfContextLevel());
   }
 
   public MethodBuilder getOuterBuilder() {
@@ -684,7 +682,7 @@ public final class MethodBuilder {
       return getSelfRead(source);
     } else {
       return OuterObjectReadNodeGen.create(ctxLevel, lexicalSelfMixinId,
-          enclosing.getMixinId(), source, getSelfRead(source));
+          enclosing.getMixinId(), getSelfRead(source)).initialize(source);
     }
   }
 

--- a/src/som/compiler/MixinBuilder.java
+++ b/src/som/compiler/MixinBuilder.java
@@ -518,9 +518,9 @@ public final class MixinBuilder {
   private SInvokable assemblePrimaryFactoryMethod() {
     // first create new Object
 
-    ExpressionNode newObject = NewObjectPrimNodeGen.create(
-        primaryFactorySource, mixinId,
+    ExpressionNode newObject = NewObjectPrimNodeGen.create(mixinId,
         primaryFactoryMethod.getSelfRead(primaryFactorySource));
+    newObject.initialize(primaryFactorySource);
 
     List<ExpressionNode> args = createPrimaryFactoryArgumentRead(newObject);
 

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -423,7 +423,7 @@ public final class MixinDefinition {
   private SInitializer assembleMixinInitializer(final int mixinId) {
     ExpressionNode body;
     if (initializerBody == null) {
-      body = new NilLiteralNode(initializerSource);
+      body = new NilLiteralNode().initialize(initializerSource);
     } else {
       body = SNodeFactory.createSequence(initializerBody, initializerSource);
     }

--- a/src/som/compiler/Variable.java
+++ b/src/som/compiler/Variable.java
@@ -101,9 +101,9 @@ public abstract class Variable {
         final SourceSection source) {
       assert this instanceof Argument;
       if (contextLevel == 0) {
-        return new LocalSelfReadNode(this, holderMixin, source);
+        return new LocalSelfReadNode(this, holderMixin).initialize(source);
       } else {
-        return new NonLocalSelfReadNode(this, holderMixin, contextLevel, source);
+        return new NonLocalSelfReadNode(this, holderMixin, contextLevel).initialize(source);
       }
     }
 
@@ -112,9 +112,10 @@ public abstract class Variable {
         final SourceSection source) {
       assert this instanceof Argument;
       if (contextLevel == 0) {
-        return new LocalSuperReadNode(this, holderClass, classSide, source);
+        return new LocalSuperReadNode(this, holderClass, classSide).initialize(source);
       } else {
-        return new NonLocalSuperReadNode(this, contextLevel, holderClass, classSide, source);
+        return new NonLocalSuperReadNode(this, contextLevel, holderClass,
+            classSide).initialize(source);
       }
     }
 
@@ -139,9 +140,9 @@ public abstract class Variable {
         final SourceSection source) {
       transferToInterpreterAndInvalidate("Variable.getReadNode");
       if (contextLevel == 0) {
-        return new LocalArgumentReadNode(this, source);
+        return new LocalArgumentReadNode(this).initialize(source);
       } else {
-        return new NonLocalArgumentReadNode(this, contextLevel, source);
+        return new NonLocalArgumentReadNode(this, contextLevel).initialize(source);
       }
     }
 
@@ -171,11 +172,14 @@ public abstract class Variable {
     public ExpressionNode getReadNode(final int contextLevel,
         final SourceSection source) {
       transferToInterpreterAndInvalidate("Variable.getReadNode");
+      ExpressionNode node;
       if (contextLevel == 0) {
-        return LocalVariableReadNodeGen.create(this, source);
+        node = LocalVariableReadNodeGen.create(this);
       } else {
-        return NonLocalVariableReadNodeGen.create(contextLevel, this, source);
+        node = NonLocalVariableReadNodeGen.create(contextLevel, this);
       }
+      node.initialize(source);
+      return node;
     }
 
     public FrameSlot getSlot() {
@@ -194,12 +198,14 @@ public abstract class Variable {
     public ExpressionNode getWriteNode(final int contextLevel,
         final ExpressionNode valueExpr, final SourceSection source) {
       transferToInterpreterAndInvalidate("Variable.getWriteNode");
+      ExpressionNode node;
       if (contextLevel == 0) {
-        return LocalVariableWriteNodeGen.create(this, source, valueExpr);
+        node = LocalVariableWriteNodeGen.create(this, valueExpr);
       } else {
-        return NonLocalVariableWriteNodeGen.create(
-            contextLevel, this, source, valueExpr);
+        node = NonLocalVariableWriteNodeGen.create(contextLevel, this, valueExpr);
       }
+      node.initialize(source);
+      return node;
     }
 
     @Override

--- a/src/som/instrumentation/MessageSendNodeWrapper.java
+++ b/src/som/instrumentation/MessageSendNodeWrapper.java
@@ -28,9 +28,8 @@ public class MessageSendNodeWrapper
     @Child private ExpressionNode delegate;
     @Child private ProbeNode      probe;
 
-    private MessageSendWrapper(final AbstractMessageSendNode delegate,
-        final ProbeNode probe) {
-      super(null, null);
+    private MessageSendWrapper(final AbstractMessageSendNode delegate, final ProbeNode probe) {
+      super(null);
       this.delegate = delegate;
       this.probe = probe;
     }

--- a/src/som/interop/InteropDispatch.java
+++ b/src/som/interop/InteropDispatch.java
@@ -53,7 +53,7 @@ public abstract class InteropDispatch extends Node {
   protected AbstractMessageSendNode createSend(final String selector, final Object[] args) {
     SClass cls = Types.getClassOf(args[0]);
     SSymbol firstFit = lookupWithPrefix(selector, cls, args.length);
-    return MessageSendNode.createForPerformNodes(firstFit, null, vm);
+    return MessageSendNode.createForPerformNodes(null, firstFit, vm);
   }
 
   @Specialization(guards = {"selector == cachedSelector"},

--- a/src/som/interpreter/SNodeFactory.java
+++ b/src/som/interpreter/SNodeFactory.java
@@ -14,7 +14,6 @@ import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.InternalObjectArrayNode;
 import som.interpreter.nodes.MessageSendNode;
 import som.interpreter.nodes.ResolvingImplicitReceiverSend;
-import som.interpreter.nodes.ReturnNonLocalNode;
 import som.interpreter.nodes.ReturnNonLocalNode.CatchNonLocalReturnNode;
 import som.interpreter.nodes.SequenceNode;
 import som.interpreter.nodes.literals.NilLiteralNode;
@@ -32,7 +31,7 @@ public final class SNodeFactory {
 
   public static InitializerFieldWrite createFieldWrite(final ExpressionNode self,
       final ExpressionNode exp, final SlotDefinition slot, final SourceSection source) {
-    return InitializerFieldWriteNodeGen.create(slot, source, self, exp);
+    return InitializerFieldWriteNodeGen.create(slot, self, exp).initialize(source);
   }
 
   public static ExpressionNode createSequence(
@@ -42,11 +41,13 @@ public final class SNodeFactory {
     }
 
     if (expressions.size() == 0) {
-      return new NilLiteralNode(source);
+      return new NilLiteralNode().initialize(source);
     } else if (expressions.size() == 1) {
       return expressions.get(0);
     }
-    return new SequenceNode(expressions.toArray(new ExpressionNode[0]), source);
+
+    SequenceNode s = new SequenceNode(expressions.toArray(new ExpressionNode[0]));
+    return s.initialize(source);
   }
 
   public static ExpressionNode createMessageSend(final SSymbol msg,
@@ -55,7 +56,7 @@ public final class SNodeFactory {
       final SomLanguage lang) {
     if (eventualSend) {
       return new EventualSendNode(msg, exprs.length,
-          new InternalObjectArrayNode(exprs, source), source, sendOperator, lang);
+          new InternalObjectArrayNode(exprs).initialize(source), source, sendOperator, lang);
     } else {
       return MessageSendNode.createMessageSend(msg, exprs, source, lang.getVM());
     }
@@ -67,23 +68,17 @@ public final class SNodeFactory {
         exprs.toArray(new ExpressionNode[0]), source, vm);
   }
 
-  public static ReturnNonLocalNode createNonLocalReturn(final ExpressionNode exp,
-      final Internal marker, final int contextLevel,
-      final SourceSection source) {
-    return new ReturnNonLocalNode(exp, marker, contextLevel, source);
-  }
-
   public static ExpressionNode createImplicitReceiverSend(
       final SSymbol selector, final ExpressionNode[] arguments,
       final MethodScope currentScope, final MixinDefinitionId mixinDefId,
       final SourceSection source, final VM vm) {
     assert mixinDefId != null;
     return new ResolvingImplicitReceiverSend(selector, arguments,
-        currentScope, mixinDefId, source, vm);
+        currentScope, mixinDefId, vm).initialize(source);
   }
 
   public static ExpressionNode createInternalObjectArray(
       final ExpressionNode[] expressions, final SourceSection source) {
-    return new InternalObjectArrayNode(expressions, source);
+    return new InternalObjectArrayNode(expressions).initialize(source);
   }
 }

--- a/src/som/interpreter/Types.java
+++ b/src/som/interpreter/Types.java
@@ -142,7 +142,7 @@ public class Types {
   private static SizeAndLengthPrim sizePrim;
 
   static {
-    sizePrim = SizeAndLengthPrimFactory.create(false, null, null);
+    sizePrim = SizeAndLengthPrimFactory.create(null);
     new DummyParent(sizePrim);
   }
 

--- a/src/som/interpreter/actors/AbstractPromiseResolutionNode.java
+++ b/src/som/interpreter/actors/AbstractPromiseResolutionNode.java
@@ -23,19 +23,22 @@ public abstract class AbstractPromiseResolutionNode extends QuaternaryExpression
   @Child protected WrapReferenceNode   wrapper = WrapReferenceNodeGen.create();
   @Child protected UnaryExpressionNode haltNode;
 
-  protected AbstractPromiseResolutionNode(final boolean eagWrap, final SourceSection source,
-      final ForkJoinPool actorPool) {
-    super(eagWrap, source);
+  protected AbstractPromiseResolutionNode(final ForkJoinPool actorPool) {
     this.actorPool = actorPool;
-    haltNode = insert(SuspendExecutionNodeGen.create(false, source, 2, null));
-    VM.insertInstrumentationWrapper(haltNode);
+    haltNode = insert(SuspendExecutionNodeGen.create(2, null));
   }
 
   protected AbstractPromiseResolutionNode(final AbstractPromiseResolutionNode node) {
-    super(node);
-    this.actorPool = node.actorPool;
-    haltNode = insert(SuspendExecutionNodeGen.create(false, node.getSourceSection(), 2, null));
+    this(node.actorPool);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public AbstractPromiseResolutionNode initialize(final SourceSection sourceSection) {
+    super.initialize(sourceSection);
+    haltNode.initialize(sourceSection);
     VM.insertInstrumentationWrapper(haltNode);
+    return this;
   }
 
   public abstract Object executeEvaluated(VirtualFrame frame,

--- a/src/som/interpreter/actors/ErrorPromiseNode.java
+++ b/src/som/interpreter/actors/ErrorPromiseNode.java
@@ -3,7 +3,6 @@ package som.interpreter.actors;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.actors.SPromise.Resolution;
@@ -15,12 +14,8 @@ import som.primitives.Primitive;
 @Primitive(primitive = "actorsError:with:isBPResolver:isBPResolution:", requiresContext = true)
 public abstract class ErrorPromiseNode extends AbstractPromiseResolutionNode {
 
-  protected ErrorPromiseNode(final boolean eagWrap, final SourceSection source, final VM vm) {
-    super(eagWrap, source, vm.getActorPool());
-  }
-
-  protected ErrorPromiseNode(final ErrorPromiseNode node) {
-    super(node);
+  protected ErrorPromiseNode(final VM vm) {
+    super(vm.getActorPool());
   }
 
   /**

--- a/src/som/interpreter/actors/ErrorPromiseNode.java
+++ b/src/som/interpreter/actors/ErrorPromiseNode.java
@@ -4,20 +4,14 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
-import som.VM;
 import som.interpreter.actors.SPromise.Resolution;
 import som.interpreter.actors.SPromise.SResolver;
 import som.primitives.Primitive;
 
 
 @GenerateNodeFactory
-@Primitive(primitive = "actorsError:with:isBPResolver:isBPResolution:", requiresContext = true)
+@Primitive(primitive = "actorsError:with:isBPResolver:isBPResolution:")
 public abstract class ErrorPromiseNode extends AbstractPromiseResolutionNode {
-
-  protected ErrorPromiseNode(final VM vm) {
-    super(vm.getActorPool());
-  }
-
   /**
    * Standard error case, when the promise is errored with a value that's not a promise.
    */

--- a/src/som/interpreter/actors/EventualSendNode.java
+++ b/src/som/interpreter/actors/EventualSendNode.java
@@ -49,19 +49,14 @@ public class EventualSendNode extends ExprWithTagsNode {
   public EventualSendNode(final SSymbol selector, final int numArgs,
       final InternalObjectArrayNode arguments, final SourceSection source,
       final SourceSection sendOperator, final SomLanguage lang) {
-    super(source);
     this.arguments = arguments;
     this.send = SendNodeGen.create(selector, createArgWrapper(numArgs),
         createOnReceiveCallTarget(selector, source, lang),
         sendOperator, lang.getVM());
+    initialize(source);
   }
 
-  /**
-   * Use for wrapping node only.
-   */
-  protected EventualSendNode(final EventualSendNode wrappedNode) {
-    super((SourceSection) null);
-  }
+  protected EventualSendNode(final EventualSendNode wrappedNode) {}
 
   @Override
   public Object executeGeneric(final VirtualFrame frame) {

--- a/src/som/interpreter/actors/ReceivedRootNode.java
+++ b/src/som/interpreter/actors/ReceivedRootNode.java
@@ -1,5 +1,7 @@
 package som.interpreter.actors;
 
+import java.util.concurrent.ForkJoinPool;
+
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -47,10 +49,9 @@ public abstract class ReceivedRootNode extends RootNode {
     if (resolve == null) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
       if (resolver == null) {
-        this.resolve = insert(new NullResolver(sourceSection));
+        this.resolve = insert(new NullResolver());
       } else {
-        this.resolve = insert(ResolvePromiseNodeFactory.create(false, sourceSection, vm, null,
-            null, null, null));
+        this.resolve = insert(ResolvePromiseNodeFactory.create(vm, null, null, null, null));
       }
     }
 
@@ -65,10 +66,9 @@ public abstract class ReceivedRootNode extends RootNode {
     if (error == null) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
       if (resolver == null) {
-        this.error = insert(new NullResolver(getSourceSection()));
+        this.error = insert(new NullResolver());
       } else {
-        this.error = insert(
-            ErrorPromiseNodeFactory.create(false, sourceSection, vm, null, null, null, null));
+        this.error = insert(ErrorPromiseNodeFactory.create(vm, null, null, null, null));
       }
     }
 
@@ -80,8 +80,8 @@ public abstract class ReceivedRootNode extends RootNode {
    * Promise resolver for the case that the actual promise has been optimized out.
    */
   public final class NullResolver extends AbstractPromiseResolutionNode {
-    public NullResolver(final SourceSection source) {
-      super(false, source, null);
+    public NullResolver() {
+      super((ForkJoinPool) null);
     }
 
     @Override

--- a/src/som/interpreter/actors/ReceivedRootNode.java
+++ b/src/som/interpreter/actors/ReceivedRootNode.java
@@ -1,7 +1,5 @@
 package som.interpreter.actors;
 
-import java.util.concurrent.ForkJoinPool;
-
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -51,7 +49,8 @@ public abstract class ReceivedRootNode extends RootNode {
       if (resolver == null) {
         this.resolve = insert(new NullResolver());
       } else {
-        this.resolve = insert(ResolvePromiseNodeFactory.create(vm, null, null, null, null));
+        this.resolve = insert(
+            ResolvePromiseNodeFactory.create(null, null, null, null).initialize(vm));
       }
     }
 
@@ -68,7 +67,8 @@ public abstract class ReceivedRootNode extends RootNode {
       if (resolver == null) {
         this.error = insert(new NullResolver());
       } else {
-        this.error = insert(ErrorPromiseNodeFactory.create(vm, null, null, null, null));
+        this.error = insert(
+            ErrorPromiseNodeFactory.create(null, null, null, null).initialize(vm));
       }
     }
 
@@ -80,10 +80,6 @@ public abstract class ReceivedRootNode extends RootNode {
    * Promise resolver for the case that the actual promise has been optimized out.
    */
   public final class NullResolver extends AbstractPromiseResolutionNode {
-    public NullResolver() {
-      super((ForkJoinPool) null);
-    }
-
     @Override
     public Object executeEvaluated(final VirtualFrame frame,
         final SResolver receiver, final Object argument,

--- a/src/som/interpreter/actors/ResolvePromiseNode.java
+++ b/src/som/interpreter/actors/ResolvePromiseNode.java
@@ -4,21 +4,14 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
-import som.VM;
 import som.interpreter.actors.SPromise.Resolution;
 import som.interpreter.actors.SPromise.SResolver;
 import som.primitives.Primitive;
 
 
 @GenerateNodeFactory
-@Primitive(primitive = "actorsResolve:with:isBPResolver:isBPResolution:",
-    requiresContext = true)
+@Primitive(primitive = "actorsResolve:with:isBPResolver:isBPResolution:")
 public abstract class ResolvePromiseNode extends AbstractPromiseResolutionNode {
-
-  protected ResolvePromiseNode(final VM vm) {
-    super(vm.getActorPool());
-  }
-
   /**
    * Normal case, when the promise is resolved with a value that's not a promise.
    * Here we need to distinguish the explicit promises to ask directly to the promise

--- a/src/som/interpreter/actors/ResolvePromiseNode.java
+++ b/src/som/interpreter/actors/ResolvePromiseNode.java
@@ -3,7 +3,6 @@ package som.interpreter.actors;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.actors.SPromise.Resolution;
@@ -16,13 +15,8 @@ import som.primitives.Primitive;
     requiresContext = true)
 public abstract class ResolvePromiseNode extends AbstractPromiseResolutionNode {
 
-  protected ResolvePromiseNode(final boolean eagWrap, final SourceSection source,
-      final VM vm) {
-    super(eagWrap, source, vm.getActorPool());
-  }
-
-  protected ResolvePromiseNode(final ResolvePromiseNode node) {
-    super(node);
+  protected ResolvePromiseNode(final VM vm) {
+    super(vm.getActorPool());
   }
 
   /**

--- a/src/som/interpreter/actors/SuspendExecutionNode.java
+++ b/src/som/interpreter/actors/SuspendExecutionNode.java
@@ -2,7 +2,6 @@ package som.interpreter.actors;
 
 import com.oracle.truffle.api.debug.DebuggerTags.AlwaysHalt;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryExpressionNode;
 
@@ -10,14 +9,7 @@ import som.interpreter.nodes.nary.UnaryExpressionNode;
 public abstract class SuspendExecutionNode extends UnaryExpressionNode {
   private int skipFrames;
 
-  SuspendExecutionNode(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-    this.skipFrames = 0;
-  }
-
-  SuspendExecutionNode(final boolean eagWrap, final SourceSection source,
-      final int skipFrames) {
-    super(eagWrap, source);
+  SuspendExecutionNode(final int skipFrames) {
     this.skipFrames = skipFrames;
   }
 

--- a/src/som/interpreter/actors/WrapReferenceNode.java
+++ b/src/som/interpreter/actors/WrapReferenceNode.java
@@ -46,7 +46,7 @@ public abstract class WrapReferenceNode extends Node {
     return !(obj instanceof SFarReference) && !(obj instanceof SPromise);
   }
 
-  @Child protected IsValue isValue = IsValueFactory.create(false, null, null);
+  @Child protected IsValue isValue = IsValueFactory.create(null);
 
   protected final boolean isValue(final Object obj) {
     return isValue.executeEvaluated(obj);

--- a/src/som/interpreter/nodes/ArgumentReadNode.java
+++ b/src/som/interpreter/nodes/ArgumentReadNode.java
@@ -3,7 +3,6 @@ package som.interpreter.nodes;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
 import com.oracle.truffle.api.profiles.ValueProfile;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.MixinBuilder.MixinDefinitionId;
 import som.compiler.Variable.Argument;
@@ -22,27 +21,22 @@ public abstract class ArgumentReadNode {
     protected final int      argumentIndex;
     protected final Argument arg;
 
-    public LocalArgumentReadNode(final Argument arg, final SourceSection source) {
-      super(source);
+    public LocalArgumentReadNode(final Argument arg) {
       assert arg.index > 0 ||
           this instanceof LocalSelfReadNode ||
           this instanceof LocalSuperReadNode;
-      assert source != null;
       this.argumentIndex = arg.index;
       this.arg = arg;
     }
 
     /** For Wrapper use only. */
     protected LocalArgumentReadNode(final LocalArgumentReadNode wrappedNode) {
-      super(wrappedNode);
       this.argumentIndex = wrappedNode.argumentIndex;
       this.arg = wrappedNode.arg;
     }
 
     /** For use in primitives only. */
-    public LocalArgumentReadNode(final boolean insidePrim, final int argIdx,
-        final SourceSection source) {
-      super(source);
+    public LocalArgumentReadNode(final boolean insidePrim, final int argIdx) {
       this.argumentIndex = argIdx;
       this.arg = null;
       assert insidePrim : "Only to be used for primitive nodes";
@@ -80,9 +74,8 @@ public abstract class ArgumentReadNode {
     private final MixinDefinitionId mixin;
     private final ValueProfile      rcvrClass = ValueProfile.createClassProfile();
 
-    public LocalSelfReadNode(final Argument arg, final MixinDefinitionId mixin,
-        final SourceSection source) {
-      super(arg, source);
+    public LocalSelfReadNode(final Argument arg, final MixinDefinitionId mixin) {
+      super(arg);
       this.mixin = mixin;
     }
 
@@ -125,9 +118,8 @@ public abstract class ArgumentReadNode {
     protected final int      argumentIndex;
     protected final Argument arg;
 
-    public NonLocalArgumentReadNode(final Argument arg, final int contextLevel,
-        final SourceSection source) {
-      super(contextLevel, source);
+    public NonLocalArgumentReadNode(final Argument arg, final int contextLevel) {
+      super(contextLevel);
       assert contextLevel > 0;
       assert arg.index > 0 ||
           this instanceof NonLocalSelfReadNode ||
@@ -165,8 +157,8 @@ public abstract class ArgumentReadNode {
     private final ValueProfile rcvrClass = ValueProfile.createClassProfile();
 
     public NonLocalSelfReadNode(final Argument arg, final MixinDefinitionId mixin,
-        final int contextLevel, final SourceSection source) {
-      super(arg, contextLevel, source);
+        final int contextLevel) {
+      super(arg, contextLevel);
       this.mixin = mixin;
     }
 
@@ -211,10 +203,9 @@ public abstract class ArgumentReadNode {
     private final MixinDefinitionId holderMixin;
     private final boolean           classSide;
 
-    public LocalSuperReadNode(final Argument arg,
-        final MixinDefinitionId holderMixin, final boolean classSide,
-        final SourceSection source) {
-      super(arg, source);
+    public LocalSuperReadNode(final Argument arg, final MixinDefinitionId holderMixin,
+        final boolean classSide) {
+      super(arg);
       this.holderMixin = holderMixin;
       this.classSide = classSide;
     }
@@ -251,9 +242,8 @@ public abstract class ArgumentReadNode {
     private final boolean           classSide;
 
     public NonLocalSuperReadNode(final Argument arg, final int contextLevel,
-        final MixinDefinitionId holderMixin, final boolean classSide,
-        final SourceSection source) {
-      super(arg, contextLevel, source);
+        final MixinDefinitionId holderMixin, final boolean classSide) {
+      super(arg, contextLevel);
       this.holderMixin = holderMixin;
       this.classSide = classSide;
     }

--- a/src/som/interpreter/nodes/ContextualNode.java
+++ b/src/som/interpreter/nodes/ContextualNode.java
@@ -26,7 +26,6 @@ import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.profiles.ValueProfile;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.SArguments;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
@@ -44,8 +43,7 @@ public abstract class ContextualNode extends ExprWithTagsNode {
 
   @CompilationFinal DetermineContext determineContext;
 
-  public ContextualNode(final int contextLevel, final SourceSection source) {
-    super(source);
+  public ContextualNode(final int contextLevel) {
     this.contextLevel = contextLevel;
     this.frameType = ValueProfile.createClassProfile();
     this.outerType = ValueProfile.createClassProfile();

--- a/src/som/interpreter/nodes/ExpressionNode.java
+++ b/src/som/interpreter/nodes/ExpressionNode.java
@@ -29,7 +29,6 @@ import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
 import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.TypesGen;
 import som.interpreter.actors.SFarReference;
@@ -46,16 +45,9 @@ import som.vmobjects.SSymbol;
 @Instrumentable(factory = ExpressionNodeWrapper.class)
 public abstract class ExpressionNode extends SOMNode {
 
-  public ExpressionNode(final SourceSection sourceSection) {
-    super(sourceSection);
-  }
+  protected ExpressionNode() {}
 
-  /**
-   * Use for wrapping node only.
-   */
-  protected ExpressionNode(final ExpressionNode wrappedNode) {
-    super(null);
-  }
+  protected ExpressionNode(final ExpressionNode wrapped) {}
 
   public boolean assertIsStatement() {
     return isTaggedWith(StatementTag.class);

--- a/src/som/interpreter/nodes/InternalObjectArrayNode.java
+++ b/src/som/interpreter/nodes/InternalObjectArrayNode.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.NodeCost;
 import com.oracle.truffle.api.nodes.NodeInfo;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.ExprWithTagsNode;
 
@@ -13,9 +12,7 @@ import som.interpreter.nodes.nary.ExprWithTagsNode;
 public final class InternalObjectArrayNode extends ExprWithTagsNode {
   @Children private final ExpressionNode[] expressions;
 
-  public InternalObjectArrayNode(final ExpressionNode[] expressions,
-      final SourceSection source) {
-    super(source);
+  public InternalObjectArrayNode(final ExpressionNode[] expressions) {
     this.expressions = expressions;
   }
 

--- a/src/som/interpreter/nodes/IsValueCheckNode.java
+++ b/src/som/interpreter/nodes/IsValueCheckNode.java
@@ -22,19 +22,18 @@ public abstract class IsValueCheckNode extends UnaryExpressionNode {
 
   public static IsValueCheckNode create(final SourceSection source,
       final ExpressionNode self) {
-    return new UninitializedNode(source, self);
+    return new UninitializedNode(self).initialize(source);
   }
 
   @Child protected ExpressionNode self;
 
-  protected IsValueCheckNode(final SourceSection source, final ExpressionNode self) {
-    super(false, source);
+  protected IsValueCheckNode(final ExpressionNode self) {
     this.self = self;
   }
 
   private static final class UninitializedNode extends IsValueCheckNode {
-    UninitializedNode(final SourceSection source, final ExpressionNode self) {
-      super(source, self);
+    UninitializedNode(final ExpressionNode self) {
+      super(self);
     }
 
     @Override
@@ -59,8 +58,8 @@ public abstract class IsValueCheckNode extends UnaryExpressionNode {
       SImmutableObject rcvr = (SImmutableObject) receiver;
 
       if (rcvr.isValue()) {
-        return replace(new ValueCheckNode(sourceSection, self)).executeEvaluated(frame,
-            receiver);
+        ValueCheckNode node = new ValueCheckNode(self).initialize(sourceSection);
+        return replace(node).executeEvaluated(frame, receiver);
       } else {
         // neither transfer object nor value, so nothing to check
         dropCheckNode();
@@ -81,8 +80,8 @@ public abstract class IsValueCheckNode extends UnaryExpressionNode {
   }
 
   private static final class ValueCheckNode extends IsValueCheckNode {
-    ValueCheckNode(final SourceSection source, final ExpressionNode self) {
-      super(source, self);
+    ValueCheckNode(final ExpressionNode self) {
+      super(self);
     }
 
     @Override

--- a/src/som/interpreter/nodes/LocalVariableNode.java
+++ b/src/som/interpreter/nodes/LocalVariableNode.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.FrameSlotTypeException;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.Variable.Local;
 import som.interpreter.InliningVisitor;
@@ -21,8 +20,7 @@ public abstract class LocalVariableNode extends ExprWithTagsNode {
   protected final FrameSlot slot;
   protected final Local     var;
 
-  private LocalVariableNode(final Local var, final SourceSection source) {
-    super(source);
+  private LocalVariableNode(final Local var) {
     this.slot = var.getSlot();
     this.var = var;
   }
@@ -38,12 +36,12 @@ public abstract class LocalVariableNode extends ExprWithTagsNode {
 
   public abstract static class LocalVariableReadNode extends LocalVariableNode {
 
-    public LocalVariableReadNode(final Local variable, final SourceSection source) {
-      super(variable, source);
+    public LocalVariableReadNode(final Local variable) {
+      super(variable);
     }
 
     public LocalVariableReadNode(final LocalVariableReadNode node) {
-      this(node.var, node.sourceSection);
+      this(node.var);
     }
 
     @Specialization(guards = "isUninitialized(frame)")
@@ -116,12 +114,12 @@ public abstract class LocalVariableNode extends ExprWithTagsNode {
   @NodeChild(value = "exp", type = ExpressionNode.class)
   public abstract static class LocalVariableWriteNode extends LocalVariableNode {
 
-    public LocalVariableWriteNode(final Local variable, final SourceSection source) {
-      super(variable, source);
+    public LocalVariableWriteNode(final Local variable) {
+      super(variable);
     }
 
     public LocalVariableWriteNode(final LocalVariableWriteNode node) {
-      super(node.var, node.sourceSection);
+      super(node.var);
     }
 
     public abstract ExpressionNode getExp();

--- a/src/som/interpreter/nodes/MessageSendNode.java
+++ b/src/som/interpreter/nodes/MessageSendNode.java
@@ -62,7 +62,13 @@ public final class MessageSendNode {
 
   public static AbstractMessageSendNode createForPerformNodes(final SourceSection source,
       final SSymbol selector, final VM vm) {
-    return new UninitializedSymbolSendNode(selector, vm).initialize(source);
+    AbstractMessageSendNode result = new UninitializedSymbolSendNode(selector, vm);
+
+    // This is currently needed for interop, don't have source section there
+    if (source != null) {
+      result.initialize(source);
+    }
+    return result;
   }
 
   public static GenericMessageSendNode createGeneric(final SSymbol selector,

--- a/src/som/interpreter/nodes/NonLocalVariableNode.java
+++ b/src/som/interpreter/nodes/NonLocalVariableNode.java
@@ -8,7 +8,6 @@ import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.FrameSlotTypeException;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.Variable.Local;
 import som.interpreter.InliningVisitor;
@@ -23,9 +22,8 @@ public abstract class NonLocalVariableNode extends ContextualNode {
   protected final FrameSlot slot;
   protected final Local     var;
 
-  private NonLocalVariableNode(final int contextLevel, final Local var,
-      final SourceSection source) {
-    super(contextLevel, source);
+  private NonLocalVariableNode(final int contextLevel, final Local var) {
+    super(contextLevel);
     this.slot = var.getSlot();
     this.var = var;
   }
@@ -41,13 +39,12 @@ public abstract class NonLocalVariableNode extends ContextualNode {
 
   public abstract static class NonLocalVariableReadNode extends NonLocalVariableNode {
 
-    public NonLocalVariableReadNode(final int contextLevel,
-        final Local var, final SourceSection source) {
-      super(contextLevel, var, source);
+    public NonLocalVariableReadNode(final int contextLevel, final Local var) {
+      super(contextLevel, var);
     }
 
     public NonLocalVariableReadNode(final NonLocalVariableReadNode node) {
-      this(node.contextLevel, node.var, node.sourceSection);
+      this(node.contextLevel, node.var);
     }
 
     @Specialization(guards = "isUninitialized(frame)")
@@ -115,13 +112,12 @@ public abstract class NonLocalVariableNode extends ContextualNode {
   @NodeChild(value = "exp", type = ExpressionNode.class)
   public abstract static class NonLocalVariableWriteNode extends NonLocalVariableNode {
 
-    public NonLocalVariableWriteNode(final int contextLevel,
-        final Local var, final SourceSection source) {
-      super(contextLevel, var, source);
+    public NonLocalVariableWriteNode(final int contextLevel, final Local var) {
+      super(contextLevel, var);
     }
 
     public NonLocalVariableWriteNode(final NonLocalVariableWriteNode node) {
-      this(node.contextLevel, node.var, node.sourceSection);
+      this(node.contextLevel, node.var);
     }
 
     public abstract ExpressionNode getExp();

--- a/src/som/interpreter/nodes/OuterObjectRead.java
+++ b/src/som/interpreter/nodes/OuterObjectRead.java
@@ -10,7 +10,6 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.profiles.ValueProfile;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.MixinBuilder.MixinDefinitionId;
 import som.interpreter.actors.SFarReference;
@@ -57,11 +56,8 @@ public abstract class OuterObjectRead
 
   private final ValueProfile enclosingObj;
 
-  public OuterObjectRead(final int contextLevel,
-      final MixinDefinitionId mixinId,
-      final MixinDefinitionId enclosingMixinId,
-      final SourceSection sourceSection) {
-    super(sourceSection);
+  public OuterObjectRead(final int contextLevel, final MixinDefinitionId mixinId,
+      final MixinDefinitionId enclosingMixinId) {
     this.contextLevel = contextLevel;
     this.mixinId = mixinId;
     this.enclosingMixinId = enclosingMixinId;

--- a/src/som/interpreter/nodes/ResolvingImplicitReceiverSend.java
+++ b/src/som/interpreter/nodes/ResolvingImplicitReceiverSend.java
@@ -5,7 +5,6 @@ import java.util.concurrent.locks.Lock;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.compiler.MixinBuilder.MixinDefinitionId;
@@ -38,8 +37,8 @@ public final class ResolvingImplicitReceiverSend extends AbstractMessageSendNode
 
   public ResolvingImplicitReceiverSend(final SSymbol selector,
       final ExpressionNode[] arguments, final MethodScope currentScope,
-      final MixinDefinitionId mixinId, final SourceSection source, final VM vm) {
-    super(arguments, source);
+      final MixinDefinitionId mixinId, final VM vm) {
+    super(arguments);
     this.selector = selector;
     this.currentScope = currentScope;
     this.mixinId = mixinId;
@@ -50,7 +49,7 @@ public final class ResolvingImplicitReceiverSend extends AbstractMessageSendNode
    * For wrapped nodes only.
    */
   protected ResolvingImplicitReceiverSend(final ResolvingImplicitReceiverSend wrappedNode) {
-    super(null, null);
+    super(null);
     this.selector = wrappedNode.selector;
     this.currentScope = wrappedNode.currentScope;
     this.mixinId = wrappedNode.mixinId;
@@ -94,8 +93,8 @@ public final class ResolvingImplicitReceiverSend extends AbstractMessageSendNode
     MixinIdAndContextLevel result = currentScope.lookupSlotOrClass(selector);
     if (result != null && result.contextLevel > 0) {
       newReceiverNodeForOuterSend = OuterObjectReadNodeGen.create(
-          result.contextLevel, mixinId, result.mixinId, sourceSection,
-          argumentNodes[0]);
+          result.contextLevel, mixinId, result.mixinId,
+          argumentNodes[0]).initialize(sourceSection);
       ExpressionNode[] msgArgNodes = argumentNodes.clone();
       msgArgNodes[0] = newReceiverNodeForOuterSend;
 

--- a/src/som/interpreter/nodes/ReturnNonLocalNode.java
+++ b/src/som/interpreter/nodes/ReturnNonLocalNode.java
@@ -29,7 +29,6 @@ import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.profiles.BranchProfile;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.AccessModifier;
 import som.compiler.Variable.Internal;
@@ -52,23 +51,19 @@ public final class ReturnNonLocalNode extends ContextualNode {
   private final FrameSlot       frameOnStackMarker;
   private final Internal        onStackMarkerVar;
 
-  public ReturnNonLocalNode(final ExpressionNode expression,
-      final Internal frameOnStackMarker,
-      final int outerSelfContextLevel,
-      final SourceSection source) {
-    super(outerSelfContextLevel, source);
+  public ReturnNonLocalNode(final ExpressionNode expression, final Internal frameOnStackMarker,
+      final int outerSelfContextLevel) {
+    super(outerSelfContextLevel);
     assert outerSelfContextLevel > 0;
     this.expression = expression;
     this.frameOnStackMarker = frameOnStackMarker.getSlot();
     this.onStackMarkerVar = frameOnStackMarker;
     assert this.frameOnStackMarker.getIdentifier() == frameOnStackMarker : "We expect slots to use `Variable` objects as identity";
-    assert source != null;
   }
 
   public ReturnNonLocalNode(final ReturnNonLocalNode node,
       final Internal inlinedFrameOnStack) {
-    this(node.expression, inlinedFrameOnStack,
-        node.contextLevel, node.getSourceSection());
+    this(node.expression, inlinedFrameOnStack, node.contextLevel);
   }
 
   private FrameOnStackMarker getMarkerFromContext(final MaterializedFrame ctx) {
@@ -110,11 +105,11 @@ public final class ReturnNonLocalNode extends ContextualNode {
     if (se.var != onStackMarkerVar || se.contextLevel < contextLevel) {
       ExpressionNode node;
       if (se.contextLevel == 0) {
-        node = new ReturnLocalNode(expression, (Internal) se.var, sourceSection);
+        node = new ReturnLocalNode(expression, (Internal) se.var);
       } else {
-        node = new ReturnNonLocalNode(expression, (Internal) se.var, se.contextLevel,
-            sourceSection);
+        node = new ReturnNonLocalNode(expression, (Internal) se.var, se.contextLevel);
       }
+      node.initialize(sourceSection);
       replace(node);
     }
   }
@@ -129,9 +124,7 @@ public final class ReturnNonLocalNode extends ContextualNode {
     private final FrameSlot       frameOnStackMarker;
     private final Internal        onStackMarkerVar;
 
-    private ReturnLocalNode(final ExpressionNode exp,
-        final Internal onStackMarker, final SourceSection source) {
-      super(source);
+    private ReturnLocalNode(final ExpressionNode exp, final Internal onStackMarker) {
       this.expression = exp;
       this.frameOnStackMarker = onStackMarker.getSlot();
       this.onStackMarkerVar = onStackMarker;
@@ -165,7 +158,9 @@ public final class ReturnNonLocalNode extends ContextualNode {
     public void replaceAfterScopeChange(final InliningVisitor inliner) {
       ScopeElement se = inliner.getSplitVar(onStackMarkerVar);
       if (se.var != onStackMarkerVar) {
-        replace(new ReturnLocalNode(expression, (Internal) se.var, sourceSection));
+        ReturnLocalNode node = new ReturnLocalNode(expression, (Internal) se.var);
+        node.initialize(sourceSection);
+        replace(node);
       }
     }
   }
@@ -180,7 +175,7 @@ public final class ReturnNonLocalNode extends ContextualNode {
 
     public CatchNonLocalReturnNode(final ExpressionNode methodBody,
         final Internal frameOnStackMarker) {
-      super(methodBody.getSourceSection());
+      this.sourceSection = methodBody.sourceSection;
       this.methodBody = methodBody;
       this.nonLocalReturnHandler = BranchProfile.create();
       this.frameOnStackMarker = frameOnStackMarker.getSlot();

--- a/src/som/interpreter/nodes/SOMNode.java
+++ b/src/som/interpreter/nodes/SOMNode.java
@@ -24,6 +24,7 @@ package som.interpreter.nodes;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.TypeSystemReference;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
@@ -37,11 +38,14 @@ import som.interpreter.Types;
 @TypeSystemReference(Types.class)
 public abstract class SOMNode extends Node {
 
-  protected final SourceSection sourceSection;
+  @CompilationFinal protected SourceSection sourceSection;
 
-  public SOMNode(final SourceSection sourceSection) {
-    super();
+  @SuppressWarnings("unchecked")
+  public <T extends SOMNode> T initialize(final SourceSection sourceSection) {
+    assert sourceSection != null;
+    assert this.sourceSection == null : "sourceSection should only be set once";
     this.sourceSection = sourceSection;
+    return (T) this;
   }
 
   @Override

--- a/src/som/interpreter/nodes/SequenceNode.java
+++ b/src/som/interpreter/nodes/SequenceNode.java
@@ -26,7 +26,6 @@ import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeCost;
 import com.oracle.truffle.api.nodes.NodeInfo;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.ExprWithTagsNode;
 
@@ -35,9 +34,7 @@ import som.interpreter.nodes.nary.ExprWithTagsNode;
 public final class SequenceNode extends ExprWithTagsNode {
   @Children private final ExpressionNode[] expressions;
 
-  public SequenceNode(final ExpressionNode[] expressions, final SourceSection source) {
-    super(source);
-    assert source != null;
+  public SequenceNode(final ExpressionNode[] expressions) {
     this.expressions = expressions;
   }
 

--- a/src/som/interpreter/nodes/dispatch/UninitializedDispatchNode.java
+++ b/src/som/interpreter/nodes/dispatch/UninitializedDispatchNode.java
@@ -200,8 +200,7 @@ public final class UninitializedDispatchNode {
       if (result != null) {
         assert result.getAccessModifier() != AccessModifier.PRIVATE;
       }
-      return new UninitializedReceiverSend(
-          getSourceSection(), selector, minimalVisibility);
+      return new UninitializedReceiverSend(sourceSection, selector, minimalVisibility);
     }
 
     @Override

--- a/src/som/interpreter/nodes/literals/ArrayLiteralNode.java
+++ b/src/som/interpreter/nodes/literals/ArrayLiteralNode.java
@@ -14,14 +14,12 @@ import tools.dym.Tags.NewArray;
 public abstract class ArrayLiteralNode extends LiteralNode {
   public static ArrayLiteralNode create(final ExpressionNode[] exprs,
       final SourceSection source) {
-    return new Uninit(exprs, source);
+    return new Uninit(exprs).initialize(source);
   }
 
   @Children protected final ExpressionNode[] expressions;
 
-  protected ArrayLiteralNode(final ExpressionNode[] expressions, final SourceSection source) {
-    super(source);
-    assert source != null;
+  protected ArrayLiteralNode(final ExpressionNode[] expressions) {
     this.expressions = expressions;
   }
 
@@ -35,8 +33,8 @@ public abstract class ArrayLiteralNode extends LiteralNode {
   }
 
   private static final class Uninit extends ArrayLiteralNode {
-    private Uninit(final ExpressionNode[] expressions, final SourceSection source) {
-      super(expressions, source);
+    private Uninit(final ExpressionNode[] expressions) {
+      super(expressions);
     }
 
     @Override
@@ -49,24 +47,26 @@ public abstract class ArrayLiteralNode extends LiteralNode {
     }
 
     private void specialize(final SMutableArray storage) {
+      LiteralNode node;
       if (storage.isBooleanType()) {
-        replace(new Booleans(expressions, sourceSection));
+        node = new Booleans(expressions);
       } else if (storage.isDoubleType()) {
-        replace(new Doubles(expressions, sourceSection));
+        node = new Doubles(expressions);
       } else if (storage.isEmptyType()) {
-        replace(new Empty(expressions, sourceSection));
+        node = new Empty(expressions);
       } else if (storage.isLongType()) {
-        replace(new Longs(expressions, sourceSection));
+        node = new Longs(expressions);
       } else {
         assert storage.isObjectType() : "Partially empty is not supported yet. Should be simple to add.";
-        replace(new Objects(expressions, sourceSection));
+        node = new Objects(expressions);
       }
+      replace(node.initialize(sourceSection));
     }
   }
 
   private abstract static class Specialized extends ArrayLiteralNode {
-    private Specialized(final ExpressionNode[] expressions, final SourceSection source) {
-      super(expressions, source);
+    private Specialized(final ExpressionNode[] expressions) {
+      super(expressions);
     }
 
     protected abstract Object executeSpecialized(VirtualFrame frame);
@@ -78,15 +78,15 @@ public abstract class ArrayLiteralNode extends LiteralNode {
       Object storage = executeSpecialized(frame);
       SMutableArray result = new SMutableArray(storage, Classes.arrayClass);
       if (!expectedType(result)) {
-        replace(new Objects(expressions, sourceSection));
+        replace(new Objects(expressions).initialize(sourceSection));
       }
       return result;
     }
   }
 
   private static final class Booleans extends Specialized {
-    private Booleans(final ExpressionNode[] expressions, final SourceSection source) {
-      super(expressions, source);
+    private Booleans(final ExpressionNode[] expressions) {
+      super(expressions);
     }
 
     @Override
@@ -102,8 +102,8 @@ public abstract class ArrayLiteralNode extends LiteralNode {
   }
 
   private static final class Doubles extends Specialized {
-    private Doubles(final ExpressionNode[] expressions, final SourceSection source) {
-      super(expressions, source);
+    private Doubles(final ExpressionNode[] expressions) {
+      super(expressions);
     }
 
     @Override
@@ -119,8 +119,8 @@ public abstract class ArrayLiteralNode extends LiteralNode {
   }
 
   private static final class Longs extends Specialized {
-    private Longs(final ExpressionNode[] expressions, final SourceSection source) {
-      super(expressions, source);
+    private Longs(final ExpressionNode[] expressions) {
+      super(expressions);
     }
 
     @Override
@@ -136,8 +136,8 @@ public abstract class ArrayLiteralNode extends LiteralNode {
   }
 
   private static final class Empty extends Specialized {
-    private Empty(final ExpressionNode[] expressions, final SourceSection source) {
-      super(expressions, source);
+    private Empty(final ExpressionNode[] expressions) {
+      super(expressions);
     }
 
     @Override
@@ -153,8 +153,8 @@ public abstract class ArrayLiteralNode extends LiteralNode {
   }
 
   private static final class Objects extends Specialized {
-    private Objects(final ExpressionNode[] expressions, final SourceSection source) {
-      super(expressions, source);
+    private Objects(final ExpressionNode[] expressions) {
+      super(expressions);
     }
 
     @Override

--- a/src/som/interpreter/nodes/literals/BigIntegerLiteralNode.java
+++ b/src/som/interpreter/nodes/literals/BigIntegerLiteralNode.java
@@ -3,16 +3,13 @@ package som.interpreter.nodes.literals;
 import java.math.BigInteger;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 
 public final class BigIntegerLiteralNode extends LiteralNode {
 
   private final BigInteger value;
 
-  public BigIntegerLiteralNode(final BigInteger value,
-      final SourceSection source) {
-    super(source);
+  public BigIntegerLiteralNode(final BigInteger value) {
     this.value = value;
   }
 

--- a/src/som/interpreter/nodes/literals/BlockNode.java
+++ b/src/som/interpreter/nodes/literals/BlockNode.java
@@ -3,7 +3,6 @@ package som.interpreter.nodes.literals;
 import java.util.ArrayList;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.AccessModifier;
 import som.compiler.MethodBuilder;
@@ -25,9 +24,7 @@ public class BlockNode extends LiteralNode {
   protected final SClass     blockClass;
   protected final boolean    needsAdjustmentOnScopeChange;
 
-  public BlockNode(final SInvokable blockMethod, final boolean needsAdjustmentOnScopeChange,
-      final SourceSection source) {
-    super(source);
+  public BlockNode(final SInvokable blockMethod, final boolean needsAdjustmentOnScopeChange) {
     this.blockMethod = blockMethod;
     this.needsAdjustmentOnScopeChange = needsAdjustmentOnScopeChange;
     switch (blockMethod.getNumberOfArguments()) {
@@ -102,7 +99,7 @@ public class BlockNode extends LiteralNode {
   }
 
   protected BlockNode createNode(final SInvokable adapted) {
-    return new BlockNode(adapted, needsAdjustmentOnScopeChange, sourceSection);
+    return new BlockNode(adapted, needsAdjustmentOnScopeChange).initialize(sourceSection);
   }
 
   @Override
@@ -113,8 +110,8 @@ public class BlockNode extends LiteralNode {
   public static final class BlockNodeWithContext extends BlockNode {
 
     public BlockNodeWithContext(final SInvokable blockMethod,
-        final boolean needsAdjustmentOnScopeChange, final SourceSection source) {
-      super(blockMethod, needsAdjustmentOnScopeChange, source);
+        final boolean needsAdjustmentOnScopeChange) {
+      super(blockMethod, needsAdjustmentOnScopeChange);
     }
 
     @Override
@@ -124,7 +121,7 @@ public class BlockNode extends LiteralNode {
 
     @Override
     protected BlockNode createNode(final SInvokable adapted) {
-      return new BlockNodeWithContext(adapted, needsAdjustmentOnScopeChange,
+      return new BlockNodeWithContext(adapted, needsAdjustmentOnScopeChange).initialize(
           sourceSection);
     }
   }

--- a/src/som/interpreter/nodes/literals/BooleanLiteralNode.java
+++ b/src/som/interpreter/nodes/literals/BooleanLiteralNode.java
@@ -1,19 +1,11 @@
 package som.interpreter.nodes.literals;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 
 public abstract class BooleanLiteralNode extends LiteralNode {
 
-  public BooleanLiteralNode(final SourceSection source) {
-    super(source);
-  }
-
   public static final class TrueLiteralNode extends BooleanLiteralNode {
-    public TrueLiteralNode(final SourceSection source) {
-      super(source);
-    }
 
     @Override
     public boolean executeBoolean(final VirtualFrame frame) {
@@ -27,9 +19,6 @@ public abstract class BooleanLiteralNode extends LiteralNode {
   }
 
   public static final class FalseLiteralNode extends BooleanLiteralNode {
-    public FalseLiteralNode(final SourceSection source) {
-      super(source);
-    }
 
     @Override
     public boolean executeBoolean(final VirtualFrame frame) {

--- a/src/som/interpreter/nodes/literals/DoubleLiteralNode.java
+++ b/src/som/interpreter/nodes/literals/DoubleLiteralNode.java
@@ -1,14 +1,12 @@
 package som.interpreter.nodes.literals;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 
 public final class DoubleLiteralNode extends LiteralNode {
   private final double value;
 
-  public DoubleLiteralNode(final double value, final SourceSection source) {
-    super(source);
+  public DoubleLiteralNode(final double value) {
     this.value = value;
   }
 

--- a/src/som/interpreter/nodes/literals/IntegerLiteralNode.java
+++ b/src/som/interpreter/nodes/literals/IntegerLiteralNode.java
@@ -1,15 +1,13 @@
 package som.interpreter.nodes.literals;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 
 public final class IntegerLiteralNode extends LiteralNode {
 
   private final long value;
 
-  public IntegerLiteralNode(final long value, final SourceSection source) {
-    super(source);
+  public IntegerLiteralNode(final long value) {
     this.value = value;
   }
 

--- a/src/som/interpreter/nodes/literals/LiteralNode.java
+++ b/src/som/interpreter/nodes/literals/LiteralNode.java
@@ -25,7 +25,6 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
 import com.oracle.truffle.api.nodes.NodeCost;
 import com.oracle.truffle.api.nodes.NodeInfo;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.MethodBuilder;
 import som.interpreter.nodes.ExpressionNode;
@@ -39,16 +38,9 @@ import tools.debugger.Tags.LiteralTag;
 public abstract class LiteralNode extends ExprWithTagsNode
     implements PreevaluatedExpression {
 
-  public LiteralNode(final SourceSection source) {
-    super(source);
-  }
+  protected LiteralNode() {}
 
-  /**
-   * For use by wrapping only.
-   */
-  protected LiteralNode(final LiteralNode wrappedNode) {
-    super(wrappedNode);
-  }
+  protected LiteralNode(final LiteralNode wrapped) {}
 
   @Override
   public final Object doPreEvaluated(final VirtualFrame frame,

--- a/src/som/interpreter/nodes/literals/NilLiteralNode.java
+++ b/src/som/interpreter/nodes/literals/NilLiteralNode.java
@@ -1,21 +1,14 @@
 package som.interpreter.nodes.literals;
 
-import som.vm.constants.Nil;
-
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
+
+import som.vm.constants.Nil;
 
 
 public final class NilLiteralNode extends LiteralNode {
-
-  public NilLiteralNode(final SourceSection source) {
-    super(source);
-    assert source != null;
-  }
 
   @Override
   public Object executeGeneric(final VirtualFrame frame) {
     return Nil.nilObject;
   }
-
 }

--- a/src/som/interpreter/nodes/literals/ObjectLiteralNode.java
+++ b/src/som/interpreter/nodes/literals/ObjectLiteralNode.java
@@ -2,7 +2,6 @@ package som.interpreter.nodes.literals;
 
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.MixinDefinition;
 import som.interpreter.InliningVisitor;
@@ -32,9 +31,7 @@ public class ObjectLiteralNode extends LiteralNode {
    * from that class.
    */
   public ObjectLiteralNode(final MixinDefinition mixinDefiniton,
-      final ExpressionNode outerRead,
-      final ExpressionNode newMessage, final SourceSection source) {
-    super(source);
+      final ExpressionNode outerRead, final ExpressionNode newMessage) {
     this.mixinDef = mixinDefiniton;
     this.superClassResolver =
         mixinDefiniton.getSuperclassAndMixinResolutionInvokable().createCallTarget();
@@ -61,7 +58,7 @@ public class ObjectLiteralNode extends LiteralNode {
   }
 
   protected ObjectLiteralNode createNode(final MixinDefinition mixinDefinition) {
-    return new ObjectLiteralNode(mixinDefinition, outerRead, newMessage, sourceSection);
+    return new ObjectLiteralNode(mixinDefinition, outerRead, newMessage).initialize(
+        sourceSection);
   }
-
 }

--- a/src/som/interpreter/nodes/literals/StringLiteralNode.java
+++ b/src/som/interpreter/nodes/literals/StringLiteralNode.java
@@ -1,15 +1,13 @@
 package som.interpreter.nodes.literals;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 
 public final class StringLiteralNode extends LiteralNode {
 
   private final String value;
 
-  public StringLiteralNode(final String value, final SourceSection source) {
-    super(source);
+  public StringLiteralNode(final String value) {
     this.value = value;
   }
 

--- a/src/som/interpreter/nodes/literals/SymbolLiteralNode.java
+++ b/src/som/interpreter/nodes/literals/SymbolLiteralNode.java
@@ -1,17 +1,15 @@
 package som.interpreter.nodes.literals;
 
-import som.vmobjects.SSymbol;
-
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
+
+import som.vmobjects.SSymbol;
 
 
 public final class SymbolLiteralNode extends LiteralNode {
 
   private final SSymbol value;
 
-  public SymbolLiteralNode(final SSymbol value, final SourceSection source) {
-    super(source);
+  public SymbolLiteralNode(final SSymbol value) {
     this.value = value;
   }
 

--- a/src/som/interpreter/nodes/nary/BinaryBasicOperation.java
+++ b/src/som/interpreter/nodes/nary/BinaryBasicOperation.java
@@ -1,7 +1,5 @@
 package som.interpreter.nodes.nary;
 
-import com.oracle.truffle.api.source.SourceSection;
-
 import tools.dym.Tags.BasicPrimitiveOperation;
 
 
@@ -11,11 +9,6 @@ import tools.dym.Tags.BasicPrimitiveOperation;
  * a few basic operations in an ideal native code mapping.
  */
 public abstract class BinaryBasicOperation extends BinaryExpressionNode {
-  protected BinaryBasicOperation(final boolean eagerlyWrapped,
-      final SourceSection source) {
-    super(eagerlyWrapped, source);
-  }
-
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
     if (tag == BasicPrimitiveOperation.class) {

--- a/src/som/interpreter/nodes/nary/BinaryComplexOperation.java
+++ b/src/som/interpreter/nodes/nary/BinaryComplexOperation.java
@@ -1,5 +1,9 @@
 package som.interpreter.nodes.nary;
 
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+
+import som.VM;
+import som.primitives.WithContext;
 import tools.dym.Tags.ComplexPrimitiveOperation;
 
 
@@ -16,6 +20,18 @@ public abstract class BinaryComplexOperation extends BinaryExpressionNode {
       return true;
     } else {
       return super.isTaggedWithIgnoringEagerness(tag);
+    }
+  }
+
+  public abstract static class BinarySystemOperation extends BinaryComplexOperation
+      implements WithContext<BinarySystemOperation> {
+    @CompilationFinal protected VM vm;
+
+    @Override
+    public BinarySystemOperation initialize(final VM vm) {
+      assert this.vm == null && vm != null;
+      this.vm = vm;
+      return this;
     }
   }
 }

--- a/src/som/interpreter/nodes/nary/BinaryComplexOperation.java
+++ b/src/som/interpreter/nodes/nary/BinaryComplexOperation.java
@@ -1,7 +1,5 @@
 package som.interpreter.nodes.nary;
 
-import com.oracle.truffle.api.source.SourceSection;
-
 import tools.dym.Tags.ComplexPrimitiveOperation;
 
 
@@ -12,14 +10,6 @@ import tools.dym.Tags.ComplexPrimitiveOperation;
  * instructions or cause the execution of arbitrarily complex code.
  */
 public abstract class BinaryComplexOperation extends BinaryExpressionNode {
-  protected BinaryComplexOperation(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
-  protected BinaryComplexOperation(final BinaryComplexOperation node) {
-    super(node);
-  }
-
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
     if (tag == ComplexPrimitiveOperation.class) {

--- a/src/som/interpreter/nodes/nary/BinaryExpressionNode.java
+++ b/src/som/interpreter/nodes/nary/BinaryExpressionNode.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.vmobjects.SSymbol;
@@ -16,17 +15,9 @@ import som.vmobjects.SSymbol;
 @Instrumentable(factory = BinaryExpressionNodeWrapper.class)
 public abstract class BinaryExpressionNode extends EagerlySpecializableNode {
 
-  public BinaryExpressionNode(final boolean eagerlyWrapped,
-      final SourceSection source) {
-    super(eagerlyWrapped, source);
-  }
+  protected BinaryExpressionNode() {}
 
-  /**
-   * For wrapped nodes only.
-   */
-  protected BinaryExpressionNode(final BinaryExpressionNode wrappedNode) {
-    super(wrappedNode);
-  }
+  protected BinaryExpressionNode(final BinaryExpressionNode wrappedNode) {}
 
   public abstract Object executeEvaluated(VirtualFrame frame, Object receiver,
       Object argument);
@@ -40,7 +31,9 @@ public abstract class BinaryExpressionNode extends EagerlySpecializableNode {
   @Override
   public EagerPrimitive wrapInEagerWrapper(final SSymbol selector,
       final ExpressionNode[] arguments) {
-    return new EagerBinaryPrimitiveNode(sourceSection, selector,
-        arguments[0], arguments[1], this);
+    EagerBinaryPrimitiveNode result =
+        new EagerBinaryPrimitiveNode(selector, arguments[0], arguments[1], this);
+    result.initialize(sourceSection);
+    return result;
   }
 }

--- a/src/som/interpreter/nodes/nary/EagerBinaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerBinaryPrimitiveNode.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
 import com.oracle.truffle.api.nodes.Node;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.TruffleCompiler;
@@ -23,13 +22,8 @@ public final class EagerBinaryPrimitiveNode extends EagerPrimitive {
 
   private final SSymbol selector;
 
-  public EagerBinaryPrimitiveNode(final SourceSection source,
-      final SSymbol selector,
-      final ExpressionNode receiver,
-      final ExpressionNode argument,
-      final BinaryExpressionNode primitive) {
-    super(source);
-    assert source == primitive.getSourceSection();
+  public EagerBinaryPrimitiveNode(final SSymbol selector, final ExpressionNode receiver,
+      final ExpressionNode argument, final BinaryExpressionNode primitive) {
     this.receiver = insert(receiver);
     this.argument = insert(argument);
     this.primitive = insert(primitive);

--- a/src/som/interpreter/nodes/nary/EagerPrimitive.java
+++ b/src/som/interpreter/nodes/nary/EagerPrimitive.java
@@ -1,7 +1,5 @@
 package som.interpreter.nodes.nary;
 
-import com.oracle.truffle.api.source.SourceSection;
-
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.OperationNode;
 import som.interpreter.nodes.PreevaluatedExpression;
@@ -9,14 +7,5 @@ import som.interpreter.nodes.PreevaluatedExpression;
 
 public abstract class EagerPrimitive extends ExpressionNode
     implements OperationNode, PreevaluatedExpression {
-
-  protected EagerPrimitive(final SourceSection source) {
-    super(source);
-  }
-
-  protected EagerPrimitive(final EagerPrimitive prim) {
-    super(prim);
-  }
-
   protected abstract void setTags(byte tagMark);
 }

--- a/src/som/interpreter/nodes/nary/EagerTernaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerTernaryPrimitiveNode.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
 import com.oracle.truffle.api.nodes.Node;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.TruffleCompiler;
@@ -25,15 +24,9 @@ public final class EagerTernaryPrimitiveNode extends EagerPrimitive {
 
   private final SSymbol selector;
 
-  public EagerTernaryPrimitiveNode(
-      final SourceSection source,
-      final SSymbol selector,
-      final ExpressionNode receiver,
-      final ExpressionNode argument1,
-      final ExpressionNode argument2,
+  public EagerTernaryPrimitiveNode(final SSymbol selector, final ExpressionNode receiver,
+      final ExpressionNode argument1, final ExpressionNode argument2,
       final TernaryExpressionNode primitive) {
-    super(source);
-    assert source == primitive.getSourceSection();
     this.receiver = insert(receiver);
     this.argument1 = insert(argument1);
     this.argument2 = insert(argument2);

--- a/src/som/interpreter/nodes/nary/EagerUnaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerUnaryPrimitiveNode.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
 import com.oracle.truffle.api.nodes.Node;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.TruffleCompiler;
@@ -22,10 +21,8 @@ public final class EagerUnaryPrimitiveNode extends EagerPrimitive {
 
   private final SSymbol selector;
 
-  public EagerUnaryPrimitiveNode(final SourceSection source, final SSymbol selector,
-      final ExpressionNode receiver, final UnaryExpressionNode primitive) {
-    super(source);
-    assert source == primitive.getSourceSection();
+  public EagerUnaryPrimitiveNode(final SSymbol selector, final ExpressionNode receiver,
+      final UnaryExpressionNode primitive) {
     this.receiver = insert(receiver);
     this.primitive = insert(primitive);
     this.selector = selector;

--- a/src/som/interpreter/nodes/nary/EagerlySpecializableNode.java
+++ b/src/som/interpreter/nodes/nary/EagerlySpecializableNode.java
@@ -7,6 +7,7 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.PreevaluatedExpression;
+import som.interpreter.nodes.SOMNode;
 import som.vmobjects.SSymbol;
 
 
@@ -15,16 +16,13 @@ public abstract class EagerlySpecializableNode extends ExprWithTagsNode
 
   @CompilationFinal private boolean eagerlyWrapped;
 
-  protected EagerlySpecializableNode(final EagerlySpecializableNode wrappedNode) {
-    super(wrappedNode);
-    assert !wrappedNode.eagerlyWrapped : "I think this should be true.";
-    this.eagerlyWrapped = false;
-  }
-
-  public EagerlySpecializableNode(final boolean eagerlyWrapped,
-      final SourceSection source) {
-    super(source);
+  @SuppressWarnings("unchecked")
+  public <T extends SOMNode> T initialize(final SourceSection sourceSection,
+      final boolean eagerlyWrapped) {
+    this.initialize(sourceSection);
+    assert !this.eagerlyWrapped;
     this.eagerlyWrapped = eagerlyWrapped;
+    return (T) this;
   }
 
   /**

--- a/src/som/interpreter/nodes/nary/ExprWithTagsNode.java
+++ b/src/som/interpreter/nodes/nary/ExprWithTagsNode.java
@@ -5,7 +5,6 @@ import com.oracle.truffle.api.instrumentation.InstrumentableFactory.WrapperNode;
 import com.oracle.truffle.api.instrumentation.StandardTags.RootTag;
 import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.Node;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.vm.NotYetImplementedException;
@@ -50,14 +49,6 @@ public abstract class ExprWithTagsNode extends ExpressionNode {
    * Indicate that this node is the first/root node of a statement.
    */
   private static final byte STATEMENT = 1 << 5;
-
-  public ExprWithTagsNode(final SourceSection sourceSection) {
-    super(sourceSection);
-  }
-
-  public ExprWithTagsNode(final ExpressionNode wrappedNode) {
-    super(wrappedNode);
-  }
 
   private boolean isTagged(final byte mask) {
     return (tagMark & mask) != 0;

--- a/src/som/interpreter/nodes/nary/QuaternaryExpressionNode.java
+++ b/src/som/interpreter/nodes/nary/QuaternaryExpressionNode.java
@@ -3,7 +3,6 @@ package som.interpreter.nodes.nary;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.vm.NotYetImplementedException;
@@ -16,18 +15,6 @@ import som.vmobjects.SSymbol;
     @NodeChild(value = "secondArg", type = ExpressionNode.class),
     @NodeChild(value = "thirdArg", type = ExpressionNode.class)})
 public abstract class QuaternaryExpressionNode extends EagerlySpecializableNode {
-
-  public QuaternaryExpressionNode(final boolean eagerlyWrapped,
-      final SourceSection source) {
-    super(eagerlyWrapped, source);
-  }
-
-  /**
-   * For wrapped nodes only.
-   */
-  protected QuaternaryExpressionNode(final QuaternaryExpressionNode wrappedNode) {
-    super(wrappedNode);
-  }
 
   public abstract Object executeEvaluated(VirtualFrame frame, Object receiver,
       Object firstArg, Object secondArg, Object thirdArg);

--- a/src/som/interpreter/nodes/nary/TernaryExpressionNode.java
+++ b/src/som/interpreter/nodes/nary/TernaryExpressionNode.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.vmobjects.SSymbol;
@@ -17,17 +16,9 @@ import som.vmobjects.SSymbol;
 @Instrumentable(factory = TernaryExpressionNodeWrapper.class)
 public abstract class TernaryExpressionNode extends EagerlySpecializableNode {
 
-  public TernaryExpressionNode(final boolean eagerlyWrapped,
-      final SourceSection sourceSection) {
-    super(eagerlyWrapped, sourceSection);
-  }
+  protected TernaryExpressionNode() {}
 
-  /**
-   * For wrapper nodes only.
-   */
-  protected TernaryExpressionNode(final TernaryExpressionNode wrappedNode) {
-    super(wrappedNode);
-  }
+  protected TernaryExpressionNode(final TernaryExpressionNode wrappedNode) {}
 
   public abstract Object executeEvaluated(VirtualFrame frame, Object receiver,
       Object firstArg, Object secondArg);
@@ -41,7 +32,9 @@ public abstract class TernaryExpressionNode extends EagerlySpecializableNode {
   @Override
   public EagerPrimitive wrapInEagerWrapper(final SSymbol selector,
       final ExpressionNode[] arguments) {
-    return new EagerTernaryPrimitiveNode(getSourceSection(), selector,
+    EagerTernaryPrimitiveNode result = new EagerTernaryPrimitiveNode(selector,
         arguments[0], arguments[1], arguments[2], this);
+    result.initialize(sourceSection);
+    return result;
   }
 }

--- a/src/som/interpreter/nodes/nary/TernaryExpressionNode.java
+++ b/src/som/interpreter/nodes/nary/TernaryExpressionNode.java
@@ -1,11 +1,14 @@
 package som.interpreter.nodes.nary;
 
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
 
+import som.VM;
 import som.interpreter.nodes.ExpressionNode;
+import som.primitives.WithContext;
 import som.vmobjects.SSymbol;
 
 
@@ -36,5 +39,17 @@ public abstract class TernaryExpressionNode extends EagerlySpecializableNode {
         arguments[0], arguments[1], arguments[2], this);
     result.initialize(sourceSection);
     return result;
+  }
+
+  public abstract static class TernarySystemOperation extends TernaryExpressionNode
+      implements WithContext<TernaryExpressionNode> {
+    @CompilationFinal protected VM vm;
+
+    @Override
+    public TernaryExpressionNode initialize(final VM vm) {
+      assert this.vm == null && vm != null;
+      this.vm = vm;
+      return this;
+    }
   }
 }

--- a/src/som/interpreter/nodes/nary/UnaryBasicOperation.java
+++ b/src/som/interpreter/nodes/nary/UnaryBasicOperation.java
@@ -1,7 +1,5 @@
 package som.interpreter.nodes.nary;
 
-import com.oracle.truffle.api.source.SourceSection;
-
 import tools.dym.Tags.BasicPrimitiveOperation;
 
 
@@ -11,10 +9,6 @@ import tools.dym.Tags.BasicPrimitiveOperation;
  * a few basic operations in an ideal native code mapping.
  */
 public abstract class UnaryBasicOperation extends UnaryExpressionNode {
-  protected UnaryBasicOperation(final boolean eagerlyWrapped, final SourceSection source) {
-    super(eagerlyWrapped, source);
-  }
-
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
     if (tag == BasicPrimitiveOperation.class) {

--- a/src/som/interpreter/nodes/nary/UnaryExpressionNode.java
+++ b/src/som/interpreter/nodes/nary/UnaryExpressionNode.java
@@ -3,7 +3,6 @@ package som.interpreter.nodes.nary;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.vmobjects.SSymbol;
@@ -13,17 +12,9 @@ import som.vmobjects.SSymbol;
 @NodeChild(value = "receiver", type = ExpressionNode.class)
 public abstract class UnaryExpressionNode extends EagerlySpecializableNode {
 
-  public UnaryExpressionNode(final boolean eagerlyWrapped,
-      final SourceSection source) {
-    super(eagerlyWrapped, source);
-  }
+  protected UnaryExpressionNode() {}
 
-  /**
-   * For use by wrapper nodes only.
-   */
-  protected UnaryExpressionNode(final UnaryExpressionNode wrappedNode) {
-    super(wrappedNode);
-  }
+  protected UnaryExpressionNode(final UnaryExpressionNode wrappedNode) {}
 
   public abstract Object executeEvaluated(VirtualFrame frame, Object receiver);
 
@@ -36,7 +27,8 @@ public abstract class UnaryExpressionNode extends EagerlySpecializableNode {
   @Override
   public EagerPrimitive wrapInEagerWrapper(final SSymbol selector,
       final ExpressionNode[] arguments) {
-    return new EagerUnaryPrimitiveNode(getSourceSection(), selector,
-        arguments[0], this);
+    EagerUnaryPrimitiveNode result = new EagerUnaryPrimitiveNode(selector, arguments[0], this);
+    result.initialize(sourceSection);
+    return result;
   }
 }

--- a/src/som/interpreter/nodes/nary/UnaryExpressionNode.java
+++ b/src/som/interpreter/nodes/nary/UnaryExpressionNode.java
@@ -1,10 +1,13 @@
 package som.interpreter.nodes.nary;
 
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
 
+import som.VM;
 import som.interpreter.nodes.ExpressionNode;
+import som.primitives.WithContext;
 import som.vmobjects.SSymbol;
 
 
@@ -30,5 +33,17 @@ public abstract class UnaryExpressionNode extends EagerlySpecializableNode {
     EagerUnaryPrimitiveNode result = new EagerUnaryPrimitiveNode(selector, arguments[0], this);
     result.initialize(sourceSection);
     return result;
+  }
+
+  public abstract static class UnarySystemOperation extends UnaryExpressionNode
+      implements WithContext<UnarySystemOperation> {
+    @CompilationFinal protected VM vm;
+
+    @Override
+    public UnarySystemOperation initialize(final VM vm) {
+      assert this.vm == null && vm != null;
+      this.vm = vm;
+      return this;
+    }
   }
 }

--- a/src/som/interpreter/nodes/specialized/AndMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/AndMessageNode.java
@@ -61,10 +61,10 @@ public abstract class AndMessageNode extends BinaryComplexOperation {
         final ExpressionNode[] argNodes, final SourceSection section,
         final boolean eagerWrapper) {
       if (unwrapIfNecessary(argNodes[1]) instanceof BlockNode) {
-        return fact.createNode(arguments[1], section, argNodes[0], argNodes[1]);
+        return fact.createNode(arguments[1], argNodes[0], argNodes[1]).initialize(section);
       } else {
         assert arguments == null || arguments[1] instanceof Boolean;
-        return boolFact.createNode(section, argNodes[0], argNodes[1]);
+        return boolFact.createNode(argNodes[0], argNodes[1]).initialize(section);
       }
     }
   }
@@ -72,17 +72,10 @@ public abstract class AndMessageNode extends BinaryComplexOperation {
   private final SInvokable      blockMethod;
   @Child private DirectCallNode blockValueSend;
 
-  public AndMessageNode(final SBlock arg, final SourceSection source) {
-    super(false, source);
+  public AndMessageNode(final SBlock arg) {
     blockMethod = arg.getMethod();
     blockValueSend = Truffle.getRuntime().createDirectCallNode(
         blockMethod.getCallTarget());
-  }
-
-  public AndMessageNode(final AndMessageNode copy) {
-    super(false, copy.getSourceSection());
-    blockMethod = copy.blockMethod;
-    blockValueSend = copy.blockValueSend;
   }
 
   protected final boolean isSameBlock(final SBlock argument) {
@@ -112,10 +105,6 @@ public abstract class AndMessageNode extends BinaryComplexOperation {
   @GenerateNodeFactory
   public abstract static class AndBoolMessageNode extends BinaryBasicOperation
       implements OperationNode {
-    public AndBoolMessageNode(final SourceSection source) {
-      super(false, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == OpComparison.class) {

--- a/src/som/interpreter/nodes/specialized/BooleanInlinedLiteralNode.java
+++ b/src/som/interpreter/nodes/specialized/BooleanInlinedLiteralNode.java
@@ -5,7 +5,6 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
 import com.oracle.truffle.api.profiles.ConditionProfile;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
@@ -23,12 +22,8 @@ public abstract class BooleanInlinedLiteralNode extends ExprWithTagsNode {
 
   protected final ConditionProfile profile;
 
-  public BooleanInlinedLiteralNode(
-      final ExpressionNode receiverNode,
-      final ExpressionNode inlinedArgumentNode,
-      final ExpressionNode originalArgumentNode,
-      final SourceSection sourceSection) {
-    super(sourceSection);
+  public BooleanInlinedLiteralNode(final ExpressionNode receiverNode,
+      final ExpressionNode inlinedArgumentNode, final ExpressionNode originalArgumentNode) {
     this.receiverNode = receiverNode;
     this.argumentNode = inlinedArgumentNode;
     this.argumentAcutalNode = originalArgumentNode;
@@ -66,13 +61,9 @@ public abstract class BooleanInlinedLiteralNode extends ExprWithTagsNode {
 
   public static final class AndInlinedLiteralNode extends BooleanInlinedLiteralNode {
 
-    public AndInlinedLiteralNode(
-        final ExpressionNode receiverNode,
-        final ExpressionNode inlinedArgumentNode,
-        final ExpressionNode originalArgumentNode,
-        final SourceSection sourceSection) {
-      super(receiverNode, inlinedArgumentNode, originalArgumentNode,
-          sourceSection);
+    public AndInlinedLiteralNode(final ExpressionNode receiverNode,
+        final ExpressionNode inlinedArgumentNode, final ExpressionNode originalArgumentNode) {
+      super(receiverNode, inlinedArgumentNode, originalArgumentNode);
     }
 
     @Override
@@ -92,13 +83,9 @@ public abstract class BooleanInlinedLiteralNode extends ExprWithTagsNode {
 
   public static final class OrInlinedLiteralNode extends BooleanInlinedLiteralNode {
 
-    public OrInlinedLiteralNode(
-        final ExpressionNode receiverNode,
-        final ExpressionNode inlinedArgumentNode,
-        final ExpressionNode originalArgumentNode,
-        final SourceSection sourceSection) {
-      super(receiverNode, inlinedArgumentNode, originalArgumentNode,
-          sourceSection);
+    public OrInlinedLiteralNode(final ExpressionNode receiverNode,
+        final ExpressionNode inlinedArgumentNode, final ExpressionNode originalArgumentNode) {
+      super(receiverNode, inlinedArgumentNode, originalArgumentNode);
     }
 
     @Override

--- a/src/som/interpreter/nodes/specialized/IfInlinedLiteralNode.java
+++ b/src/som/interpreter/nodes/specialized/IfInlinedLiteralNode.java
@@ -1,15 +1,14 @@
 package som.interpreter.nodes.specialized;
 
-import som.interpreter.nodes.ExpressionNode;
-import som.interpreter.nodes.nary.ExprWithTagsNode;
-import som.vm.constants.Nil;
-
 import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
 import com.oracle.truffle.api.profiles.ConditionProfile;
-import com.oracle.truffle.api.source.SourceSection;
+
+import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.nary.ExprWithTagsNode;
+import som.vm.constants.Nil;
 
 
 public final class IfInlinedLiteralNode extends ExprWithTagsNode {
@@ -24,13 +23,8 @@ public final class IfInlinedLiteralNode extends ExprWithTagsNode {
   // original nodes around
   @SuppressWarnings("unused") private final ExpressionNode bodyActualNode;
 
-  public IfInlinedLiteralNode(
-      final ExpressionNode conditionNode,
-      final boolean expectedBool,
-      final ExpressionNode inlinedBodyNode,
-      final ExpressionNode originalBodyNode,
-      final SourceSection sourceSection) {
-    super(sourceSection);
+  public IfInlinedLiteralNode(final ExpressionNode conditionNode, final boolean expectedBool,
+      final ExpressionNode inlinedBodyNode, final ExpressionNode originalBodyNode) {
     this.conditionNode = conditionNode;
     this.expectedBool = expectedBool;
     this.bodyNode = inlinedBodyNode;

--- a/src/som/interpreter/nodes/specialized/IfMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/IfMessageNode.java
@@ -7,7 +7,6 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.profiles.ConditionProfile;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.BinaryComplexOperation;
 import som.primitives.Primitive;
@@ -21,26 +20,23 @@ public abstract class IfMessageNode extends BinaryComplexOperation {
   @GenerateNodeFactory
   @Primitive(selector = "ifTrue:", noWrapper = true)
   public abstract static class IfTrueMessageNode extends IfMessageNode {
-    public IfTrueMessageNode(final boolean eagWrap, final SourceSection source) {
-      super(true, source);
-      assert !eagWrap;
+    public IfTrueMessageNode() {
+      super(true);
     }
   }
 
   @GenerateNodeFactory
   @Primitive(selector = "ifFalse:", noWrapper = true)
   public abstract static class IfFalseMessageNode extends IfMessageNode {
-    public IfFalseMessageNode(final boolean eagWrap, final SourceSection source) {
-      super(false, source);
-      assert !eagWrap;
+    public IfFalseMessageNode() {
+      super(false);
     }
   }
 
   protected final ConditionProfile condProf = ConditionProfile.createCountingProfile();
   private final boolean            expected;
 
-  public IfMessageNode(final boolean expected, final SourceSection source) {
-    super(false, source);
+  protected IfMessageNode(final boolean expected) {
     this.expected = expected;
   }
 

--- a/src/som/interpreter/nodes/specialized/IfTrueIfFalseInlinedLiteralsNode.java
+++ b/src/som/interpreter/nodes/specialized/IfTrueIfFalseInlinedLiteralsNode.java
@@ -1,14 +1,13 @@
 package som.interpreter.nodes.specialized;
 
-import som.interpreter.nodes.ExpressionNode;
-import som.interpreter.nodes.nary.ExprWithTagsNode;
-
 import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
 import com.oracle.truffle.api.profiles.ConditionProfile;
-import com.oracle.truffle.api.source.SourceSection;
+
+import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.nary.ExprWithTagsNode;
 
 
 /**
@@ -30,14 +29,9 @@ public final class IfTrueIfFalseInlinedLiteralsNode extends ExprWithTagsNode {
   @SuppressWarnings("unused") private final ExpressionNode trueActualNode;
   @SuppressWarnings("unused") private final ExpressionNode falseActualNode;
 
-  public IfTrueIfFalseInlinedLiteralsNode(
-      final ExpressionNode conditionNode,
-      final ExpressionNode inlinedTrueNode,
-      final ExpressionNode inlinedFalseNode,
-      final ExpressionNode originalTrueNode,
-      final ExpressionNode originalFalseNode,
-      final SourceSection sourceSection) {
-    super(sourceSection);
+  public IfTrueIfFalseInlinedLiteralsNode(final ExpressionNode conditionNode,
+      final ExpressionNode inlinedTrueNode, final ExpressionNode inlinedFalseNode,
+      final ExpressionNode originalTrueNode, final ExpressionNode originalFalseNode) {
     this.conditionNode = conditionNode;
     this.trueNode = inlinedTrueNode;
     this.falseNode = inlinedFalseNode;

--- a/src/som/interpreter/nodes/specialized/IfTrueIfFalseMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/IfTrueIfFalseMessageNode.java
@@ -7,7 +7,6 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.profiles.ConditionProfile;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.TernaryExpressionNode;
 import som.primitives.Primitive;
@@ -32,11 +31,7 @@ public abstract class IfTrueIfFalseMessageNode extends TernaryExpressionNode {
 
   @Child private IndirectCallNode call;
 
-  public IfTrueIfFalseMessageNode(final boolean eagWrap, final SourceSection source,
-      final Object[] args) {
-    super(eagWrap, source);
-    assert !eagWrap;
-
+  public IfTrueIfFalseMessageNode(final Object[] args) {
     if (args[1] instanceof SBlock) {
       SBlock trueBlock = (SBlock) args[1];
       trueMethod = trueBlock.getMethod();
@@ -55,23 +50,6 @@ public abstract class IfTrueIfFalseMessageNode extends TernaryExpressionNode {
       falseMethod = null;
     }
 
-    call = Truffle.getRuntime().createIndirectCallNode();
-  }
-
-  public IfTrueIfFalseMessageNode(final IfTrueIfFalseMessageNode node) {
-    super(false, node.sourceSection);
-
-    trueMethod = node.trueMethod;
-    if (node.trueMethod != null) {
-      trueValueSend = Truffle.getRuntime().createDirectCallNode(
-          trueMethod.getCallTarget());
-    }
-
-    falseMethod = node.falseMethod;
-    if (node.falseMethod != null) {
-      falseValueSend = Truffle.getRuntime().createDirectCallNode(
-          falseMethod.getCallTarget());
-    }
     call = Truffle.getRuntime().createIndirectCallNode();
   }
 

--- a/src/som/interpreter/nodes/specialized/IntDownToDoInlinedLiteralsNode.java
+++ b/src/som/interpreter/nodes/specialized/IntDownToDoInlinedLiteralsNode.java
@@ -7,7 +7,6 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.Variable.Local;
 import som.interpreter.InliningVisitor;
@@ -36,10 +35,8 @@ public abstract class IntDownToDoInlinedLiteralsNode extends ExprWithTagsNode {
 
   public abstract ExpressionNode getTo();
 
-  public IntDownToDoInlinedLiteralsNode(final ExpressionNode body,
-      final Local loopIndex, final ExpressionNode originalBody,
-      final SourceSection sourceSection) {
-    super(sourceSection);
+  public IntDownToDoInlinedLiteralsNode(final ExpressionNode body, final Local loopIndex,
+      final ExpressionNode originalBody) {
     this.body = body;
     this.loopIndex = loopIndex.getSlot();
     this.loopIndexVar = loopIndex;
@@ -102,7 +99,8 @@ public abstract class IntDownToDoInlinedLiteralsNode extends ExprWithTagsNode {
   public void replaceAfterScopeChange(final InliningVisitor inliner) {
     ScopeElement se = inliner.getSplitVar(loopIndexVar);
     IntDownToDoInlinedLiteralsNode node = IntDownToDoInlinedLiteralsNodeGen.create(
-        body, (Local) se.var, bodyActualNode, sourceSection, getFrom(), getTo());
+        body, (Local) se.var, bodyActualNode, getFrom(), getTo());
+    node.initialize(sourceSection);
     replace(node);
   }
 

--- a/src/som/interpreter/nodes/specialized/IntDownToDoMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/IntDownToDoMessageNode.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.DirectCallNode;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.specialized.IntToDoMessageNode.ToDoSplzr;
 import som.primitives.Primitive;
@@ -16,10 +15,6 @@ import som.vmobjects.SInvokable;
 @Primitive(selector = "downTo:do:", noWrapper = true, disabled = true,
     specializer = ToDoSplzr.class)
 public abstract class IntDownToDoMessageNode extends IntToDoMessageNode {
-  public IntDownToDoMessageNode(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Override
   @Specialization(guards = "block.getMethod() == blockMethod")
   public final long doIntToDo(final long receiver,

--- a/src/som/interpreter/nodes/specialized/IntTimesRepeatLiteralNode.java
+++ b/src/som/interpreter/nodes/specialized/IntTimesRepeatLiteralNode.java
@@ -5,7 +5,6 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
@@ -26,8 +25,7 @@ public abstract class IntTimesRepeatLiteralNode extends ExprWithTagsNode {
   public abstract ExpressionNode getRepCnt();
 
   public IntTimesRepeatLiteralNode(final ExpressionNode body,
-      final ExpressionNode originalBody, final SourceSection sourceSection) {
-    super(sourceSection);
+      final ExpressionNode originalBody) {
     this.body = body;
     this.bodyActualNode = originalBody;
   }

--- a/src/som/interpreter/nodes/specialized/IntToByDoMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/IntToByDoMessageNode.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.QuaternaryExpressionNode;
@@ -23,19 +22,9 @@ public abstract class IntToByDoMessageNode extends QuaternaryExpressionNode {
   protected final SInvokable      blockMethod;
   @Child protected DirectCallNode valueSend;
 
-  public IntToByDoMessageNode(final boolean eagWrap,
-      final SourceSection section, final Object[] args) {
-    super(eagWrap, section);
-    assert !eagWrap;
+  public IntToByDoMessageNode(final Object[] args) {
     blockMethod = ((SBlock) args[3]).getMethod();
-    valueSend = Truffle.getRuntime().createDirectCallNode(
-        blockMethod.getCallTarget());
-  }
-
-  public IntToByDoMessageNode(final IntToByDoMessageNode node) {
-    super(false, node.getSourceSection());
-    this.blockMethod = node.blockMethod;
-    this.valueSend = node.valueSend;
+    valueSend = Truffle.getRuntime().createDirectCallNode(blockMethod.getCallTarget());
   }
 
   @Override

--- a/src/som/interpreter/nodes/specialized/IntToDoInlinedLiteralsNode.java
+++ b/src/som/interpreter/nodes/specialized/IntToDoInlinedLiteralsNode.java
@@ -8,12 +8,12 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.Variable.Local;
 import som.interpreter.InliningVisitor;
 import som.interpreter.InliningVisitor.ScopeElement;
 import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.SOMNode;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
 import som.interpreter.objectstorage.ObjectTransitionSafepoint;
 import tools.dym.Tags.LoopNode;
@@ -38,10 +38,8 @@ public abstract class IntToDoInlinedLiteralsNode extends ExprWithTagsNode {
 
   public abstract ExpressionNode getTo();
 
-  public IntToDoInlinedLiteralsNode(final ExpressionNode body,
-      final Local loopIndex, final ExpressionNode originalBody,
-      final SourceSection sourceSection) {
-    super(sourceSection);
+  public IntToDoInlinedLiteralsNode(final ExpressionNode body, final Local loopIndex,
+      final ExpressionNode originalBody) {
     this.body = body;
     this.loopIndex = loopIndex.getSlot();
     this.loopIndexVar = loopIndex;
@@ -109,8 +107,10 @@ public abstract class IntToDoInlinedLiteralsNode extends ExprWithTagsNode {
   @Override
   public void replaceAfterScopeChange(final InliningVisitor inliner) {
     ScopeElement se = inliner.getSplitVar(loopIndexVar);
-    replace(IntToDoInlinedLiteralsNodeGen.create(body, (Local) se.var, bodyActualNode,
-        sourceSection, getFrom(), getTo()));
+    SOMNode node = IntToDoInlinedLiteralsNodeGen.create(body, (Local) se.var, bodyActualNode,
+        getFrom(), getTo());
+    node.initialize(sourceSection);
+    replace(node);
   }
 
   @Override

--- a/src/som/interpreter/nodes/specialized/IntToDoMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/IntToDoMessageNode.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.DirectCallNode;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.nodes.ExpressionNode;
@@ -41,10 +40,6 @@ public abstract class IntToDoMessageNode extends TernaryExpressionNode {
 
   protected static final DirectCallNode create(final SInvokable blockMethod) {
     return Truffle.getRuntime().createDirectCallNode(blockMethod.getCallTarget());
-  }
-
-  protected IntToDoMessageNode(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
   }
 
   @Override

--- a/src/som/interpreter/nodes/specialized/NotMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/NotMessageNode.java
@@ -3,7 +3,6 @@ package som.interpreter.nodes.specialized;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryBasicOperation;
 import som.primitives.Primitive;
@@ -13,10 +12,6 @@ import tools.dym.Tags.OpArithmetic;
 @GenerateNodeFactory
 @Primitive(selector = "not", receiverType = Boolean.class)
 public abstract class NotMessageNode extends UnaryBasicOperation {
-  public NotMessageNode(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
     if (tag == OpArithmetic.class) {

--- a/src/som/interpreter/nodes/specialized/OrMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/OrMessageNode.java
@@ -5,7 +5,6 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.DirectCallNode;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.nodes.OperationNode;
@@ -37,17 +36,10 @@ public abstract class OrMessageNode extends BinaryComplexOperation {
   private final SInvokable      blockMethod;
   @Child private DirectCallNode blockValueSend;
 
-  public OrMessageNode(final SBlock arg, final SourceSection source) {
-    super(false, source);
+  public OrMessageNode(final SBlock arg) {
     blockMethod = arg.getMethod();
     blockValueSend = Truffle.getRuntime().createDirectCallNode(
         blockMethod.getCallTarget());
-  }
-
-  public OrMessageNode(final OrMessageNode copy) {
-    super(false, copy.getSourceSection());
-    blockMethod = copy.blockMethod;
-    blockValueSend = copy.blockValueSend;
   }
 
   @Override
@@ -77,10 +69,6 @@ public abstract class OrMessageNode extends BinaryComplexOperation {
   @GenerateNodeFactory
   public abstract static class OrBoolMessageNode extends BinaryBasicOperation
       implements OperationNode {
-    public OrBoolMessageNode(final SourceSection source) {
-      super(false, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == OpComparison.class) {

--- a/src/som/interpreter/nodes/specialized/whileloops/AbstractWhileNode.java
+++ b/src/som/interpreter/nodes/specialized/whileloops/AbstractWhileNode.java
@@ -5,7 +5,6 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
@@ -22,10 +21,7 @@ public abstract class AbstractWhileNode extends BinaryComplexOperation {
 
   protected final boolean predicateBool;
 
-  public AbstractWhileNode(final SBlock rcvr, final SBlock arg,
-      final boolean predicateBool, final SourceSection source) {
-    super(false, source);
-
+  public AbstractWhileNode(final SBlock rcvr, final SBlock arg, final boolean predicateBool) {
     CallTarget callTargetCondition = rcvr.getMethod().getCallTarget();
     conditionValueSend = Truffle.getRuntime().createDirectCallNode(
         callTargetCondition);

--- a/src/som/interpreter/nodes/specialized/whileloops/WhileCache.java
+++ b/src/som/interpreter/nodes/specialized/whileloops/WhileCache.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
@@ -21,8 +20,7 @@ public abstract class WhileCache extends BinaryComplexOperation {
 
   protected final boolean predicateBool;
 
-  public WhileCache(final SourceSection source, final boolean predicateBool) {
-    super(false, source);
+  public WhileCache(final boolean predicateBool) {
     this.predicateBool = predicateBool;
   }
 

--- a/src/som/interpreter/nodes/specialized/whileloops/WhileInlinedLiteralsNode.java
+++ b/src/som/interpreter/nodes/specialized/whileloops/WhileInlinedLiteralsNode.java
@@ -5,7 +5,6 @@ import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
@@ -25,14 +24,9 @@ public final class WhileInlinedLiteralsNode extends ExprWithTagsNode {
   @SuppressWarnings("unused") private final ExpressionNode conditionActualNode;
   @SuppressWarnings("unused") private final ExpressionNode bodyActualNode;
 
-  public WhileInlinedLiteralsNode(
-      final ExpressionNode inlinedConditionNode,
-      final ExpressionNode inlinedBodyNode,
-      final boolean expectedBool,
-      final ExpressionNode originalConditionNode,
-      final ExpressionNode originalBodyNode,
-      final SourceSection sourceSection) {
-    super(sourceSection);
+  public WhileInlinedLiteralsNode(final ExpressionNode inlinedConditionNode,
+      final ExpressionNode inlinedBodyNode, final boolean expectedBool,
+      final ExpressionNode originalConditionNode, final ExpressionNode originalBodyNode) {
     this.conditionNode = inlinedConditionNode;
     this.bodyNode = inlinedBodyNode;
     this.expectedBool = expectedBool;

--- a/src/som/interpreter/nodes/specialized/whileloops/WhilePrimitiveNode.java
+++ b/src/som/interpreter/nodes/specialized/whileloops/WhilePrimitiveNode.java
@@ -18,9 +18,8 @@ public abstract class WhilePrimitiveNode extends BinaryComplexOperation {
   @Child protected WhileCache whileNode;
 
   protected WhilePrimitiveNode(final SourceSection source, final boolean predicateBool) {
-    super(false, source);
     this.predicateBool = predicateBool;
-    this.whileNode = WhileCacheNodeGen.create(source, predicateBool, null, null);
+    this.whileNode = WhileCacheNodeGen.create(predicateBool, null, null).initialize(source);
   }
 
   protected WhilePrimitiveNode(final WhilePrimitiveNode node) {

--- a/src/som/interpreter/nodes/specialized/whileloops/WhileWithDynamicBlocksNode.java
+++ b/src/som/interpreter/nodes/specialized/whileloops/WhileWithDynamicBlocksNode.java
@@ -2,7 +2,6 @@ package som.interpreter.nodes.specialized.whileloops;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.vm.NotYetImplementedException;
 import som.vmobjects.SBlock;
@@ -15,12 +14,12 @@ public final class WhileWithDynamicBlocksNode extends AbstractWhileNode {
 
   public static WhileWithDynamicBlocksNode create(final SBlock rcvr,
       final SBlock arg, final boolean predicateBool) {
-    return new WhileWithDynamicBlocksNode(rcvr, arg, predicateBool, null);
+    return new WhileWithDynamicBlocksNode(rcvr, arg, predicateBool);
   }
 
-  public WhileWithDynamicBlocksNode(final SBlock rcvr, final SBlock arg,
-      final boolean predicateBool, final SourceSection source) {
-    super(rcvr, arg, predicateBool, source);
+  private WhileWithDynamicBlocksNode(final SBlock rcvr, final SBlock arg,
+      final boolean predicateBool) {
+    super(rcvr, arg, predicateBool);
     conditionMethod = rcvr.getMethod();
     bodyMethod = arg.getMethod();
   }

--- a/src/som/interpreter/nodes/specialized/whileloops/WhileWithStaticBlocksNode.java
+++ b/src/som/interpreter/nodes/specialized/whileloops/WhileWithStaticBlocksNode.java
@@ -47,7 +47,7 @@ public final class WhileWithStaticBlocksNode extends AbstractWhileNode {
       SBlock argBlock = (SBlock) arguments[1];
       return new WhileWithStaticBlocksNode(
           (BlockNode) unwrapIfNecessary(argNodes[0]), argBlockNode,
-          (SBlock) arguments[0], argBlock, whileTrueOrFalse, section);
+          (SBlock) arguments[0], argBlock, whileTrueOrFalse).initialize(section);
     }
   }
 
@@ -68,10 +68,9 @@ public final class WhileWithStaticBlocksNode extends AbstractWhileNode {
   @Child protected BlockNode receiver;
   @Child protected BlockNode argument;
 
-  private WhileWithStaticBlocksNode(final BlockNode receiver,
-      final BlockNode argument, final SBlock rcvr, final SBlock arg,
-      final boolean predicateBool, final SourceSection source) {
-    super(rcvr, arg, predicateBool, source);
+  private WhileWithStaticBlocksNode(final BlockNode receiver, final BlockNode argument,
+      final SBlock rcvr, final SBlock arg, final boolean predicateBool) {
+    super(rcvr, arg, predicateBool);
     this.receiver = receiver;
     this.argument = argument;
   }
@@ -96,7 +95,7 @@ public final class WhileWithStaticBlocksNode extends AbstractWhileNode {
     public WhileWithStaticBlocksNode createNode(final Object... args) {
       return new WhileWithStaticBlocksNode((BlockNode) args[0],
           (BlockNode) args[1], (SBlock) args[2], (SBlock) args[3],
-          (Boolean) args[4], (SourceSection) args[5]);
+          (Boolean) args[4]).initialize((SourceSection) args[5]);
     }
 
     @Override

--- a/src/som/interpreter/objectstorage/InitializerFieldWrite.java
+++ b/src/som/interpreter/objectstorage/InitializerFieldWrite.java
@@ -9,7 +9,6 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.profiles.IntValueProfile;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.MixinDefinition.SlotDefinition;
 import som.interpreter.nodes.ExpressionNode;
@@ -38,9 +37,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
 
   protected final SlotDefinition slot;
 
-  protected InitializerFieldWrite(final SlotDefinition slot,
-      final SourceSection source) {
-    super(source);
+  protected InitializerFieldWrite(final SlotDefinition slot) {
     this.slot = slot;
   }
 

--- a/src/som/interpreter/transactions/TxArrayAccess.java
+++ b/src/som/interpreter/transactions/TxArrayAccess.java
@@ -2,7 +2,6 @@ package som.interpreter.transactions;
 
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.BinaryBasicOperation;
 import som.interpreter.nodes.nary.TernaryExpressionNode;
@@ -16,9 +15,7 @@ public abstract class TxArrayAccess {
 
     @Child protected BinaryBasicOperation arrayOp;
 
-    protected TxBinaryArrayOp(final boolean eagerlyWrapped,
-        final SourceSection source, final BinaryBasicOperation arrayOp) {
-      super(eagerlyWrapped, source);
+    protected TxBinaryArrayOp(final BinaryBasicOperation arrayOp) {
       this.arrayOp = arrayOp;
     }
 
@@ -38,9 +35,7 @@ public abstract class TxArrayAccess {
   public abstract static class TxTernaryArrayOp extends TernaryExpressionNode {
     @Child protected TernaryExpressionNode arrayOp;
 
-    protected TxTernaryArrayOp(final boolean eagWrap,
-        final SourceSection source, final TernaryExpressionNode arrayOp) {
-      super(eagWrap, source);
+    protected TxTernaryArrayOp(final TernaryExpressionNode arrayOp) {
       this.arrayOp = arrayOp;
     }
 

--- a/src/som/primitives/ActivityJoin.java
+++ b/src/som/primitives/ActivityJoin.java
@@ -24,14 +24,15 @@ public class ActivityJoin {
   public abstract static class JoinPrim extends UnaryExpressionNode {
     @Child protected UnaryExpressionNode haltNode;
 
-    public JoinPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
+    @Override
+    @SuppressWarnings("unchecked")
+    public final JoinPrim initialize(final SourceSection source) {
+      super.initialize(source);
       if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
-        haltNode = insert(SuspendExecutionNodeGen.create(false, s, 0, null));
+        haltNode = insert(SuspendExecutionNodeGen.create(0, null).initialize(source));
         VM.insertInstrumentationWrapper(haltNode);
-      } else {
-        haltNode = null;
       }
+      return this;
     }
 
     @TruffleBoundary

--- a/src/som/primitives/ActivitySpawn.java
+++ b/src/som/primitives/ActivitySpawn.java
@@ -101,12 +101,21 @@ public abstract class ActivitySpawn {
     /** Breakpoint info for triggering suspension on first execution of code in activity. */
     @Child protected AbstractBreakpointNode onExec;
 
-    public SpawnPrim(final boolean ew, final SourceSection s, final VM vm) {
-      super(ew, s);
+    private final VM vm;
+
+    public SpawnPrim(final VM vm) {
+      this.vm = vm;
       this.forkJoinPool = vm.getForkJoinPool();
       this.processesPool = vm.getProcessPool();
       this.threadPool = vm.getThreadPool();
-      this.onExec = insert(Breakpoints.create(s, BreakpointType.ACTIVITY_ON_EXEC, vm));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final SpawnPrim initialize(final SourceSection source) {
+      super.initialize(source);
+      this.onExec = insert(Breakpoints.create(source, BreakpointType.ACTIVITY_ON_EXEC, vm));
+      return this;
     }
 
     @Specialization(guards = "clazz == TaskClass")
@@ -175,12 +184,21 @@ public abstract class ActivitySpawn {
     /** Breakpoint info for triggering suspension on first execution of code in activity. */
     @Child protected AbstractBreakpointNode onExec;
 
-    public SpawnWithPrim(final boolean ew, final SourceSection s, final VM vm) {
-      super(ew, s);
+    private final VM vm;
+
+    public SpawnWithPrim(final VM vm) {
+      this.vm = vm;
       this.forkJoinPool = vm.getForkJoinPool();
       this.processesPool = vm.getProcessPool();
       this.threadPool = vm.getThreadPool();
-      this.onExec = insert(Breakpoints.create(s, BreakpointType.ACTIVITY_ON_EXEC, vm));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final SpawnWithPrim initialize(final SourceSection source) {
+      super.initialize(source);
+      this.onExec = insert(Breakpoints.create(source, BreakpointType.ACTIVITY_ON_EXEC, vm));
+      return this;
     }
 
     @Specialization(guards = "clazz == TaskClass")

--- a/src/som/primitives/AsStringPrim.java
+++ b/src/som/primitives/AsStringPrim.java
@@ -5,7 +5,6 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryBasicOperation;
 import som.vmobjects.SSymbol;
@@ -16,10 +15,6 @@ import som.vmobjects.SSymbol;
 @Primitive(primitive = "intAsString:")
 @Primitive(primitive = "doubleAsString:")
 public abstract class AsStringPrim extends UnaryBasicOperation {
-  public AsStringPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   // TODO: assign a tag
 
   @Specialization

--- a/src/som/primitives/BlockPrims.java
+++ b/src/som/primitives/BlockPrims.java
@@ -52,10 +52,6 @@ public abstract class BlockPrims {
   @Primitive(primitive = "blockValue:", selector = "value", inParser = false,
       receiverType = {SBlock.class, Boolean.class})
   public abstract static class ValueNonePrim extends UnaryExpressionNode {
-    public ValueNonePrim(final boolean eagerlyWrapped, final SourceSection source) {
-      super(eagerlyWrapped, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == OpClosureApplication.class) {
@@ -89,10 +85,6 @@ public abstract class BlockPrims {
   @Primitive(primitive = "blockValue:with:", selector = "value:", inParser = false,
       receiverType = SBlock.class)
   public abstract static class ValueOnePrim extends BinaryExpressionNode {
-    protected ValueOnePrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == OpClosureApplication.class) {
@@ -121,10 +113,6 @@ public abstract class BlockPrims {
   @Primitive(primitive = "blockValue:with:with:", selector = "value:with:", inParser = false,
       receiverType = SBlock.class)
   public abstract static class ValueTwoPrim extends TernaryExpressionNode {
-    public ValueTwoPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == OpClosureApplication.class) {
@@ -152,10 +140,6 @@ public abstract class BlockPrims {
 
   @GenerateNodeFactory
   public abstract static class ValueMorePrim extends QuaternaryExpressionNode {
-    public ValueMorePrim() {
-      super(null);
-    }
-
     @Specialization
     public final Object doSBlock(final SBlock receiver, final Object firstArg,
         final Object secondArg, final Object thirdArg) {

--- a/src/som/primitives/ClassPrims.java
+++ b/src/som/primitives/ClassPrims.java
@@ -2,7 +2,6 @@ package som.primitives;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.Types;
@@ -17,10 +16,6 @@ public class ClassPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "mirrorAClassesName:")
   public abstract static class NamePrim extends UnaryExpressionNode {
-    public NamePrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SAbstractObject doSClass(final SClass receiver) {
       return receiver.getName();
@@ -30,10 +25,6 @@ public class ClassPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "mirrorClassName:")
   public abstract static class ClassNamePrim extends UnaryExpressionNode {
-    public ClassNamePrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SAbstractObject doSClass(final Object receiver) {
       VM.thisMethodNeedsToBeOptimized("should specialize, to avoid Types.getClassOf()");
@@ -43,10 +34,6 @@ public class ClassPrims {
 
   @GenerateNodeFactory
   public abstract static class SuperClassPrim extends UnaryExpressionNode {
-    public SuperClassPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SAbstractObject doSClass(final SClass receiver) {
       return receiver.getSuperClass();

--- a/src/som/primitives/ComparisonPrim.java
+++ b/src/som/primitives/ComparisonPrim.java
@@ -1,16 +1,10 @@
 package som.primitives;
 
-import com.oracle.truffle.api.source.SourceSection;
-
 import som.interpreter.nodes.nary.BinaryBasicOperation;
 import tools.dym.Tags.OpComparison;
 
 
 public abstract class ComparisonPrim extends BinaryBasicOperation {
-  protected ComparisonPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
     if (tag == OpComparison.class) {

--- a/src/som/primitives/CosPrim.java
+++ b/src/som/primitives/CosPrim.java
@@ -2,7 +2,6 @@ package som.primitives;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryBasicOperation;
 import tools.dym.Tags.OpArithmetic;
@@ -11,10 +10,6 @@ import tools.dym.Tags.OpArithmetic;
 @GenerateNodeFactory
 @Primitive(primitive = "doubleCos:", selector = "cos", receiverType = Double.class)
 public abstract class CosPrim extends UnaryBasicOperation {
-  public CosPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
     if (tag == OpArithmetic.class) { // TODO: is this good enough?

--- a/src/som/primitives/DoublePrims.java
+++ b/src/som/primitives/DoublePrims.java
@@ -3,7 +3,6 @@ package som.primitives;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.nodes.ExpressionNode;
@@ -21,10 +20,6 @@ public abstract class DoublePrims {
   @Primitive(primitive = "doubleRound:", selector = "round",
       receiverType = Double.class)
   public abstract static class RoundPrim extends UnaryBasicOperation {
-    public RoundPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == OpArithmetic.class) {
@@ -44,10 +39,6 @@ public abstract class DoublePrims {
   @Primitive(primitive = "doubleAsInteger:", selector = "asInteger", inParser = false,
       receiverType = Double.class)
   public abstract static class AsIntPrim extends UnaryBasicOperation {
-    public AsIntPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == OpArithmetic.class) {
@@ -85,10 +76,6 @@ public abstract class DoublePrims {
       selector = "PositiveInfinity", noWrapper = true,
       specializer = IsDoubleClass.class)
   public abstract static class PositiveInfinityPrim extends UnaryExpressionNode {
-    public PositiveInfinityPrim(final boolean eagerWrapper, final SourceSection source) {
-      super(eagerWrapper, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == LiteralTag.class) {

--- a/src/som/primitives/EqualsEqualsPrim.java
+++ b/src/som/primitives/EqualsEqualsPrim.java
@@ -5,7 +5,6 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.actors.SFarReference;
 import som.primitives.threading.TaskThreads.SomThreadTask;
@@ -18,10 +17,6 @@ import som.vmobjects.SObjectWithClass;
 @GenerateNodeFactory
 @Primitive(primitive = "object:identicalTo:", selector = "==")
 public abstract class EqualsEqualsPrim extends ComparisonPrim {
-  protected EqualsEqualsPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final boolean doSBlock(final SBlock left, final Object right) {
     return left == right;

--- a/src/som/primitives/EqualsPrim.java
+++ b/src/som/primitives/EqualsPrim.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.actors.SFarReference;
 import som.vm.constants.Nil;
@@ -24,10 +23,6 @@ import som.vmobjects.SSymbol;
 @Primitive(primitive = "string:equals:")
 @Primitive(selector = "=")
 public abstract class EqualsPrim extends ComparisonPrim {
-  protected EqualsPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final boolean doBoolean(final boolean left, final boolean right) {
     return left == right;

--- a/src/som/primitives/ExceptionsPrims.java
+++ b/src/som/primitives/ExceptionsPrims.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.SomException;
 import som.interpreter.nodes.dispatch.BlockDispatchNode;
@@ -27,18 +26,14 @@ public abstract class ExceptionsPrims {
   @Primitive(primitive = "exceptionDo:catch:onException:")
   public abstract static class ExceptionDoOnPrim extends TernaryExpressionNode {
 
-    protected static final int              INLINE_CACHE_SIZE =
-        VmSettings.DYNAMIC_METRICS ? 100 : 6;
-    protected static final IndirectCallNode indirect          =
+    protected static final int INLINE_CACHE_SIZE = VmSettings.DYNAMIC_METRICS ? 100 : 6;
+
+    protected static final IndirectCallNode indirect =
         Truffle.getRuntime().createIndirectCallNode();
 
     public static final DirectCallNode createCallNode(final SBlock block) {
       return Truffle.getRuntime().createDirectCallNode(
           block.getMethod().getCallTarget());
-    }
-
-    public ExceptionDoOnPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
     }
 
     public static final boolean sameBlock(final SBlock block, final SInvokable method) {
@@ -84,10 +79,6 @@ public abstract class ExceptionsPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "signalException:")
   public abstract static class SignalPrim extends UnaryExpressionNode {
-    public SignalPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final Object doSignal(final SAbstractObject exceptionObject) {
       throw new SomException(exceptionObject);
@@ -95,16 +86,12 @@ public abstract class ExceptionsPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive(primitive = "exceptionDo:ensure:",
-      selector = "ensure:", receiverType = SBlock.class)
+  @Primitive(primitive = "exceptionDo:ensure:", selector = "ensure:",
+      receiverType = SBlock.class)
   public abstract static class EnsurePrim extends BinaryComplexOperation {
 
     @Child protected BlockDispatchNode dispatchBody    = BlockDispatchNodeGen.create();
     @Child protected BlockDispatchNode dispatchHandler = BlockDispatchNodeGen.create();
-
-    protected EnsurePrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
 
     @Specialization
     public final Object doException(final SBlock body, final SBlock ensureHandler) {

--- a/src/som/primitives/HashPrim.java
+++ b/src/som/primitives/HashPrim.java
@@ -3,7 +3,6 @@ package som.primitives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryExpressionNode;
 import som.vmobjects.SAbstractObject;
@@ -14,10 +13,6 @@ import som.vmobjects.SSymbol;
 @Primitive(primitive = "objHashcode:")
 @Primitive(primitive = "stringHashcode:")
 public abstract class HashPrim extends UnaryExpressionNode {
-  public HashPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   @TruffleBoundary
   public final long doString(final String receiver) {

--- a/src/som/primitives/IntegerPrims.java
+++ b/src/som/primitives/IntegerPrims.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.profiles.BranchProfile;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.BinaryComplexOperation;
 import som.interpreter.nodes.nary.UnaryBasicOperation;
@@ -26,10 +25,6 @@ public abstract class IntegerPrims {
   @Primitive(primitive = "intAs32BitSignedValue:",
       selector = "as32BitSignedValue", receiverType = Long.class)
   public abstract static class As32BitSignedValue extends UnaryBasicOperation {
-    public As32BitSignedValue(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == OpArithmetic.class) {
@@ -49,10 +44,6 @@ public abstract class IntegerPrims {
   @Primitive(primitive = "intAs32BitUnsignedValue:",
       selector = "as32BitUnsignedValue", receiverType = Long.class)
   public abstract static class As32BitUnsignedValue extends UnaryBasicOperation {
-    public As32BitUnsignedValue(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == OpArithmetic.class) {
@@ -71,10 +62,6 @@ public abstract class IntegerPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "intFromString:")
   public abstract static class FromStringPrim extends UnaryExpressionNode {
-    public FromStringPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == ComplexPrimitiveOperation.class) {
@@ -100,10 +87,6 @@ public abstract class IntegerPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "int:leftShift:", selector = "<<", receiverType = Long.class)
   public abstract static class LeftShiftPrim extends ArithmeticPrim {
-    protected LeftShiftPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     private final BranchProfile overflow = BranchProfile.create();
 
     @Specialization(rewriteOn = ArithmeticException.class)
@@ -132,10 +115,6 @@ public abstract class IntegerPrims {
   @Primitive(primitive = "int:unsignedRightShift:", selector = ">>>",
       receiverType = Long.class)
   public abstract static class UnsignedRightShiftPrim extends ArithmeticPrim {
-    protected UnsignedRightShiftPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final long doLong(final long receiver, final long right) {
       return receiver >>> right;
@@ -145,10 +124,6 @@ public abstract class IntegerPrims {
   @GenerateNodeFactory
   @Primitive(selector = "max:", receiverType = Long.class, disabled = true)
   public abstract static class MaxIntPrim extends ArithmeticPrim {
-    protected MaxIntPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final long doLong(final long receiver, final long right) {
       return Math.max(receiver, right);
@@ -158,10 +133,6 @@ public abstract class IntegerPrims {
   @GenerateNodeFactory
   @Primitive(selector = "to:", receiverType = Long.class, disabled = true)
   public abstract static class ToPrim extends BinaryComplexOperation {
-    protected ToPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SMutableArray doLong(final long receiver, final long right) {
       int cnt = (int) right - (int) receiver + 1;
@@ -176,10 +147,6 @@ public abstract class IntegerPrims {
   @GenerateNodeFactory
   @Primitive(selector = "abs", receiverType = Long.class)
   public abstract static class AbsPrim extends UnaryBasicOperation {
-    public AbsPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == OpArithmetic.class) {

--- a/src/som/primitives/MethodPrims.java
+++ b/src/som/primitives/MethodPrims.java
@@ -5,7 +5,6 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.PreevaluatedExpression;
@@ -24,10 +23,6 @@ public final class MethodPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "methodName:")
   public abstract static class SignaturePrim extends UnaryExpressionNode {
-    public SignaturePrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SAbstractObject doSMethod(final SInvokable receiver) {
       return receiver.getSignature();
@@ -45,16 +40,7 @@ public final class MethodPrims {
       extraChild = ToArgumentsArrayNodeFactory.class)
   public abstract static class InvokeOnPrim extends ExprWithTagsNode
       implements PreevaluatedExpression {
-    @Child private InvokeOnCache callNode;
-
-    public InvokeOnPrim(final SourceSection source) {
-      super(source);
-      callNode = InvokeOnCache.create();
-    }
-
-    public InvokeOnPrim(final InvokeOnPrim node) {
-      this(node.sourceSection);
-    }
+    @Child private InvokeOnCache callNode = InvokeOnCache.create();
 
     public abstract Object executeEvaluated(VirtualFrame frame,
         SInvokable receiver, Object target, SArray somArr);

--- a/src/som/primitives/MirrorPrims.java
+++ b/src/som/primitives/MirrorPrims.java
@@ -34,10 +34,6 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "objNestedClasses:")
   public abstract static class NestedClassesPrim extends UnaryExpressionNode {
-    public NestedClassesPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     @TruffleBoundary
     public final SMutableArray getNestedClasses(final SObjectWithClass rcvr) {
@@ -49,10 +45,6 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "obj:respondsTo:")
   public abstract static class RespondsToPrim extends BinaryComplexOperation {
-    protected RespondsToPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     @TruffleBoundary
     public final boolean objectResondsTo(final Object rcvr, final SSymbol selector) {
@@ -65,10 +57,6 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "objMethods:")
   public abstract static class MethodsPrim extends UnaryExpressionNode {
-    public MethodsPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     @TruffleBoundary
     public final SImmutableArray getMethod(final Object rcvr) {
@@ -85,9 +73,13 @@ public abstract class MirrorPrims {
   public abstract static class PerformPrim extends BinaryComplexOperation {
     @Child protected AbstractSymbolDispatch dispatch;
 
-    public PerformPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-      dispatch = AbstractSymbolDispatchNodeGen.create(source);
+    @Override
+    @SuppressWarnings("unchecked")
+    public PerformPrim initialize(final SourceSection sourceSection) {
+      assert sourceSection != null;
+      super.initialize(sourceSection);
+      dispatch = AbstractSymbolDispatchNodeGen.create(sourceSection);
+      return this;
     }
 
     @Specialization
@@ -102,9 +94,13 @@ public abstract class MirrorPrims {
   public abstract static class PerformWithArgumentsPrim extends TernaryExpressionNode {
     @Child protected AbstractSymbolDispatch dispatch;
 
-    public PerformWithArgumentsPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-      dispatch = AbstractSymbolDispatchNodeGen.create(source);
+    @Override
+    @SuppressWarnings("unchecked")
+    public PerformWithArgumentsPrim initialize(final SourceSection sourceSection) {
+      assert sourceSection != null;
+      super.initialize(sourceSection);
+      dispatch = AbstractSymbolDispatchNodeGen.create(sourceSection);
+      return this;
     }
 
     @Specialization
@@ -122,10 +118,6 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "classDefinition:")
   public abstract static class ClassDefinitionPrim extends UnaryExpressionNode {
-    public ClassDefinitionPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final Object getClassDefinition(final SClass rcvr) {
       return rcvr.getMixinDefinition();
@@ -135,10 +127,6 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "classDefNestedClassDefinitions:")
   public abstract static class NestedClassDefinitionsPrim extends UnaryExpressionNode {
-    public NestedClassDefinitionsPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     @TruffleBoundary
     public final Object getClassDefinition(final Object mixinHandle) {
@@ -152,10 +140,6 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "classDefName:")
   public abstract static class ClassDefNamePrim extends UnaryExpressionNode {
-    public ClassDefNamePrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SSymbol getName(final Object mixinHandle) {
       assert mixinHandle instanceof MixinDefinition;
@@ -167,10 +151,6 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "classDefMethods:")
   public abstract static class ClassDefMethodsPrim extends UnaryExpressionNode {
-    public ClassDefMethodsPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     @TruffleBoundary
     public final SImmutableArray getName(final Object mixinHandle) {
@@ -191,10 +171,6 @@ public abstract class MirrorPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "classDef:hasFactoryMethod:")
   public abstract static class ClassDefHasFactoryMethodPrim extends BinaryComplexOperation {
-    protected ClassDefHasFactoryMethodPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     @TruffleBoundary
     public final boolean hasFactoryMethod(final Object mixinHandle,

--- a/src/som/primitives/NewObjectPrim.java
+++ b/src/som/primitives/NewObjectPrim.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.MixinBuilder.MixinDefinitionId;
 import som.interpreter.nodes.ISpecialSend;
@@ -31,8 +30,7 @@ public abstract class NewObjectPrim extends UnaryExpressionNode implements ISpec
 
   private final MixinDefinitionId mixinId;
 
-  public NewObjectPrim(final SourceSection source, final MixinDefinitionId mixinId) {
-    super(false, source);
+  public NewObjectPrim(final MixinDefinitionId mixinId) {
     this.mixinId = mixinId;
   }
 

--- a/src/som/primitives/ObjectPrims.java
+++ b/src/som/primitives/ObjectPrims.java
@@ -8,7 +8,6 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.instrumentation.Instrumentable;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.Types;
@@ -37,10 +36,6 @@ public final class ObjectPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "objClassName:")
   public abstract static class ObjectClassNamePrim extends UnaryExpressionNode {
-    public ObjectClassNamePrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SSymbol getName(final Object obj) {
       VM.thisMethodNeedsToBeOptimized(
@@ -52,10 +47,6 @@ public final class ObjectPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "halt:")
   public abstract static class HaltPrim extends UnaryExpressionNode {
-    public HaltPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final Object doSAbstractObject(final Object receiver) {
       VM.errorPrintln("BREAKPOINT");
@@ -74,10 +65,6 @@ public final class ObjectPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "objClass:")
   public abstract static class ClassPrim extends UnaryExpressionNode {
-    public ClassPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SClass doSAbstractObject(final SAbstractObject receiver) {
       return receiver.getSOMClass();
@@ -93,10 +80,6 @@ public final class ObjectPrims {
   @GenerateNodeFactory
   @Primitive(selector = "isNil", noWrapper = true)
   public abstract static class IsNilNode extends UnaryBasicOperation implements OperationNode {
-    public IsNilNode(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == OpComparison.class) {
@@ -126,10 +109,6 @@ public final class ObjectPrims {
   @Primitive(selector = "notNil", noWrapper = true)
   public abstract static class NotNilNode extends UnaryBasicOperation
       implements OperationNode {
-    public NotNilNode(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == OpComparison.class) {
@@ -163,18 +142,14 @@ public final class ObjectPrims {
   @ImportStatic(Nil.class)
   @Instrumentable(factory = IsValueWrapper.class)
   public abstract static class IsValue extends UnaryExpressionNode {
-    public IsValue(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
+    protected IsValue() {}
 
-    public IsValue(final IsValue node) {
-      super(node);
-    }
+    protected IsValue(final IsValue node) {}
 
     public abstract boolean executeEvaluated(Object rcvr);
 
     public static IsValue createSubNode() {
-      return IsValueFactory.create(false, null, null);
+      return IsValueFactory.create(null);
     }
 
     @Specialization

--- a/src/som/primitives/ObjectSystemPrims.java
+++ b/src/som/primitives/ObjectSystemPrims.java
@@ -2,7 +2,6 @@ package som.primitives;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryExpressionNode;
 import som.vm.constants.KernelObj;
@@ -14,10 +13,6 @@ public abstract class ObjectSystemPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "kernelObject:")
   public abstract static class KernelObjectPrim extends UnaryExpressionNode {
-    public KernelObjectPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SObject getKernel(final Object self) {
       return KernelObj.kernel;

--- a/src/som/primitives/Primitive.java
+++ b/src/som/primitives/Primitive.java
@@ -45,9 +45,6 @@ public @interface Primitive {
   /** Pass array of evaluated arguments to node constructor. */
   boolean requiresArguments() default false;
 
-  /** Pass VM object, i.e., execution context to node constructor. */
-  boolean requiresContext() default false;
-
   /** Disabled for Dynamic Metrics. */
   boolean disabled() default false;
 

--- a/src/som/primitives/SizeAndLengthPrim.java
+++ b/src/som/primitives/SizeAndLengthPrim.java
@@ -3,7 +3,6 @@ package som.primitives;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.profiles.ValueProfile;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryBasicOperation;
 import som.vmobjects.SArray;
@@ -18,10 +17,6 @@ import tools.dym.Tags.OpLength;
     inParser = false)
 public abstract class SizeAndLengthPrim extends UnaryBasicOperation {
   private final ValueProfile storageType = ValueProfile.createClassProfile();
-
-  public SizeAndLengthPrim(final boolean eagerlyWrapped, final SourceSection source) {
-    super(eagerlyWrapped, source);
-  }
 
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {

--- a/src/som/primitives/StringPrims.java
+++ b/src/som/primitives/StringPrims.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.profiles.BranchProfile;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.BinaryComplexOperation;
 import som.interpreter.nodes.nary.BinaryExpressionNode;
@@ -22,10 +21,6 @@ public class StringPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "string:concat:")
   public abstract static class ConcatPrim extends BinaryComplexOperation {
-    protected ConcatPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == StringAccess.class) {
@@ -63,10 +58,6 @@ public class StringPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "stringAsSymbol:")
   public abstract static class AsSymbolPrim extends UnaryBasicOperation {
-    public AsSymbolPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
       if (tag == StringAccess.class) {
@@ -91,10 +82,6 @@ public class StringPrims {
   @Primitive(primitive = "string:substringFrom:to:",
       selector = "substringFrom:to:", receiverType = String.class)
   public abstract static class SubstringPrim extends TernaryExpressionNode {
-    public SubstringPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     private final BranchProfile invalidArgs = BranchProfile.create();
 
     @Override
@@ -142,10 +129,6 @@ public class StringPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "string:charAt:", selector = "charAt:", receiverType = String.class)
   public abstract static class CharAtPrim extends BinaryExpressionNode {
-    public CharAtPrim(final boolean eagerWrap, final SourceSection source) {
-      super(eagerWrap, source);
-    }
-
     private final BranchProfile invalidArgs = BranchProfile.create();
 
     @Override

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -52,10 +52,6 @@ public final class SystemPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "systemModuleObject:")
   public abstract static class SystemModuleObjectPrim extends UnaryExpressionNode {
-    public SystemModuleObjectPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final Object set(final SObjectWithClass system) {
       SystemModule = system;
@@ -79,8 +75,7 @@ public final class SystemPrims {
   public abstract static class LoadPrim extends UnaryExpressionNode {
     private final VM vm;
 
-    protected LoadPrim(final boolean eagWrap, final SourceSection source, final VM vm) {
-      super(eagWrap, source);
+    protected LoadPrim(final VM vm) {
       this.vm = vm;
     }
 
@@ -96,8 +91,7 @@ public final class SystemPrims {
   public abstract static class LoadNextToPrim extends BinaryComplexOperation {
     private final VM vm;
 
-    protected LoadNextToPrim(final boolean eagWrap, final SourceSection source, final VM vm) {
-      super(eagWrap, source);
+    protected LoadNextToPrim(final VM vm) {
       this.vm = vm;
     }
 
@@ -116,8 +110,7 @@ public final class SystemPrims {
   public abstract static class ExitPrim extends UnaryExpressionNode {
     private final VM vm;
 
-    public ExitPrim(final boolean eagWrap, final SourceSection source, final VM vm) {
-      super(eagWrap, source);
+    public ExitPrim(final VM vm) {
       this.vm = vm;
     }
 
@@ -132,10 +125,6 @@ public final class SystemPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "printString:")
   public abstract static class PrintStringPrim extends UnaryExpressionNode {
-    public PrintStringPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final Object doSObject(final String argument) {
       VM.print(argument);
@@ -151,10 +140,6 @@ public final class SystemPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "printNewline:")
   public abstract static class PrintInclNewlinePrim extends UnaryExpressionNode {
-    public PrintInclNewlinePrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final Object doSObject(final String argument) {
       VM.println(argument);
@@ -165,10 +150,6 @@ public final class SystemPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "printStackTrace:")
   public abstract static class PrintStackTracePrim extends UnaryExpressionNode {
-    public PrintStackTracePrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final Object doSObject(final Object receiver) {
       printStackTrace(2, null);
@@ -238,8 +219,7 @@ public final class SystemPrims {
   public abstract static class VMArgumentsPrim extends UnaryExpressionNode {
     private final VM vm;
 
-    public VMArgumentsPrim(final boolean eagWrap, final SourceSection source, final VM vm) {
-      super(eagWrap, source);
+    public VMArgumentsPrim(final VM vm) {
       this.vm = vm;
     }
 
@@ -253,10 +233,6 @@ public final class SystemPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "systemGC:")
   public abstract static class FullGCPrim extends UnaryExpressionNode {
-    public FullGCPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final Object doSObject(final Object receiver) {
       System.gc();
@@ -267,10 +243,6 @@ public final class SystemPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "systemTime:")
   public abstract static class TimePrim extends UnaryBasicOperation {
-    public TimePrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final long doSObject(final Object receiver) {
       return System.currentTimeMillis() - startTime;
@@ -297,10 +269,6 @@ public final class SystemPrims {
   @Primitive(primitive = "systemTicks:", selector = "ticks",
       specializer = IsSystemModule.class, noWrapper = true)
   public abstract static class TicksPrim extends UnaryBasicOperation implements OperationNode {
-    public TicksPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final long doSObject(final Object receiver) {
       return System.nanoTime() / 1000L - startMicroTime;
@@ -322,8 +290,7 @@ public final class SystemPrims {
   public abstract static class ExportAsPrim extends BinaryComplexOperation {
     private final VM vm;
 
-    protected ExportAsPrim(final boolean eagWrap, final SourceSection source, final VM vm) {
-      super(eagWrap, source);
+    protected ExportAsPrim(final VM vm) {
       this.vm = vm;
     }
 
@@ -342,14 +309,9 @@ public final class SystemPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "systemApply:with:")
   public abstract static class ApplyWithPrim extends BinaryComplexOperation {
-    protected ApplyWithPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     private final ValueProfile storageType = ValueProfile.createClassProfile();
 
-    @Child protected SizeAndLengthPrim size    =
-        SizeAndLengthPrimFactory.create(false, null, null);
+    @Child protected SizeAndLengthPrim size    = SizeAndLengthPrimFactory.create(null);
     @Child protected ToSomConversion   convert = ToSomConversionNodeGen.create(null);
 
     @Specialization

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -32,8 +32,10 @@ import som.interpreter.Invokable;
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.OperationNode;
 import som.interpreter.nodes.nary.BinaryComplexOperation;
+import som.interpreter.nodes.nary.BinaryComplexOperation.BinarySystemOperation;
 import som.interpreter.nodes.nary.UnaryBasicOperation;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
+import som.interpreter.nodes.nary.UnaryExpressionNode.UnarySystemOperation;
 import som.vm.NotYetImplementedException;
 import som.vm.Primitives.Specializer;
 import som.vm.constants.Classes;
@@ -71,14 +73,8 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive(primitive = "load:", requiresContext = true)
-  public abstract static class LoadPrim extends UnaryExpressionNode {
-    private final VM vm;
-
-    protected LoadPrim(final VM vm) {
-      this.vm = vm;
-    }
-
+  @Primitive(primitive = "load:")
+  public abstract static class LoadPrim extends UnarySystemOperation {
     @Specialization
     @TruffleBoundary
     public final Object doSObject(final String moduleName) {
@@ -87,14 +83,8 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive(primitive = "load:nextTo:", requiresContext = true)
-  public abstract static class LoadNextToPrim extends BinaryComplexOperation {
-    private final VM vm;
-
-    protected LoadNextToPrim(final VM vm) {
-      this.vm = vm;
-    }
-
+  @Primitive(primitive = "load:nextTo:")
+  public abstract static class LoadNextToPrim extends BinarySystemOperation {
     @Specialization
     @TruffleBoundary
     public final Object load(final String filename, final SObjectWithClass moduleObj) {
@@ -106,14 +96,8 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive(primitive = "exit:", requiresContext = true)
-  public abstract static class ExitPrim extends UnaryExpressionNode {
-    private final VM vm;
-
-    public ExitPrim(final VM vm) {
-      this.vm = vm;
-    }
-
+  @Primitive(primitive = "exit:")
+  public abstract static class ExitPrim extends UnarySystemOperation {
     @Specialization
     @TruffleBoundary
     public final Object doSObject(final long error) {
@@ -215,14 +199,8 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive(primitive = "vmArguments:", requiresContext = true)
-  public abstract static class VMArgumentsPrim extends UnaryExpressionNode {
-    private final VM vm;
-
-    public VMArgumentsPrim(final VM vm) {
-      this.vm = vm;
-    }
-
+  @Primitive(primitive = "vmArguments:")
+  public abstract static class VMArgumentsPrim extends UnarySystemOperation {
     @Specialization
     public final SImmutableArray getArguments(final Object receiver) {
       return new SImmutableArray(vm.getArguments(),
@@ -286,14 +264,8 @@ public final class SystemPrims {
   }
 
   @GenerateNodeFactory
-  @Primitive(primitive = "systemExport:as:", requiresContext = true)
-  public abstract static class ExportAsPrim extends BinaryComplexOperation {
-    private final VM vm;
-
-    protected ExportAsPrim(final VM vm) {
-      this.vm = vm;
-    }
-
+  @Primitive(primitive = "systemExport:as:")
+  public abstract static class ExportAsPrim extends BinarySystemOperation {
     @Specialization
     public final boolean doString(final Object obj, final String name) {
       vm.registerExport(name, obj);

--- a/src/som/primitives/TimerPrim.java
+++ b/src/som/primitives/TimerPrim.java
@@ -8,7 +8,6 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.actors.ResolvePromiseNode;
@@ -26,13 +25,7 @@ public abstract class TimerPrim extends BinaryComplexOperation {
 
   private final ForkJoinPool actorPool;
 
-  protected TimerPrim(final BinaryComplexOperation node) {
-    super(node);
-    this.actorPool = null;
-  }
-
-  protected TimerPrim(final boolean eagWrap, final SourceSection source, final VM vm) {
-    super(eagWrap, source);
+  protected TimerPrim(final VM vm) {
     this.actorPool = vm.getActorPool();
   }
 

--- a/src/som/primitives/TimerPrim.java
+++ b/src/som/primitives/TimerPrim.java
@@ -15,21 +15,23 @@ import som.interpreter.actors.SPromise.Resolution;
 import som.interpreter.actors.SPromise.SResolver;
 import som.interpreter.actors.WrapReferenceNode;
 import som.interpreter.actors.WrapReferenceNodeGen;
-import som.interpreter.nodes.nary.BinaryComplexOperation;
+import som.interpreter.nodes.nary.BinaryComplexOperation.BinarySystemOperation;
 
 
 @GenerateNodeFactory
-@Primitive(primitive = "actorResolveProm:after:", requiresContext = true)
-public abstract class TimerPrim extends BinaryComplexOperation {
+@Primitive(primitive = "actorResolveProm:after:")
+public abstract class TimerPrim extends BinarySystemOperation {
   @CompilationFinal private static Timer timer;
-
-  private final ForkJoinPool actorPool;
-
-  protected TimerPrim(final VM vm) {
-    this.actorPool = vm.getActorPool();
-  }
+  @CompilationFinal private ForkJoinPool actorPool;
 
   @Child protected WrapReferenceNode wrapper = WrapReferenceNodeGen.create();
+
+  @Override
+  public final TimerPrim initialize(final VM vm) {
+    super.initialize(vm);
+    this.actorPool = vm.getActorPool();
+    return this;
+  }
 
   @Specialization
   @TruffleBoundary

--- a/src/som/primitives/UnequalsPrim.java
+++ b/src/som/primitives/UnequalsPrim.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.vm.constants.Nil;
 import som.vmobjects.SObjectWithClass;
@@ -17,10 +16,6 @@ import som.vmobjects.SSymbol;
 @ImportStatic(Nil.class)
 @Primitive(selector = "<>")
 public abstract class UnequalsPrim extends ComparisonPrim {
-  protected UnequalsPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final boolean doBoolean(final boolean left, final boolean right) {
     return left != right;

--- a/src/som/primitives/WithContext.java
+++ b/src/som/primitives/WithContext.java
@@ -1,0 +1,8 @@
+package som.primitives;
+
+import som.VM;
+
+
+public interface WithContext<T> {
+  T initialize(VM vm);
+}

--- a/src/som/primitives/actors/ActorClasses.java
+++ b/src/som/primitives/actors/ActorClasses.java
@@ -3,7 +3,6 @@ package som.primitives.actors;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.MixinBuilder.MixinDefinitionId;
 import som.interpreter.actors.SFarReference;
@@ -23,10 +22,6 @@ public final class ActorClasses {
   @GenerateNodeFactory
   @Primitive(primitive = "actorsFarReferenceClass:")
   public abstract static class SetFarReferenceClassPrim extends UnaryExpressionNode {
-    public SetFarReferenceClassPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SClass setClass(final SClass value) {
       SFarReference.setSOMClass(value);
@@ -38,10 +33,6 @@ public final class ActorClasses {
   @GenerateNodeFactory
   @Primitive(primitive = "actorsPromiseClass:")
   public abstract static class SetPromiseClassPrim extends UnaryExpressionNode {
-    public SetPromiseClassPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SClass setClass(final SClass value) {
       SPromise.setSOMClass(value);
@@ -52,10 +43,6 @@ public final class ActorClasses {
   @GenerateNodeFactory
   @Primitive(primitive = "actorsPairClass:")
   public abstract static class SetPairClassPrim extends UnaryExpressionNode {
-    public SetPairClassPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SClass setClass(final SClass value) {
       SPromise.setPairClass(value);
@@ -66,10 +53,6 @@ public final class ActorClasses {
   @GenerateNodeFactory
   @Primitive(primitive = "actorsResolverClass:")
   public abstract static class SetResolverClassPrim extends UnaryExpressionNode {
-    public SetResolverClassPrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SClass setClass(final SClass value) {
       SResolver.setSOMClass(value);
@@ -80,10 +63,6 @@ public final class ActorClasses {
   @GenerateNodeFactory
   @Primitive(primitive = "actorsModule:")
   public abstract static class SetModulePrim extends UnaryExpressionNode {
-    public SetModulePrim(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SImmutableObject setClass(final SImmutableObject value) {
       ActorModule = value;

--- a/src/som/primitives/actors/CreateActorPrim.java
+++ b/src/som/primitives/actors/CreateActorPrim.java
@@ -3,10 +3,9 @@ package som.primitives.actors;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 
-import som.VM;
 import som.interpreter.actors.Actor;
 import som.interpreter.actors.SFarReference;
-import som.interpreter.nodes.nary.BinaryComplexOperation;
+import som.interpreter.nodes.nary.BinaryComplexOperation.BinarySystemOperation;
 import som.primitives.ObjectPrims.IsValue;
 import som.primitives.ObjectPrimsFactory.IsValueFactory.IsValueNodeGen;
 import som.primitives.Primitive;
@@ -21,16 +20,9 @@ import tools.debugger.entities.ActivityType;
 
 @GenerateNodeFactory
 @Primitive(primitive = "actors:createFromValue:", selector = "createActorFromValue:",
-    specializer = IsActorModule.class, requiresContext = true)
-public abstract class CreateActorPrim extends BinaryComplexOperation {
-  private final VM vm;
-
-  @Child protected IsValue isValue;
-
-  protected CreateActorPrim(final VM vm) {
-    this.vm = vm;
-    isValue = IsValueNodeGen.createSubNode();
-  }
+    specializer = IsActorModule.class)
+public abstract class CreateActorPrim extends BinarySystemOperation {
+  @Child protected IsValue isValue = IsValueNodeGen.createSubNode();
 
   @Specialization(guards = "isValue.executeEvaluated(argument)")
   public final SFarReference createActor(final Object receiver, final Object argument) {

--- a/src/som/primitives/actors/CreateActorPrim.java
+++ b/src/som/primitives/actors/CreateActorPrim.java
@@ -2,7 +2,6 @@ package som.primitives.actors;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.actors.Actor;
@@ -28,8 +27,7 @@ public abstract class CreateActorPrim extends BinaryComplexOperation {
 
   @Child protected IsValue isValue;
 
-  protected CreateActorPrim(final boolean eagWrap, final SourceSection source, final VM vm) {
-    super(eagWrap, source);
+  protected CreateActorPrim(final VM vm) {
     this.vm = vm;
     isValue = IsValueNodeGen.createSubNode();
   }

--- a/src/som/primitives/actors/PromisePrims.java
+++ b/src/som/primitives/actors/PromisePrims.java
@@ -73,19 +73,27 @@ public final class PromisePrims {
     @Child protected AbstractBreakpointNode promiseResolverBreakpoint;
     @Child protected AbstractBreakpointNode promiseResolutionBreakpoint;
 
+    private final VM vm;
+
     protected static final DirectCallNode create() {
       Dispatchable disp = SPromise.pairClass.getSOMClass().lookupMessage(
           withAndFactory, AccessModifier.PUBLIC);
       return Truffle.getRuntime().createDirectCallNode(((SInvokable) disp).getCallTarget());
     }
 
-    public CreatePromisePairPrim(final boolean eagerWrapper, final SourceSection source,
-        final VM vm) {
-      super(eagerWrapper, source);
+    public CreatePromisePairPrim(final VM vm) {
+      this.vm = vm;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final CreatePromisePairPrim initialize(final SourceSection source) {
+      super.initialize(source);
       this.promiseResolverBreakpoint =
           insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLVER, vm));
       this.promiseResolutionBreakpoint =
           insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLUTION, vm));
+      return this;
     }
 
     @Specialization
@@ -134,15 +142,22 @@ public final class PromisePrims {
     @Child protected AbstractBreakpointNode promiseResolverBreakpoint;
     @Child protected AbstractBreakpointNode promiseResolutionBreakpoint;
 
-    protected WhenResolvedPrim(final boolean eagWrap, final SourceSection source,
-        final VM vm) {
-      super(eagWrap, source);
-      this.registerNode = new RegisterWhenResolved(vm.getActorPool());
+    private final VM vm;
 
+    protected WhenResolvedPrim(final VM vm) {
+      this.registerNode = new RegisterWhenResolved(vm.getActorPool());
+      this.vm = vm;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final WhenResolvedPrim initialize(final SourceSection source) {
+      super.initialize(source);
       this.promiseResolverBreakpoint =
           insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLVER, vm));
       this.promiseResolutionBreakpoint =
           insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLUTION, vm));
+      return this;
     }
 
     @Specialization(guards = "blockMethod == callback.getMethod()", limit = "10")
@@ -200,14 +215,22 @@ public final class PromisePrims {
     @Child protected AbstractBreakpointNode promiseResolverBreakpoint;
     @Child protected AbstractBreakpointNode promiseResolutionBreakpoint;
 
-    protected OnErrorPrim(final boolean eagWrap, final SourceSection source, final VM vm) {
-      super(eagWrap, source);
-      this.registerNode = new RegisterOnError(vm.getActorPool());
+    private final VM vm;
 
+    protected OnErrorPrim(final VM vm) {
+      this.registerNode = new RegisterOnError(vm.getActorPool());
+      this.vm = vm;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final OnErrorPrim initialize(final SourceSection source) {
+      super.initialize(source);
       this.promiseResolverBreakpoint =
           insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLVER, vm));
       this.promiseResolutionBreakpoint =
           insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLUTION, vm));
+      return this;
     }
 
     @Specialization(guards = "blockMethod == callback.getMethod()", limit = "10")
@@ -267,15 +290,23 @@ public final class PromisePrims {
     @Child protected AbstractBreakpointNode promiseResolverBreakpoint;
     @Child protected AbstractBreakpointNode promiseResolutionBreakpoint;
 
-    public WhenResolvedOnErrorPrim(final boolean eagWrap, final SourceSection source,
-        final VM vm) {
-      super(eagWrap, source);
+    private final VM vm;
+
+    public WhenResolvedOnErrorPrim(final VM vm) {
       this.registerWhenResolved = new RegisterWhenResolved(vm.getActorPool());
       this.registerOnError = new RegisterOnError(vm.getActorPool());
+      this.vm = vm;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final WhenResolvedOnErrorPrim initialize(final SourceSection source) {
+      super.initialize(source);
       this.promiseResolverBreakpoint =
           insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLVER, vm));
       this.promiseResolutionBreakpoint =
           insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLUTION, vm));
+      return this;
     }
 
     @Specialization(guards = {"resolvedMethod == resolved.getMethod()",

--- a/src/som/primitives/actors/PromisePrims.java
+++ b/src/som/primitives/actors/PromisePrims.java
@@ -10,7 +10,6 @@ import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
 import com.oracle.truffle.api.nodes.DirectCallNode;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.compiler.AccessModifier;
@@ -24,9 +23,9 @@ import som.interpreter.actors.SPromise;
 import som.interpreter.actors.SPromise.SResolver;
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.dispatch.Dispatchable;
-import som.interpreter.nodes.nary.BinaryComplexOperation;
-import som.interpreter.nodes.nary.TernaryExpressionNode;
-import som.interpreter.nodes.nary.UnaryExpressionNode;
+import som.interpreter.nodes.nary.BinaryComplexOperation.BinarySystemOperation;
+import som.interpreter.nodes.nary.TernaryExpressionNode.TernarySystemOperation;
+import som.interpreter.nodes.nary.UnaryExpressionNode.UnarySystemOperation;
 import som.primitives.Primitive;
 import som.vm.Primitives.Specializer;
 import som.vm.Symbols;
@@ -68,12 +67,10 @@ public final class PromisePrims {
 
   @GenerateNodeFactory
   @Primitive(primitive = "actorsCreatePromisePair:", selector = "createPromisePair",
-      specializer = IsActorModule.class, noWrapper = true, requiresContext = true)
-  public abstract static class CreatePromisePairPrim extends UnaryExpressionNode {
+      specializer = IsActorModule.class, noWrapper = true)
+  public abstract static class CreatePromisePairPrim extends UnarySystemOperation {
     @Child protected AbstractBreakpointNode promiseResolverBreakpoint;
     @Child protected AbstractBreakpointNode promiseResolutionBreakpoint;
-
-    private final VM vm;
 
     protected static final DirectCallNode create() {
       Dispatchable disp = SPromise.pairClass.getSOMClass().lookupMessage(
@@ -81,18 +78,13 @@ public final class PromisePrims {
       return Truffle.getRuntime().createDirectCallNode(((SInvokable) disp).getCallTarget());
     }
 
-    public CreatePromisePairPrim(final VM vm) {
-      this.vm = vm;
-    }
-
     @Override
-    @SuppressWarnings("unchecked")
-    public final CreatePromisePairPrim initialize(final SourceSection source) {
-      super.initialize(source);
+    public final CreatePromisePairPrim initialize(final VM vm) {
+      super.initialize(vm);
       this.promiseResolverBreakpoint =
-          insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLVER, vm));
+          insert(Breakpoints.create(sourceSection, BreakpointType.PROMISE_RESOLVER, vm));
       this.promiseResolutionBreakpoint =
-          insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLUTION, vm));
+          insert(Breakpoints.create(sourceSection, BreakpointType.PROMISE_RESOLUTION, vm));
       return this;
     }
 
@@ -135,28 +127,21 @@ public final class PromisePrims {
   @GenerateNodeFactory
   @ImportStatic(PromisePrims.class)
   @Primitive(primitive = "actorsWhen:resolved:", selector = "whenResolved:",
-      receiverType = SPromise.class, requiresContext = true)
-  public abstract static class WhenResolvedPrim extends BinaryComplexOperation {
+      receiverType = SPromise.class)
+  public abstract static class WhenResolvedPrim extends BinarySystemOperation {
     @Child protected RegisterWhenResolved registerNode;
 
     @Child protected AbstractBreakpointNode promiseResolverBreakpoint;
     @Child protected AbstractBreakpointNode promiseResolutionBreakpoint;
 
-    private final VM vm;
-
-    protected WhenResolvedPrim(final VM vm) {
-      this.registerNode = new RegisterWhenResolved(vm.getActorPool());
-      this.vm = vm;
-    }
-
     @Override
-    @SuppressWarnings("unchecked")
-    public final WhenResolvedPrim initialize(final SourceSection source) {
-      super.initialize(source);
+    public final WhenResolvedPrim initialize(final VM vm) {
+      super.initialize(vm);
+      this.registerNode = new RegisterWhenResolved(vm.getActorPool());
       this.promiseResolverBreakpoint =
-          insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLVER, vm));
+          insert(Breakpoints.create(sourceSection, BreakpointType.PROMISE_RESOLVER, vm));
       this.promiseResolutionBreakpoint =
-          insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLUTION, vm));
+          insert(Breakpoints.create(sourceSection, BreakpointType.PROMISE_RESOLUTION, vm));
       return this;
     }
 
@@ -209,27 +194,20 @@ public final class PromisePrims {
   // TODO: should I add a literal version of OnErrorPrim??
   @GenerateNodeFactory
   @ImportStatic(PromisePrims.class)
-  @Primitive(primitive = "actorsFor:onError:", selector = "onError:", requiresContext = true)
-  public abstract static class OnErrorPrim extends BinaryComplexOperation {
+  @Primitive(primitive = "actorsFor:onError:", selector = "onError:")
+  public abstract static class OnErrorPrim extends BinarySystemOperation {
     @Child protected RegisterOnError        registerNode;
     @Child protected AbstractBreakpointNode promiseResolverBreakpoint;
     @Child protected AbstractBreakpointNode promiseResolutionBreakpoint;
 
-    private final VM vm;
-
-    protected OnErrorPrim(final VM vm) {
-      this.registerNode = new RegisterOnError(vm.getActorPool());
-      this.vm = vm;
-    }
-
     @Override
-    @SuppressWarnings("unchecked")
-    public final OnErrorPrim initialize(final SourceSection source) {
-      super.initialize(source);
+    public final OnErrorPrim initialize(final VM vm) {
+      super.initialize(vm);
+      this.registerNode = new RegisterOnError(vm.getActorPool());
       this.promiseResolverBreakpoint =
-          insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLVER, vm));
+          insert(Breakpoints.create(sourceSection, BreakpointType.PROMISE_RESOLVER, vm));
       this.promiseResolutionBreakpoint =
-          insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLUTION, vm));
+          insert(Breakpoints.create(sourceSection, BreakpointType.PROMISE_RESOLUTION, vm));
       return this;
     }
 
@@ -281,31 +259,22 @@ public final class PromisePrims {
 
   @GenerateNodeFactory
   @ImportStatic(PromisePrims.class)
-  @Primitive(primitive = "actorsWhen:resolved:onError:", selector = "whenResolved:onError:",
-      requiresContext = true)
-  public abstract static class WhenResolvedOnErrorPrim extends TernaryExpressionNode {
+  @Primitive(primitive = "actorsWhen:resolved:onError:", selector = "whenResolved:onError:")
+  public abstract static class WhenResolvedOnErrorPrim extends TernarySystemOperation {
     @Child protected RegisterWhenResolved registerWhenResolved;
     @Child protected RegisterOnError      registerOnError;
 
     @Child protected AbstractBreakpointNode promiseResolverBreakpoint;
     @Child protected AbstractBreakpointNode promiseResolutionBreakpoint;
 
-    private final VM vm;
-
-    public WhenResolvedOnErrorPrim(final VM vm) {
+    @Override
+    public final WhenResolvedOnErrorPrim initialize(final VM vm) {
+      this.promiseResolverBreakpoint =
+          insert(Breakpoints.create(sourceSection, BreakpointType.PROMISE_RESOLVER, vm));
+      this.promiseResolutionBreakpoint =
+          insert(Breakpoints.create(sourceSection, BreakpointType.PROMISE_RESOLUTION, vm));
       this.registerWhenResolved = new RegisterWhenResolved(vm.getActorPool());
       this.registerOnError = new RegisterOnError(vm.getActorPool());
-      this.vm = vm;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public final WhenResolvedOnErrorPrim initialize(final SourceSection source) {
-      super.initialize(source);
-      this.promiseResolverBreakpoint =
-          insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLVER, vm));
-      this.promiseResolutionBreakpoint =
-          insert(Breakpoints.create(source, BreakpointType.PROMISE_RESOLUTION, vm));
       return this;
     }
 

--- a/src/som/primitives/arithmetic/AdditionPrim.java
+++ b/src/som/primitives/arithmetic/AdditionPrim.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.ExactMath;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.Primitive;
 import som.vmobjects.SClass;
@@ -18,10 +17,6 @@ import som.vmobjects.SSymbol;
 @Primitive(primitive = "double:add:")
 @Primitive(selector = "+")
 public abstract class AdditionPrim extends ArithmeticPrim {
-  protected AdditionPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization(rewriteOn = ArithmeticException.class)
   public final long doLong(final long left, final long argument) {
     return ExactMath.addExact(left, argument);

--- a/src/som/primitives/arithmetic/ArithmeticPrim.java
+++ b/src/som/primitives/arithmetic/ArithmeticPrim.java
@@ -3,17 +3,12 @@ package som.primitives.arithmetic;
 import java.math.BigInteger;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.BinaryBasicOperation;
 import tools.dym.Tags.OpArithmetic;
 
 
 public abstract class ArithmeticPrim extends BinaryBasicOperation {
-  protected ArithmeticPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
     if (tag == OpArithmetic.class) {

--- a/src/som/primitives/arithmetic/DividePrim.java
+++ b/src/som/primitives/arithmetic/DividePrim.java
@@ -5,7 +5,6 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.Primitive;
 
@@ -13,10 +12,6 @@ import som.primitives.Primitive;
 @GenerateNodeFactory
 @Primitive(primitive = "int:divideBy:", selector = "/")
 public abstract class DividePrim extends ArithmeticPrim {
-  protected DividePrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final long doLong(final long left, final long right) {
     return left / right;

--- a/src/som/primitives/arithmetic/DoubleDivPrim.java
+++ b/src/som/primitives/arithmetic/DoubleDivPrim.java
@@ -5,7 +5,6 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.Primitive;
 import som.vm.NotYetImplementedException;
@@ -17,10 +16,6 @@ import som.vmobjects.SAbstractObject;
 @Primitive(primitive = "double:divideDouble:")
 @Primitive(selector = "//")
 public abstract class DoubleDivPrim extends ArithmeticPrim {
-  protected DoubleDivPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final double doDouble(final double left, final double right) {
     return left / right;
@@ -39,9 +34,9 @@ public abstract class DoubleDivPrim extends ArithmeticPrim {
   @Specialization
   public final SAbstractObject doLong(final long left, final BigInteger right) {
     CompilerAsserts.neverPartOfCompilation("DoubleDiv100");
-    throw new NotYetImplementedException(); // TODO: need to implement the "/" case here
-                                            // directly... : return resendAsBigInteger("/",
-                                            // left, (SBigInteger) rightObj, frame.pack());
+    // TODO: need to implement the "/" case here
+    // directly: return resendAsBigInteger("/", left, (SBigInteger) rightObj, frame.pack());
+    throw new NotYetImplementedException();
   }
 
   @Specialization

--- a/src/som/primitives/arithmetic/ExpPrim.java
+++ b/src/som/primitives/arithmetic/ExpPrim.java
@@ -2,7 +2,6 @@ package som.primitives.arithmetic;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryExpressionNode;
 import som.primitives.Primitive;
@@ -11,10 +10,6 @@ import som.primitives.Primitive;
 @GenerateNodeFactory
 @Primitive(primitive = "doubleExp:", selector = "exp", receiverType = Double.class)
 public abstract class ExpPrim extends UnaryExpressionNode {
-  public ExpPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final double doExp(final double rcvr) {
     return Math.exp(rcvr);

--- a/src/som/primitives/arithmetic/GreaterThanOrEqualPrim.java
+++ b/src/som/primitives/arithmetic/GreaterThanOrEqualPrim.java
@@ -5,7 +5,6 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.ComparisonPrim;
 import som.primitives.Primitive;
@@ -14,10 +13,6 @@ import som.primitives.Primitive;
 @GenerateNodeFactory
 @Primitive(selector = ">=")
 public abstract class GreaterThanOrEqualPrim extends ComparisonPrim {
-  protected GreaterThanOrEqualPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final boolean doLong(final long left, final long right) {
     return left >= right;

--- a/src/som/primitives/arithmetic/GreaterThanPrim.java
+++ b/src/som/primitives/arithmetic/GreaterThanPrim.java
@@ -5,7 +5,6 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.ComparisonPrim;
 import som.primitives.Primitive;
@@ -14,10 +13,6 @@ import som.primitives.Primitive;
 @GenerateNodeFactory
 @Primitive(selector = ">")
 public abstract class GreaterThanPrim extends ComparisonPrim {
-  protected GreaterThanPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final boolean doLong(final long left, final long right) {
     return left > right;

--- a/src/som/primitives/arithmetic/LessThanOrEqualPrim.java
+++ b/src/som/primitives/arithmetic/LessThanOrEqualPrim.java
@@ -5,7 +5,6 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.ComparisonPrim;
 import som.primitives.Primitive;
@@ -14,10 +13,6 @@ import som.primitives.Primitive;
 @GenerateNodeFactory
 @Primitive(selector = "<=")
 public abstract class LessThanOrEqualPrim extends ComparisonPrim {
-  protected LessThanOrEqualPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final boolean doLong(final long left, final long right) {
     return left <= right;

--- a/src/som/primitives/arithmetic/LessThanPrim.java
+++ b/src/som/primitives/arithmetic/LessThanPrim.java
@@ -5,7 +5,6 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.ComparisonPrim;
 import som.primitives.Primitive;
@@ -16,10 +15,6 @@ import som.primitives.Primitive;
 @Primitive(primitive = "double:lessThan:")
 @Primitive(selector = "<")
 public abstract class LessThanPrim extends ComparisonPrim {
-  protected LessThanPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final boolean doLong(final long left, final long right) {
     return left < right;

--- a/src/som/primitives/arithmetic/LogPrim.java
+++ b/src/som/primitives/arithmetic/LogPrim.java
@@ -2,7 +2,6 @@ package som.primitives.arithmetic;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryBasicOperation;
 import som.primitives.Primitive;
@@ -11,12 +10,7 @@ import som.primitives.Primitive;
 @GenerateNodeFactory
 @Primitive(primitive = "doubleLog:", selector = "log", receiverType = Double.class)
 public abstract class LogPrim extends UnaryBasicOperation {
-  public LogPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   // TODO: assign some specific tag
-
   @Specialization
   public final double doLog(final double rcvr) {
     return Math.log(rcvr);

--- a/src/som/primitives/arithmetic/ModuloPrim.java
+++ b/src/som/primitives/arithmetic/ModuloPrim.java
@@ -5,7 +5,6 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.Primitive;
 
@@ -15,10 +14,6 @@ import som.primitives.Primitive;
 @Primitive(primitive = "double:modulo:")
 @Primitive(selector = "%")
 public abstract class ModuloPrim extends ArithmeticPrim {
-  protected ModuloPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final double doDouble(final double left, final double right) {
     return left % right;

--- a/src/som/primitives/arithmetic/MultiplicationPrim.java
+++ b/src/som/primitives/arithmetic/MultiplicationPrim.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.ExactMath;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.Primitive;
 
@@ -16,10 +15,6 @@ import som.primitives.Primitive;
 @Primitive(primitive = "double:multiply:")
 @Primitive(selector = "*")
 public abstract class MultiplicationPrim extends ArithmeticPrim {
-  protected MultiplicationPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization(rewriteOn = ArithmeticException.class)
   public final long doLong(final long left, final long right) {
     return ExactMath.multiplyExact(left, right);

--- a/src/som/primitives/arithmetic/RemainderPrim.java
+++ b/src/som/primitives/arithmetic/RemainderPrim.java
@@ -5,7 +5,6 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.Primitive;
 
@@ -13,10 +12,6 @@ import som.primitives.Primitive;
 @GenerateNodeFactory
 @Primitive(primitive = "int:reminder:", selector = "rem:")
 public abstract class RemainderPrim extends ArithmeticPrim {
-  protected RemainderPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final double doDouble(final double left, final double right) {
     return left % right;

--- a/src/som/primitives/arithmetic/SinPrim.java
+++ b/src/som/primitives/arithmetic/SinPrim.java
@@ -2,7 +2,6 @@ package som.primitives.arithmetic;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryBasicOperation;
 import som.primitives.Primitive;
@@ -12,10 +11,6 @@ import tools.dym.Tags.OpArithmetic;
 @GenerateNodeFactory
 @Primitive(primitive = "doubleSin:", selector = "sin", receiverType = Double.class)
 public abstract class SinPrim extends UnaryBasicOperation {
-  public SinPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
     if (tag == OpArithmetic.class) { // TODO: is this good enough?

--- a/src/som/primitives/arithmetic/SqrtPrim.java
+++ b/src/som/primitives/arithmetic/SqrtPrim.java
@@ -5,7 +5,6 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryBasicOperation;
 import som.primitives.Primitive;
@@ -17,10 +16,6 @@ import tools.dym.Tags.OpArithmetic;
 @Primitive(primitive = "doubleSqrt:")
 @Primitive(selector = "sqrt", receiverType = {Long.class, BigInteger.class, Double.class})
 public abstract class SqrtPrim extends UnaryBasicOperation {
-  public SqrtPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Override
   protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
     if (tag == OpArithmetic.class) {

--- a/src/som/primitives/arithmetic/SubtractionPrim.java
+++ b/src/som/primitives/arithmetic/SubtractionPrim.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.ExactMath;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.Primitive;
 
@@ -16,10 +15,6 @@ import som.primitives.Primitive;
 @Primitive(primitive = "double:subtract:")
 @Primitive(selector = "-")
 public abstract class SubtractionPrim extends ArithmeticPrim {
-  protected SubtractionPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization(rewriteOn = ArithmeticException.class)
   public final long doLong(final long left, final long right) {
     return ExactMath.subtractExact(left, right);

--- a/src/som/primitives/arrays/AtPrim.java
+++ b/src/som/primitives/arrays/AtPrim.java
@@ -56,7 +56,8 @@ public abstract class AtPrim extends BinaryBasicOperation {
       }
 
       if (forAtomic) {
-        return TxBinaryArrayOpNodeGen.create(eagerWrapper, section, node, null, null);
+        return TxBinaryArrayOpNodeGen.create(node, null, null).initialize(section,
+            eagerWrapper);
       } else {
         return node;
       }
@@ -67,10 +68,13 @@ public abstract class AtPrim extends BinaryBasicOperation {
 
   @Child protected AbstractMessageSendNode exception;
 
-  protected AtPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-    exception = MessageSendNode.createGeneric(
-        Symbols.symbolFor("signalWith:index:"), null, getSourceSection());
+  @Override
+  @SuppressWarnings("unchecked")
+  public AtPrim initialize(final SourceSection sourceSection) {
+    super.initialize(sourceSection);
+    this.exception = MessageSendNode.createGeneric(
+        Symbols.symbolFor("signalWith:index:"), null, sourceSection);
+    return this;
   }
 
   @Override

--- a/src/som/primitives/arrays/AtPutPrim.java
+++ b/src/som/primitives/arrays/AtPutPrim.java
@@ -62,7 +62,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
       }
 
       if (forAtomic) {
-        return TxTernaryArrayOpNodeGen.create(eagerWrapper, section, node, null, null, null);
+        return TxTernaryArrayOpNodeGen.create(node, null, null, null).initialize(section);
       } else {
         return node;
       }
@@ -73,10 +73,13 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
 
   @Child protected AbstractMessageSendNode exception;
 
-  protected AtPutPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
+  @Override
+  @SuppressWarnings("unchecked")
+  public AtPutPrim initialize(final SourceSection sourceSection) {
+    super.initialize(sourceSection);
     exception = MessageSendNode.createGeneric(
-        Symbols.symbolFor("signalWith:index:"), null, getSourceSection());
+        Symbols.symbolFor("signalWith:index:"), null, sourceSection);
+    return this;
   }
 
   @Override

--- a/src/som/primitives/arrays/CopyPrim.java
+++ b/src/som/primitives/arrays/CopyPrim.java
@@ -3,7 +3,6 @@ package som.primitives.arrays;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.profiles.ValueProfile;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryExpressionNode;
 import som.primitives.Primitive;
@@ -14,10 +13,6 @@ import som.vmobjects.SArray.SMutableArray;
 @GenerateNodeFactory
 @Primitive(selector = "copy", receiverType = SArray.class, disabled = true)
 public abstract class CopyPrim extends UnaryExpressionNode {
-  public CopyPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   private final ValueProfile storageType = ValueProfile.createClassProfile();
 
   @Specialization(guards = "receiver.isEmptyType()")

--- a/src/som/primitives/arrays/DoIndexesPrim.java
+++ b/src/som/primitives/arrays/DoIndexesPrim.java
@@ -3,7 +3,6 @@ package som.primitives.arrays;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.dispatch.BlockDispatchNode;
@@ -20,19 +19,9 @@ import som.vmobjects.SBlock;
 @GenerateNodeFactory
 @Primitive(selector = "doIndexes:", receiverType = SArray.class, disabled = true)
 public abstract class DoIndexesPrim extends BinaryComplexOperation {
-  @Child protected BlockDispatchNode block;
-  @Child protected SizeAndLengthPrim length;
-
-  public DoIndexesPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-    // TODO: tag properly, this is a loop, but without array access
-    block = BlockDispatchNodeGen.create();
-    length = SizeAndLengthPrimFactory.create(false, null, null);
-  }
-
-  public DoIndexesPrim(final SourceSection source) {
-    this(false, source);
-  }
+  @Child protected BlockDispatchNode block  = BlockDispatchNodeGen.create();
+  @Child protected SizeAndLengthPrim length = SizeAndLengthPrimFactory.create(null);
+  // TODO: tag properly, this is a loop, but without array access
 
   @Specialization
   public final SArray doArray(final SArray receiver, final SBlock block) {
@@ -48,8 +37,8 @@ public abstract class DoIndexesPrim extends BinaryComplexOperation {
 
       if (SArray.FIRST_IDX < length) {
         this.block.executeDispatch(new Object[] {
-            block, (long) SArray.FIRST_IDX + 1}); // +1 because it is going to the smalltalk
-                                                  // level
+            // +1 because it is going to the smalltalk level
+            block, (long) SArray.FIRST_IDX + 1});
       }
       for (long i = 1; i < length; i++) {
         this.block.executeDispatch(new Object[] {

--- a/src/som/primitives/arrays/DoPrim.java
+++ b/src/som/primitives/arrays/DoPrim.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.profiles.ValueProfile;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.dispatch.BlockDispatchNode;
@@ -23,17 +22,9 @@ import som.vmobjects.SBlock;
 public abstract class DoPrim extends BinaryComplexOperation {
   private final ValueProfile storageType = ValueProfile.createClassProfile();
 
-  @Child private BlockDispatchNode block;
+  @Child private BlockDispatchNode block = BlockDispatchNodeGen.create();
 
-  public DoPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-    // TODO: tag properly, it is a loop and an access
-    block = BlockDispatchNodeGen.create();
-  }
-
-  public DoPrim(final SourceSection source) {
-    this(false, source);
-  }
+  // TODO: tag properly, it is a loop and an access
 
   private void execBlock(final SBlock block, final Object arg) {
     this.block.executeDispatch(new Object[] {block, arg});

--- a/src/som/primitives/arrays/NewImmutableArrayNode.java
+++ b/src/som/primitives/arrays/NewImmutableArrayNode.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.nodes.ExpressionNode;
@@ -44,12 +43,8 @@ public abstract class NewImmutableArrayNode extends TernaryExpressionNode {
     }
   }
 
-  public NewImmutableArrayNode(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Child protected BlockDispatchNode block   = BlockDispatchNodeGen.create();
-  @Child protected IsValue           isValue = IsValueFactory.create(false, null, null);
+  @Child protected IsValue           isValue = IsValueFactory.create(null);
 
   public static boolean isValueArrayClass(final SClass valueArrayClass) {
     return Classes.valueArrayClass == valueArrayClass;

--- a/src/som/primitives/arrays/NewPrim.java
+++ b/src/som/primitives/arrays/NewPrim.java
@@ -3,7 +3,6 @@ package som.primitives.arrays;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.nodes.ExpressionNode;
@@ -31,10 +30,6 @@ public abstract class NewPrim extends BinaryExpressionNode {
     public boolean matches(final Object[] args, final ExpressionNode[] argNodes) {
       return args[0] instanceof SClass && ((SClass) args[0]).isArray();
     }
-  }
-
-  public NewPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
   }
 
   @Override

--- a/src/som/primitives/arrays/PutAllNode.java
+++ b/src/som/primitives/arrays/PutAllNode.java
@@ -5,7 +5,6 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.dispatch.BlockDispatchNode;
 import som.interpreter.nodes.dispatch.BlockDispatchNodeGen;
@@ -26,16 +25,8 @@ import som.vmobjects.SObjectWithClass;
     extraChild = SizeAndLengthPrimFactory.class)
 @NodeChild(value = "length", type = SizeAndLengthPrim.class, executeWith = "receiver")
 public abstract class PutAllNode extends BinaryComplexOperation {
-  @Child protected BlockDispatchNode block;
-
-  public PutAllNode(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source); // TODO: tag properly, it is a loop, and array access
-    block = BlockDispatchNodeGen.create();
-  }
-
-  public PutAllNode(final SourceSection source) {
-    this(false, source);
-  }
+  @Child protected BlockDispatchNode block = BlockDispatchNodeGen.create();
+  // TODO: tag properly, it is a loop, and array access
 
   protected static final boolean valueOfNoOtherSpecialization(final Object value) {
     return !(value instanceof Long) &&

--- a/src/som/primitives/arrays/ToArgumentsArrayNode.java
+++ b/src/som/primitives/arrays/ToArgumentsArrayNode.java
@@ -7,7 +7,6 @@ import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.profiles.ValueProfile;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.SArguments;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
@@ -21,14 +20,6 @@ import som.vmobjects.SArray;
     @NodeChild("receiver")})
 public abstract class ToArgumentsArrayNode extends ExprWithTagsNode {
   private final ValueProfile storageType = ValueProfile.createClassProfile();
-
-  public ToArgumentsArrayNode() {
-    super((SourceSection) null);
-  }
-
-  public ToArgumentsArrayNode(final boolean eagWrap) {
-    this();
-  } // to have uniform create() for @Primitive
 
   public static final boolean isNull(final Object somArray) {
     return somArray == null;

--- a/src/som/primitives/bitops/BitAndPrim.java
+++ b/src/som/primitives/bitops/BitAndPrim.java
@@ -5,7 +5,6 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.Primitive;
 import som.primitives.arithmetic.ArithmeticPrim;
@@ -14,10 +13,6 @@ import som.primitives.arithmetic.ArithmeticPrim;
 @GenerateNodeFactory
 @Primitive(primitive = "int:bitAnd:", selector = "&")
 public abstract class BitAndPrim extends ArithmeticPrim {
-  protected BitAndPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final long doLong(final long left, final long right) {
     return left & right;

--- a/src/som/primitives/bitops/BitOrPrim.java
+++ b/src/som/primitives/bitops/BitOrPrim.java
@@ -2,7 +2,6 @@ package som.primitives.bitops;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.Primitive;
 import som.primitives.arithmetic.ArithmeticPrim;
@@ -11,10 +10,6 @@ import som.primitives.arithmetic.ArithmeticPrim;
 @GenerateNodeFactory
 @Primitive(primitive = "int:bitOr:", selector = "bitOr:")
 public abstract class BitOrPrim extends ArithmeticPrim {
-  protected BitOrPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final long doLong(final long receiver, final long right) {
     return receiver | right;

--- a/src/som/primitives/bitops/BitXorPrim.java
+++ b/src/som/primitives/bitops/BitXorPrim.java
@@ -2,7 +2,6 @@ package som.primitives.bitops;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.primitives.Primitive;
 import som.primitives.arithmetic.ArithmeticPrim;
@@ -11,10 +10,6 @@ import som.primitives.arithmetic.ArithmeticPrim;
 @GenerateNodeFactory
 @Primitive(primitive = "int:bitXor:", selector = "bitXor:")
 public abstract class BitXorPrim extends ArithmeticPrim {
-  protected BitXorPrim(final boolean eagWrap, final SourceSection source) {
-    super(eagWrap, source);
-  }
-
   @Specialization
   public final long doLong(final long receiver, final long right) {
     return receiver ^ right;

--- a/src/som/primitives/processes/ChannelPrimitives.java
+++ b/src/som/primitives/processes/ChannelPrimitives.java
@@ -188,10 +188,6 @@ public abstract class ChannelPrimitives {
   @Primitive(primitive = "procOut:")
   @GenerateNodeFactory
   public abstract static class OutPrim extends UnaryExpressionNode {
-    public OutPrim(final boolean eagerlyWrapped, final SourceSection source) {
-      super(eagerlyWrapped, source);
-    }
-
     @Specialization
     public static final SChannelOutput getOut(final SChannel channel) {
       return channel.out;
@@ -207,10 +203,19 @@ public abstract class ChannelPrimitives {
     /** Breakpoint info for triggering suspension after write. */
     @Child protected AbstractBreakpointNode afterWrite;
 
-    public ReadPrim(final boolean eagerlyWrapped, final SourceSection source, final VM vm) {
-      super(eagerlyWrapped, source);
-      haltNode = SuspendExecutionNodeGen.create(false, sourceSection, null);
+    private final VM vm;
+
+    public ReadPrim(final VM vm) {
+      this.vm = vm;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final ReadPrim initialize(final SourceSection source) {
+      super.initialize(source);
+      haltNode = SuspendExecutionNodeGen.create(0, null).initialize(source);
       afterWrite = insert(Breakpoints.create(source, BreakpointType.CHANNEL_AFTER_SEND, vm));
+      return this;
     }
 
     @Specialization
@@ -240,7 +245,7 @@ public abstract class ChannelPrimitives {
   @Primitive(primitive = "procWrite:val:", selector = "write:", requiresContext = true)
   @GenerateNodeFactory
   public abstract static class WritePrim extends BinaryComplexOperation {
-    @Child protected IsValue isVal;
+    @Child protected IsValue isVal = IsValue.createSubNode();
 
     /** Halt execution when triggered by breakpoint on write end. */
     @Child protected UnaryExpressionNode haltNode;
@@ -248,11 +253,19 @@ public abstract class ChannelPrimitives {
     /** Breakpoint info for triggering suspension after read. */
     @Child protected AbstractBreakpointNode afterRead;
 
-    public WritePrim(final boolean eagerlyWrapped, final SourceSection source, final VM vm) {
-      super(eagerlyWrapped, source);
-      isVal = IsValue.createSubNode();
-      haltNode = SuspendExecutionNodeGen.create(false, sourceSection, null);
+    private final VM vm;
+
+    public WritePrim(final VM vm) {
+      this.vm = vm;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final WritePrim initialize(final SourceSection source) {
+      super.initialize(source);
+      haltNode = SuspendExecutionNodeGen.create(0, null).initialize(source);
       afterRead = insert(Breakpoints.create(source, BreakpointType.CHANNEL_AFTER_RCV, vm));
+      return this;
     }
 
     @Specialization
@@ -286,10 +299,6 @@ public abstract class ChannelPrimitives {
   @Primitive(primitive = "procIn:")
   @GenerateNodeFactory
   public abstract static class InPrim extends UnaryExpressionNode {
-    public InPrim(final boolean eagerlyWrapped, final SourceSection source) {
-      super(eagerlyWrapped, source);
-    }
-
     @Specialization
     public static final SChannelInput getInt(final SChannel channel) {
       return channel.in;
@@ -299,10 +308,6 @@ public abstract class ChannelPrimitives {
   @Primitive(primitive = "procChannelNew:")
   @GenerateNodeFactory
   public abstract static class ChannelNewPrim extends UnaryExpressionNode {
-    public ChannelNewPrim(final boolean eagerlyWrapped, final SourceSection source) {
-      super(eagerlyWrapped, source);
-    }
-
     @Specialization
     public final SChannel newChannel(final Object module) {
       SChannel result = SChannel.create();
@@ -318,10 +323,6 @@ public abstract class ChannelPrimitives {
   @Primitive(primitive = "procClassChannel:in:out:")
   @GenerateNodeFactory
   public abstract static class SetChannelClasses extends TernaryExpressionNode {
-    public SetChannelClasses(final boolean eagerlyWrapped, final SourceSection source) {
-      super(eagerlyWrapped, source);
-    }
-
     @Specialization
     public static final Object set(final SClass channel, final SClass in, final SClass out) {
       Channel = channel;
@@ -337,10 +338,6 @@ public abstract class ChannelPrimitives {
   @Primitive(primitive = "procModule:")
   @GenerateNodeFactory
   public abstract static class SetChannelModule extends UnaryExpressionNode {
-    public SetChannelModule(final boolean eagerlyWrapped, final SourceSection source) {
-      super(eagerlyWrapped, source);
-    }
-
     @Specialization
     public static final SImmutableObject setModule(final SImmutableObject module) {
       ProcessesModule = module;

--- a/src/som/primitives/reflection/AbstractSymbolDispatch.java
+++ b/src/som/primitives/reflection/AbstractSymbolDispatch.java
@@ -51,9 +51,8 @@ public abstract class AbstractSymbolDispatch extends Node {
   public abstract Object executeDispatch(VirtualFrame frame, Object receiver,
       SSymbol selector, Object argsArr);
 
-  public final AbstractMessageSendNode createForPerformNodes(
-      final SSymbol selector) {
-    return MessageSendNode.createForPerformNodes(selector, sourceSection,
+  public final AbstractMessageSendNode createForPerformNodes(final SSymbol selector) {
+    return MessageSendNode.createForPerformNodes(sourceSection, selector,
         SomLanguage.getVM(getRootNode()));
   }
 

--- a/src/som/primitives/reflection/PerformInSuperclassPrim.java
+++ b/src/som/primitives/reflection/PerformInSuperclassPrim.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.compiler.AccessModifier;
@@ -18,10 +17,6 @@ import som.vmobjects.SSymbol;
 @GenerateNodeFactory
 public abstract class PerformInSuperclassPrim extends TernaryExpressionNode {
   @Child private IndirectCallNode call = Truffle.getRuntime().createIndirectCallNode();
-
-  public PerformInSuperclassPrim(final SourceSection source) {
-    super(false, source);
-  }
 
   @Specialization
   public final Object doSAbstractObject(final SAbstractObject receiver,

--- a/src/som/primitives/reflection/PerformWithArgumentsInSuperclassPrim.java
+++ b/src/som/primitives/reflection/PerformWithArgumentsInSuperclassPrim.java
@@ -16,12 +16,7 @@ import som.vmobjects.SSymbol;
 
 @GenerateNodeFactory
 public abstract class PerformWithArgumentsInSuperclassPrim extends QuaternaryExpressionNode {
-  @Child private IndirectCallNode call;
-
-  public PerformWithArgumentsInSuperclassPrim() {
-    super(null);
-    call = Truffle.getRuntime().createIndirectCallNode();
-  }
+  @Child private IndirectCallNode call = Truffle.getRuntime().createIndirectCallNode();
 
   @Specialization
   public final Object doSAbstractObject(final Object receiver, final SSymbol selector,

--- a/src/som/primitives/threading/ConditionPrimitives.java
+++ b/src/som/primitives/threading/ConditionPrimitives.java
@@ -6,7 +6,6 @@ import java.util.concurrent.locks.Condition;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.BinaryExpressionNode;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
@@ -17,10 +16,6 @@ public final class ConditionPrimitives {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingSignalOne:")
   public abstract static class SignalOnePrim extends UnaryExpressionNode {
-    public SignalOnePrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Specialization
     @TruffleBoundary
     public final Condition doCondition(final Condition cond) {
@@ -32,10 +27,6 @@ public final class ConditionPrimitives {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingSignalAll:")
   public abstract static class SignalAllPrim extends UnaryExpressionNode {
-    public SignalAllPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Specialization
     @TruffleBoundary
     public final Condition doCondition(final Condition cond) {
@@ -47,10 +38,6 @@ public final class ConditionPrimitives {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingAwait:")
   public abstract static class AwaitPrim extends UnaryExpressionNode {
-    public AwaitPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Specialization
     @TruffleBoundary
     public final Condition doCondition(final Condition cond) {
@@ -66,10 +53,6 @@ public final class ConditionPrimitives {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingAwait:for:")
   public abstract static class AwaitForPrim extends BinaryExpressionNode {
-    public AwaitForPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Specialization
     @TruffleBoundary
     public final boolean doCondition(final Condition cond, final long milliseconds) {

--- a/src/som/primitives/threading/DelayPrimitives.java
+++ b/src/som/primitives/threading/DelayPrimitives.java
@@ -3,7 +3,6 @@ package som.primitives.threading;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.UnaryExpressionNode;
 import som.primitives.Primitive;
@@ -15,10 +14,6 @@ public final class DelayPrimitives {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingWait:")
   public abstract static class WaitPrim extends UnaryExpressionNode {
-    public WaitPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Specialization
     @TruffleBoundary
     public final SObjectWithoutFields doLong(final long milliseconds) {

--- a/src/som/primitives/threading/MutexPrimitives.java
+++ b/src/som/primitives/threading/MutexPrimitives.java
@@ -6,7 +6,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.dispatch.BlockDispatchNode;
 import som.interpreter.nodes.dispatch.BlockDispatchNodeGen;
@@ -24,10 +23,6 @@ public final class MutexPrimitives {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingLock:", selector = "lock")
   public abstract static class LockPrim extends UnaryExpressionNode {
-    public LockPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @TruffleBoundary
     @Specialization
     public static final ReentrantLock lock(final ReentrantLock lock) {
@@ -48,10 +43,6 @@ public final class MutexPrimitives {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingUnlock:", selector = "unlock")
   public abstract static class UnlockPrim extends UnaryExpressionNode {
-    public UnlockPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @TruffleBoundary
     @Specialization
     public static final ReentrantLock unlock(final ReentrantLock lock) {
@@ -72,10 +63,6 @@ public final class MutexPrimitives {
   @GenerateNodeFactory
   @Primitive(selector = "critical:", receiverType = ReentrantLock.class)
   public abstract static class CritialPrim extends BinaryExpressionNode {
-    public CritialPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Child protected BlockDispatchNode dispatchBody = BlockDispatchNodeGen.create();
 
     @Specialization
@@ -92,10 +79,6 @@ public final class MutexPrimitives {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingIsLocked:")
   public abstract static class IsLockedPrim extends UnaryExpressionNode {
-    public IsLockedPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Specialization
     @TruffleBoundary
     public boolean doLock(final ReentrantLock lock) {
@@ -106,10 +89,6 @@ public final class MutexPrimitives {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingConditionFor:")
   public abstract static class ConditionForPrim extends UnaryExpressionNode {
-    public ConditionForPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Specialization
     @TruffleBoundary
     public Condition doLock(final ReentrantLock lock) {
@@ -120,10 +99,6 @@ public final class MutexPrimitives {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingMutexNew:")
   public abstract static class MutexNewPrim extends UnaryExpressionNode {
-    public MutexNewPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     // TODO: should I guard this on the mutex class?
     @Specialization
     @TruffleBoundary

--- a/src/som/primitives/threading/ThreadPrimitives.java
+++ b/src/som/primitives/threading/ThreadPrimitives.java
@@ -2,7 +2,6 @@ package som.primitives.threading;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.nodes.nary.BinaryExpressionNode;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
@@ -18,10 +17,6 @@ public final class ThreadPrimitives {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingName:")
   public abstract static class NamePrim extends UnaryExpressionNode {
-    public NamePrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Specialization
     public final Object doThread(final SomThreadTask thread) {
       String name = thread.getName();
@@ -36,10 +31,6 @@ public final class ThreadPrimitives {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingName:set:")
   public abstract static class NameSetPrim extends BinaryExpressionNode {
-    public NameSetPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Specialization
     public final Object doThread(final SomThreadTask thread, final String name) {
       thread.setName(name);
@@ -50,10 +41,6 @@ public final class ThreadPrimitives {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingCurrent:")
   public abstract static class CurrentPrim extends UnaryExpressionNode {
-    public CurrentPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Specialization
     public final Object doSClass(final SClass module) {
       Activity activity = TracingActivityThread.currentThread().getActivity();
@@ -68,10 +55,6 @@ public final class ThreadPrimitives {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingYieldCurrent:")
   public abstract static class YieldPrim extends UnaryExpressionNode {
-    public YieldPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Specialization
     public final SClass doSClass(final SClass module) {
       Thread.yield();

--- a/src/som/primitives/threading/ThreadingModule.java
+++ b/src/som/primitives/threading/ThreadingModule.java
@@ -3,7 +3,6 @@ package som.primitives.threading;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.compiler.MixinBuilder.MixinDefinitionId;
 import som.interpreter.nodes.nary.BinaryExpressionNode;
@@ -27,10 +26,6 @@ public final class ThreadingModule {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingRegisterCondition:mutex:")
   public abstract static class RegisterConditionAndMutexPrim extends BinaryExpressionNode {
-    public RegisterConditionAndMutexPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Specialization
     public final SClass doSClass(final SClass condition, final SClass mutex) {
       assert ConditionClass == null && MutexClass == null;
@@ -46,10 +41,6 @@ public final class ThreadingModule {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingRegisterThread:task:")
   public abstract static class RegisterThreadAndTaskPrim extends BinaryExpressionNode {
-    public RegisterThreadAndTaskPrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Specialization
     public final SClass doSClass(final SClass thread, final SClass task) {
       assert ThreadClass == null && TaskClass == null;
@@ -65,10 +56,6 @@ public final class ThreadingModule {
   @GenerateNodeFactory
   @Primitive(primitive = "threadingRegisterModule:")
   public abstract static class RegisterModulePrim extends UnaryExpressionNode {
-    public RegisterModulePrim(final boolean ew, final SourceSection s) {
-      super(ew, s);
-    }
-
     @Specialization
     public final SImmutableObject doSClass(final SImmutableObject module) {
       ThreadingModule = module;

--- a/src/som/primitives/transactions/AtomicPrim.java
+++ b/src/som/primitives/transactions/AtomicPrim.java
@@ -4,11 +4,10 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.StandardTags.StatementTag;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.actors.SuspendExecutionNodeGen;
-import som.interpreter.nodes.nary.BinaryComplexOperation;
+import som.interpreter.nodes.nary.BinaryComplexOperation.BinarySystemOperation;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
 import som.interpreter.transactions.Transactions;
 import som.primitives.Primitive;
@@ -26,23 +25,17 @@ import tools.debugger.session.Breakpoints;
 
 
 @GenerateNodeFactory
-@Primitive(primitive = "tx:atomic:", requiresContext = true, selector = "atomic:")
-public abstract class AtomicPrim extends BinaryComplexOperation {
-  private final VM vm;
-
+@Primitive(primitive = "tx:atomic:", selector = "atomic:")
+public abstract class AtomicPrim extends BinarySystemOperation {
   @Child protected AbstractBreakpointNode beforeCommit;
   @Child protected UnaryExpressionNode    haltNode;
 
-  protected AtomicPrim(final VM vm) {
-    this.vm = vm;
-  }
-
   @Override
-  @SuppressWarnings("unchecked")
-  public final AtomicPrim initialize(final SourceSection source) {
-    super.initialize(source);
-    beforeCommit = insert(Breakpoints.create(source, BreakpointType.ATOMIC_BEFORE_COMMIT, vm));
-    haltNode = SuspendExecutionNodeGen.create(0, null).initialize(source);
+  public final AtomicPrim initialize(final VM vm) {
+    super.initialize(vm);
+    beforeCommit = insert(
+        Breakpoints.create(sourceSection, BreakpointType.ATOMIC_BEFORE_COMMIT, vm));
+    haltNode = SuspendExecutionNodeGen.create(0, null).initialize(sourceSection);
     return this;
   }
 

--- a/src/som/primitives/transactions/AtomicPrim.java
+++ b/src/som/primitives/transactions/AtomicPrim.java
@@ -33,11 +33,17 @@ public abstract class AtomicPrim extends BinaryComplexOperation {
   @Child protected AbstractBreakpointNode beforeCommit;
   @Child protected UnaryExpressionNode    haltNode;
 
-  protected AtomicPrim(final boolean eagWrap, final SourceSection source, final VM vm) {
-    super(eagWrap, source);
+  protected AtomicPrim(final VM vm) {
     this.vm = vm;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public final AtomicPrim initialize(final SourceSection source) {
+    super.initialize(source);
     beforeCommit = insert(Breakpoints.create(source, BreakpointType.ATOMIC_BEFORE_COMMIT, vm));
-    haltNode = SuspendExecutionNodeGen.create(false, sourceSection, null);
+    haltNode = SuspendExecutionNodeGen.create(0, null).initialize(source);
+    return this;
   }
 
   @Specialization

--- a/src/som/vm/constants/KernelObj.java
+++ b/src/som/vm/constants/KernelObj.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
@@ -37,10 +36,6 @@ public final class KernelObj {
   @GenerateNodeFactory
   @Primitive(primitive = "kernelIndexOutOfBounds:")
   public abstract static class SetIndexOutOfBounds extends UnaryExpressionNode {
-    public SetIndexOutOfBounds(final boolean eagWrap, final SourceSection source) {
-      super(eagWrap, source);
-    }
-
     @Specialization
     public final SClass setClass(final SClass value) {
       assert indexOutOfBoundsClass == null;

--- a/src/tools/dym/nodes/ArrayAllocationProfilingNode.java
+++ b/src/tools/dym/nodes/ArrayAllocationProfilingNode.java
@@ -14,7 +14,7 @@ public class ArrayAllocationProfilingNode extends CountingNode<ArrayCreationProf
 
   public ArrayAllocationProfilingNode(final ArrayCreationProfile counter) {
     super(counter);
-    size = SizeAndLengthPrimFactory.create(false, null, null);
+    size = SizeAndLengthPrimFactory.create(null);
   }
 
   @Override

--- a/src/tools/dym/nodes/InvocationProfilingNode.java
+++ b/src/tools/dym/nodes/InvocationProfilingNode.java
@@ -16,8 +16,7 @@ public class InvocationProfilingNode extends CountingNode<InvocationProfile> {
 
   private final DynamicMetrics meter;
 
-  public InvocationProfilingNode(final DynamicMetrics meter,
-      final InvocationProfile counter) {
+  public InvocationProfilingNode(final DynamicMetrics meter, final InvocationProfile counter) {
     super(counter);
     this.meter = meter;
   }


### PR DESCRIPTION
This change removes a lot of trivial constructors and thus, reduces the boilerplate code for all primitives.

However, it comes at the additional complexity of non-final fields for the source section as well as the VM, where needed.
Furthermore, it needs extra calls to `initialize(.)` methods, which means we need to ensure things are initialized in the in the right order:

1. set source section
2. optionally, set the eager primitive flag
3. set VM, i.e., context

With this order, initializations of breakpoints and other things that require source sections and the VM, are only safe in the last step, after setting the VM.
