### PR TITLE
Exit VM on uncaught exception

### DIFF
--- a/src/som/UncaughtExceptions.java
+++ b/src/som/UncaughtExceptions.java
@@ -10,6 +10,12 @@ import tools.concurrency.TracingActivityThread;
  */
 public final class UncaughtExceptions implements UncaughtExceptionHandler {
 
+  private final VM vm;
+
+  public UncaughtExceptions(final VM vm) {
+    this.vm = vm;
+  }
+
   @Override
   public void uncaughtException(final Thread t, final Throwable e) {
     if (e instanceof ThreadDeath) {
@@ -20,5 +26,7 @@ public final class UncaughtExceptions implements UncaughtExceptionHandler {
     VM.errorPrintln("Processing failed for: "
         + thread.getActivity().toString());
     e.printStackTrace();
+
+    vm.requestExit(2);
   }
 }

--- a/src/som/VM.java
+++ b/src/som/VM.java
@@ -85,13 +85,13 @@ public final class VM {
     options = vmOptions;
 
     actorPool = new ForkJoinPool(VmSettings.NUM_THREADS,
-        new ActorProcessingThreadFactory(), new UncaughtExceptions(), true);
+        new ActorProcessingThreadFactory(), new UncaughtExceptions(this), true);
     processesPool = new ForkJoinPool(VmSettings.NUM_THREADS,
-        new ProcessThreadFactory(), new UncaughtExceptions(), true);
+        new ProcessThreadFactory(), new UncaughtExceptions(this), true);
     forkJoinPool = new ForkJoinPool(VmSettings.NUM_THREADS,
-        new ForkJoinThreadFactory(), new UncaughtExceptions(), false);
+        new ForkJoinThreadFactory(), new UncaughtExceptions(this), false);
     threadPool = new ForkJoinPool(MAX_THREADS,
-        new ForkJoinThreadFactory(), new UncaughtExceptions(), false);
+        new ForkJoinThreadFactory(), new UncaughtExceptions(this), false);
   }
 
   /**

--- a/src/som/vm/ObjectSystem.java
+++ b/src/som/vm/ObjectSystem.java
@@ -367,7 +367,7 @@ public final class ObjectSystem {
 
     assert !vm.shouldExit();
     TracingActors.ReplayActor.printMissingMessages();
-    vm.errorExit("VM seems to have exited prematurely. But the actor pool has been idle for "
+    VM.errorPrintln("VM seems to have exited prematurely. The actor pool has been idle for "
         + emptyFJPool + " checks in a row.");
     vm.shutdownAndExit(1); // just in case it was disable for VM.errorExit
   }
@@ -417,8 +417,9 @@ public final class ObjectSystem {
         handlePromiseResult((SPromise) result);
         return;
       } else {
-        vm.errorExit("The application's #main: method returned a " + result.toString()
+        VM.errorPrintln("The application's #main: method returned a " + result.toString()
             + ", but it needs to return a Promise or Integer as return value.");
+        vm.shutdownAndExit(1);
       }
     } catch (InterruptedException | ExecutionException e) {
       // TODO Auto-generated catch block


### PR DESCRIPTION
Request a VM exit when we catch an uncaught exception.

Was there any reason we didn't do this before?
Not sure why this isn't done.
This leaves the VM hanging on error, which is problematic on the CI systems, and strange locally.

@daumayr could you have a look at this?