### PR TITLE
Enable more language server support

### DIFF
--- a/.project
+++ b/.project
@@ -31,4 +31,33 @@
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 		<nature>edu.umd.cs.findbugs.plugin.eclipse.findbugsNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1511470005540</id>
+			<name>libs</name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-black-diamonds</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1511470005545</id>
+			<name>libs</name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-truffle</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1511470005549</id>
+			<name>libs</name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-mx</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/src/som/compiler/MethodBuilder.java
+++ b/src/som/compiler/MethodBuilder.java
@@ -58,6 +58,7 @@ import som.vm.constants.Nil;
 import som.vmobjects.SInvokable;
 import som.vmobjects.SInvokable.SInitializer;
 import som.vmobjects.SSymbol;
+import tools.language.StructuralProbe;
 
 
 public final class MethodBuilder {
@@ -90,27 +91,32 @@ public final class MethodBuilder {
 
   private int cascadeId;
 
-  public MethodBuilder(final MixinBuilder holder, final MixinScope clsScope) {
-    this(holder, clsScope, null, false, holder.getLanguage());
+  private final StructuralProbe structuralProbe;
+
+  public MethodBuilder(final MixinBuilder holder, final MixinScope clsScope,
+      final StructuralProbe probe) {
+    this(holder, clsScope, null, false, holder.getLanguage(), probe);
   }
 
-  public MethodBuilder(final boolean withoutContext, final SomLanguage language) {
-    this(null, null, null, false, language);
+  public MethodBuilder(final boolean withoutContext, final SomLanguage language,
+      final StructuralProbe probe) {
+    this(null, null, null, false, language, probe);
     assert withoutContext;
   }
 
   public MethodBuilder(final MethodBuilder outerBuilder) {
     this(outerBuilder.directOuterMixin, outerBuilder.getHolderScope(),
-        outerBuilder, true, outerBuilder.language);
+        outerBuilder, true, outerBuilder.language, outerBuilder.structuralProbe);
   }
 
   private MethodBuilder(final MixinBuilder holder, final MixinScope clsScope,
       final MethodBuilder outerBuilder, final boolean isBlockMethod,
-      final SomLanguage language) {
+      final SomLanguage language, final StructuralProbe probe) {
     this.directOuterMixin = holder;
     this.outerBuilder = outerBuilder;
     this.blockMethod = isBlockMethod;
     this.language = language;
+    this.structuralProbe = probe;
 
     MethodScope outer = (outerBuilder != null)
         ? outerBuilder.getCurrentMethodScope()
@@ -346,6 +352,10 @@ public final class MethodBuilder {
 
     Argument argument = new Argument(arg, arguments.size(), source);
     arguments.put(arg, argument);
+
+    if (structuralProbe != null) {
+      structuralProbe.recordNewVariable(argument);
+    }
   }
 
   public Local addMessageCascadeTemp(final SourceSection source) throws MethodDefinitionError {
@@ -372,6 +382,10 @@ public final class MethodBuilder {
     }
     l.init(currentScope.getFrameDescriptor().addFrameSlot(l));
     locals.put(name, l);
+
+    if (structuralProbe != null) {
+      structuralProbe.recordNewVariable(l);
+    }
     return l;
   }
 

--- a/src/som/compiler/MixinBuilder.java
+++ b/src/som/compiler/MixinBuilder.java
@@ -381,6 +381,10 @@ public final class MixinBuilder {
       write.markAsStatement();
       slotAndInitExprs.add(write);
     }
+
+    if (structuralProbe != null) {
+      structuralProbe.recordNewSlot(slot);
+    }
   }
 
   /**

--- a/src/som/compiler/MixinBuilder.java
+++ b/src/som/compiler/MixinBuilder.java
@@ -161,8 +161,8 @@ public final class MixinBuilder {
     this.instanceScope = new MixinScope(outerMixinScope, outerMethodScope);
     this.classScope = new MixinScope(outerMixinScope, outerMethodScope);
 
-    this.initializer = new MethodBuilder(this, this.instanceScope);
-    this.primaryFactoryMethod = new MethodBuilder(this, this.classScope);
+    this.initializer = new MethodBuilder(this, this.instanceScope, structuralProbe);
+    this.primaryFactoryMethod = new MethodBuilder(this, this.classScope, structuralProbe);
     this.superclassAndMixinResolutionBuilder = createSuperclassResolutionBuilder();
 
     this.accessModifier = accessModifier;
@@ -479,10 +479,10 @@ public final class MixinBuilder {
   private MethodBuilder createSuperclassResolutionBuilder() {
     MethodBuilder definitionMethod;
     if (isModule()) {
-      definitionMethod = new MethodBuilder(true, language);
+      definitionMethod = new MethodBuilder(true, language, structuralProbe);
     } else {
       definitionMethod = new MethodBuilder(outerMixin,
-          outerMixin.getInstanceScope());
+          outerMixin.getInstanceScope(), structuralProbe);
     }
 
     // self is going to be the enclosing object

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -136,7 +136,11 @@ public final class MixinDefinition {
    * Used by the SOMns Language Server.
    */
   public MixinDefinition getOuterMixinDefinition() {
-    return instanceScope.getOuterMixin().getMixinDefinition();
+    MixinScope outer = instanceScope.getOuterMixin();
+    if (outer == null) {
+      return null;
+    }
+    return outer.getMixinDefinition();
   }
 
   public SSymbol getPrimaryFactorySelector() {

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -717,7 +717,7 @@ public final class MixinDefinition {
 
   public void addSyntheticInitializerWithoutSuperSendOnlyForThingClass() {
     SSymbol init = MixinBuilder.getInitializerName(Symbols.NEW);
-    MethodBuilder builder = new MethodBuilder(true, initializerBuilder.getLanguage());
+    MethodBuilder builder = new MethodBuilder(true, initializerBuilder.getLanguage(), null);
     builder.setSignature(init);
     builder.addArgument("self",
         SomLanguage.getSyntheticSource("self read", "super-class-resolution")

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -462,6 +462,10 @@ public final class MixinDefinition {
     return factoryMethods;
   }
 
+  public HashMap<SSymbol, SlotDefinition> getSlots() {
+    return slots;
+  }
+
   public HashMap<SSymbol, Dispatchable> getInstanceDispatchables() {
     return instanceDispatchables;
   }

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -496,7 +496,7 @@ public class Parser {
     } else if (acceptIdentifier("self", KeywordTag.class)) {
       self = meth.getSelfRead(getSource(coord));
     } else {
-      return meth.getImplicitReceiverSend(unarySelector(), getSource(coord));
+      return implicitUnaryMessage(meth, unarySelector(), getSource(coord));
     }
     return unaryMessage(self, false, null);
   }
@@ -1225,7 +1225,7 @@ public class Parser {
 
         comments();
 
-        return builder.getImplicitReceiverSend(selector, getSource(coord));
+        return implicitUnaryMessage(builder, selector, getSource(coord));
       }
       case NewTerm: {
         return nestedTerm(builder);
@@ -1328,6 +1328,11 @@ public class Parser {
     }
 
     return msg;
+  }
+
+  protected ExpressionNode implicitUnaryMessage(final MethodBuilder meth,
+      final SSymbol selector, final SourceSection section) {
+    return meth.getImplicitReceiverSend(selector, section);
   }
 
   protected ExpressionNode unaryMessage(final ExpressionNode receiver,

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -830,7 +830,7 @@ public class Parser {
       final SourceCoordinate coord, final MixinBuilder mxnBuilder)
       throws ProgramDefinitionError {
     MethodBuilder builder = new MethodBuilder(
-        mxnBuilder, mxnBuilder.getScopeForCurrentParserPosition());
+        mxnBuilder, mxnBuilder.getScopeForCurrentParserPosition(), structuralProbe);
 
     comments();
 

--- a/src/som/interpreter/nodes/ArgumentReadNode.java
+++ b/src/som/interpreter/nodes/ArgumentReadNode.java
@@ -42,6 +42,10 @@ public abstract class ArgumentReadNode {
       assert insidePrim : "Only to be used for primitive nodes";
     }
 
+    public Argument getArg() {
+      return arg;
+    }
+
     @Override
     public Object executeGeneric(final VirtualFrame frame) {
       return SArguments.arg(frame, argumentIndex);
@@ -126,6 +130,10 @@ public abstract class ArgumentReadNode {
           this instanceof NonLocalSuperReadNode;
       this.argumentIndex = arg.index;
       this.arg = arg;
+    }
+
+    public final Argument getArg() {
+      return arg;
     }
 
     @Override

--- a/src/som/interpreter/nodes/LocalVariableNode.java
+++ b/src/som/interpreter/nodes/LocalVariableNode.java
@@ -25,7 +25,7 @@ public abstract class LocalVariableNode extends ExprWithTagsNode {
     this.var = var;
   }
 
-  public Local getLocal() {
+  public final Local getLocal() {
     return var;
   }
 

--- a/src/som/interpreter/nodes/LocalVariableNode.java
+++ b/src/som/interpreter/nodes/LocalVariableNode.java
@@ -25,6 +25,10 @@ public abstract class LocalVariableNode extends ExprWithTagsNode {
     this.var = var;
   }
 
+  public Local getLocal() {
+    return var;
+  }
+
   @Override
   protected boolean isTaggedWith(final Class<?> tag) {
     if (tag == LocalVariableTag.class) {

--- a/src/som/interpreter/nodes/NonLocalVariableNode.java
+++ b/src/som/interpreter/nodes/NonLocalVariableNode.java
@@ -28,6 +28,10 @@ public abstract class NonLocalVariableNode extends ContextualNode {
     this.var = var;
   }
 
+  public final Local getLocal() {
+    return var;
+  }
+
   @Override
   protected boolean isTaggedWith(final Class<?> tag) {
     if (tag == LocalVariableTag.class) {

--- a/src/som/interpreter/nodes/ResolvingImplicitReceiverSend.java
+++ b/src/som/interpreter/nodes/ResolvingImplicitReceiverSend.java
@@ -114,6 +114,10 @@ public final class ResolvingImplicitReceiverSend extends AbstractMessageSendNode
     return replacedBy;
   }
 
+  public SSymbol getSelector() {
+    return selector;
+  }
+
   @Override
   public String toString() {
     return "ImplicitSend(" + selector.toString() + ")";

--- a/src/som/interpreter/nodes/nary/EagerBinaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerBinaryPrimitiveNode.java
@@ -20,14 +20,12 @@ public final class EagerBinaryPrimitiveNode extends EagerPrimitiveNode {
   @Child private ExpressionNode       argument;
   @Child private BinaryExpressionNode primitive;
 
-  private final SSymbol selector;
-
   public EagerBinaryPrimitiveNode(final SSymbol selector, final ExpressionNode receiver,
       final ExpressionNode argument, final BinaryExpressionNode primitive) {
+    super(selector);
     this.receiver = insert(receiver);
     this.argument = insert(argument);
     this.primitive = insert(primitive);
-    this.selector = selector;
   }
 
   @Override

--- a/src/som/interpreter/nodes/nary/EagerPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerPrimitiveNode.java
@@ -2,7 +2,18 @@ package som.interpreter.nodes.nary;
 
 import bd.nodes.EagerPrimitive;
 import som.interpreter.nodes.ExpressionNode;
+import som.vmobjects.SSymbol;
 
 
 public abstract class EagerPrimitiveNode extends ExpressionNode
-    implements EagerPrimitive {}
+    implements EagerPrimitive {
+  protected final SSymbol selector;
+
+  protected EagerPrimitiveNode(final SSymbol selector) {
+    this.selector = selector;
+  }
+
+  public SSymbol getSelector() {
+    return selector;
+  }
+}

--- a/src/som/interpreter/nodes/nary/EagerTernaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerTernaryPrimitiveNode.java
@@ -22,16 +22,14 @@ public final class EagerTernaryPrimitiveNode extends EagerPrimitiveNode {
   @Child private ExpressionNode        argument2;
   @Child private TernaryExpressionNode primitive;
 
-  private final SSymbol selector;
-
   public EagerTernaryPrimitiveNode(final SSymbol selector, final ExpressionNode receiver,
       final ExpressionNode argument1, final ExpressionNode argument2,
       final TernaryExpressionNode primitive) {
+    super(selector);
     this.receiver = insert(receiver);
     this.argument1 = insert(argument1);
     this.argument2 = insert(argument2);
     this.primitive = insert(primitive);
-    this.selector = selector;
   }
 
   @Override

--- a/src/som/interpreter/nodes/nary/EagerUnaryPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerUnaryPrimitiveNode.java
@@ -19,13 +19,11 @@ public final class EagerUnaryPrimitiveNode extends EagerPrimitiveNode {
   @Child private ExpressionNode      receiver;
   @Child private UnaryExpressionNode primitive;
 
-  private final SSymbol selector;
-
   public EagerUnaryPrimitiveNode(final SSymbol selector, final ExpressionNode receiver,
       final UnaryExpressionNode primitive) {
+    super(selector);
     this.receiver = insert(receiver);
     this.primitive = insert(primitive);
-    this.selector = selector;
   }
 
   @Override

--- a/src/som/vm/Primitives.java
+++ b/src/som/vm/Primitives.java
@@ -118,7 +118,7 @@ public class Primitives extends PrimitiveLoader<VM, ExpressionNode, SSymbol> {
     final int numArgs = signature.getNumberOfSignatureArguments() - 1;
 
     Source s = SomLanguage.getSyntheticSource("primitive", specializer.getName());
-    MethodBuilder prim = new MethodBuilder(true, lang);
+    MethodBuilder prim = new MethodBuilder(true, lang, null);
     ExpressionNode[] args = new ExpressionNode[numArgs];
 
     SourceSection source = s.createSection(1);

--- a/src/tools/language/StructuralProbe.java
+++ b/src/tools/language/StructuralProbe.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import som.compiler.MixinDefinition;
 import som.compiler.MixinDefinition.SlotDefinition;
+import som.compiler.Variable;
 import som.vmobjects.SInvokable;
 
 
@@ -13,11 +14,13 @@ public class StructuralProbe {
   protected final Set<MixinDefinition> classes;
   protected final Set<SInvokable>      methods;
   protected final Set<SlotDefinition>  slots;
+  protected final Set<Variable>        variables;
 
   public StructuralProbe() {
     classes = new HashSet<>();
     methods = new HashSet<>();
     slots = new HashSet<>();
+    variables = new HashSet<>();
   }
 
   public void recordNewClass(final MixinDefinition clazz) {
@@ -32,6 +35,10 @@ public class StructuralProbe {
     slots.add(slot);
   }
 
+  public void recordNewVariable(final Variable var) {
+    variables.add(var);
+  }
+
   public Set<MixinDefinition> getClasses() {
     return classes;
   }
@@ -42,5 +49,9 @@ public class StructuralProbe {
 
   public Set<SlotDefinition> getSlots() {
     return slots;
+  }
+
+  public Set<Variable> getVariables() {
+    return variables;
   }
 }

--- a/src/tools/language/StructuralProbe.java
+++ b/src/tools/language/StructuralProbe.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import som.compiler.MixinDefinition;
+import som.compiler.MixinDefinition.SlotDefinition;
 import som.vmobjects.SInvokable;
 
 
@@ -11,10 +12,12 @@ public class StructuralProbe {
 
   protected final Set<MixinDefinition> classes;
   protected final Set<SInvokable>      methods;
+  protected final Set<SlotDefinition>  slots;
 
   public StructuralProbe() {
     classes = new HashSet<>();
     methods = new HashSet<>();
+    slots = new HashSet<>();
   }
 
   public void recordNewClass(final MixinDefinition clazz) {
@@ -25,11 +28,19 @@ public class StructuralProbe {
     methods.add(method);
   }
 
+  public void recordNewSlot(final SlotDefinition slot) {
+    slots.add(slot);
+  }
+
   public Set<MixinDefinition> getClasses() {
     return classes;
   }
 
   public Set<SInvokable> getMethods() {
     return methods;
+  }
+
+  public Set<SlotDefinition> getSlots() {
+    return slots;
   }
 }


### PR DESCRIPTION
This PR adds:
- extra accessors
- handle implicit receiver sends
- record slots and variables in structural probe for easy access

It further fixes:
- null pointer exception when accessing outer mixin
- Eclipse project filters out libs folder