### PR TITLE
Bug fixes, LSP, and debugger improvements

### DIFF
--- a/src/som/compiler/MixinBuilder.java
+++ b/src/som/compiler/MixinBuilder.java
@@ -486,7 +486,7 @@ public final class MixinBuilder {
     }
 
     // self is going to be the enclosing object
-    definitionMethod.addArgument("self",
+    definitionMethod.addArgument(Symbols.SELF,
         SomLanguage.getSyntheticSource("self read", "super-class-resolution")
                    .createSection(1));
     definitionMethod.setSignature(Symbols.DEF_CLASS);
@@ -582,7 +582,7 @@ public final class MixinBuilder {
     args.add(objectInstantiationExpr);
 
     for (Argument arg : arguments) {
-      if (!"self".equals(arg.name)) { // already have self as the newly instantiated object
+      if (Symbols.SELF != arg.name) { // already have self as the newly instantiated object
         args.add(primaryFactoryMethod.getReadNode(arg.name, arg.source));
       }
     }

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -719,7 +719,7 @@ public final class MixinDefinition {
     SSymbol init = MixinBuilder.getInitializerName(Symbols.NEW);
     MethodBuilder builder = new MethodBuilder(true, initializerBuilder.getLanguage(), null);
     builder.setSignature(init);
-    builder.addArgument("self",
+    builder.addArgument(Symbols.SELF,
         SomLanguage.getSyntheticSource("self read", "super-class-resolution")
                    .createSection(1));
 

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -132,6 +132,10 @@ public final class MixinDefinition {
     return name;
   }
 
+  public SourceSection getNameSourceSection() {
+    return nameSection;
+  }
+
   /**
    * Used by the SOMns Language Server.
    */

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -1758,7 +1758,7 @@ public class Parser {
     return new ObjectLiteralNode(mixinDef, outerRead, newMessage).initialize(source);
   }
 
-  private SSymbol selector() throws ParseError {
+  protected SSymbol selector() throws ParseError {
     if (sym == OperatorSequence || symIn(singleOpSyms)) {
       return binarySelector();
     } else if (sym == Keyword || sym == KeywordSequence) {

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -341,7 +341,7 @@ public class Parser {
       messagePattern(primaryFactory);
     } else {
       // in the standard case, the primary factory method is #new
-      primaryFactory.addArgument("self", getEmptySource());
+      primaryFactory.addArgument(Symbols.SELF, getEmptySource());
       primaryFactory.setSignature(Symbols.NEW);
     }
     mxnBuilder.setupInitializerBasedOnPrimaryFactory(getSource(coord));
@@ -855,7 +855,7 @@ public class Parser {
   }
 
   private void messagePattern(final MethodBuilder builder) throws ParseError {
-    builder.addArgument("self", getEmptySource());
+    builder.addArgument(Symbols.SELF, getEmptySource());
     switch (sym) {
       case Identifier:
         unaryPattern(builder);
@@ -885,7 +885,7 @@ public class Parser {
     builder.addMethodDefinitionSource(getSource(coord));
 
     coord = getCoordinate();
-    builder.addArgument(argument(), getSource(coord));
+    builder.addArgument(symbolFor(argument()), getSource(coord));
   }
 
   protected void keywordPattern(final MethodBuilder builder) throws ParseError {
@@ -896,7 +896,7 @@ public class Parser {
       builder.addMethodDefinitionSource(getSource(coord));
 
       coord = getCoordinate();
-      builder.addArgument(argument(), getSource(coord));
+      builder.addArgument(symbolFor(argument()), getSource(coord));
     } while (sym == Keyword);
 
     builder.setSignature(symbolFor(kw.toString()));
@@ -1027,7 +1027,7 @@ public class Parser {
       initializer = null;
     }
 
-    Local local = builder.addLocal(slotName, immutable, source);
+    Local local = builder.addLocal(symbolFor(slotName), immutable, source);
 
     if (initializer != null) {
       SourceSection write = getSource(coord);
@@ -1563,7 +1563,7 @@ public class Parser {
       // if it is a literal, we still need a memory location for counting, so,
       // add a synthetic local
       loopIdx = builder.addLocalAndUpdateScope(
-          "!i" + SourceCoordinate.getLocationQualifier(source), false, source);
+          symbolFor("!i" + SourceCoordinate.getLocationQualifier(source)), false, source);
     }
     return loopIdx;
   }
@@ -1742,7 +1742,7 @@ public class Parser {
 
     // Setup the builder and "new" factory for the implicit class
     MethodBuilder primaryFactory = classBuilder.getPrimaryFactoryMethodBuilder();
-    primaryFactory.addArgument("self", getEmptySource());
+    primaryFactory.addArgument(Symbols.SELF, getEmptySource());
     primaryFactory.setSignature(Symbols.NEW);
     classBuilder.setupInitializerBasedOnPrimaryFactory(source);
 
@@ -1796,7 +1796,7 @@ public class Parser {
     SourceCoordinate coord = getCoordinate();
     expect(NewBlock, DelimiterOpeningTag.class);
 
-    builder.addArgument("$blockSelf", getEmptySource());
+    builder.addArgument(Symbols.BLOCK_SELF, getEmptySource());
 
     if (sym == Colon) {
       blockPattern(builder);
@@ -1830,7 +1830,7 @@ public class Parser {
     do {
       expect(Colon, KeywordTag.class);
       SourceCoordinate coord = getCoordinate();
-      builder.addArgument(argument(), getSource(coord));
+      builder.addArgument(symbolFor(argument()), getSource(coord));
     } while (sym == Colon);
   }
 

--- a/src/som/compiler/Variable.java
+++ b/src/som/compiler/Variable.java
@@ -22,6 +22,8 @@ import som.interpreter.nodes.LocalVariableNodeFactory.LocalVariableReadNodeGen;
 import som.interpreter.nodes.LocalVariableNodeFactory.LocalVariableWriteNodeGen;
 import som.interpreter.nodes.NonLocalVariableNodeFactory.NonLocalVariableReadNodeGen;
 import som.interpreter.nodes.NonLocalVariableNodeFactory.NonLocalVariableWriteNodeGen;
+import som.vm.Symbols;
+import som.vmobjects.SSymbol;
 import tools.SourceCoordinate;
 
 
@@ -29,22 +31,22 @@ import tools.SourceCoordinate;
  * Represents state belonging to a method activation.
  */
 public abstract class Variable {
-  public final String        name;
+  public final SSymbol       name;
   public final SourceSection source;
 
-  Variable(final String name, final SourceSection source) {
+  Variable(final SSymbol name, final SourceSection source) {
     this.name = name;
     this.source = source;
   }
 
   /** Gets the name including lexical location. */
-  public String getQualifiedName() {
-    return name + SourceCoordinate.getLocationQualifier(source);
+  public SSymbol getQualifiedName() {
+    return Symbols.symbolFor(name.getString() + SourceCoordinate.getLocationQualifier(source));
   }
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "(" + name + ")";
+    return getClass().getSimpleName() + "(" + name.getString() + ")";
   }
 
   @Override
@@ -58,7 +60,7 @@ public abstract class Variable {
     }
     Variable var = (Variable) o;
     if (var.source == source) {
-      assert name.equals(var.name) : "Defined in the same place, but names not equal?";
+      assert name == var.name : "Defined in the same place, but names not equal?";
       return true;
     }
     assert source == null || !source.equals(
@@ -87,13 +89,13 @@ public abstract class Variable {
   public static final class Argument extends Variable {
     public final int index;
 
-    Argument(final String name, final int index, final SourceSection source) {
+    Argument(final SSymbol name, final int index, final SourceSection source) {
       super(name, source);
       this.index = index;
     }
 
     public boolean isSelf() {
-      return "self".equals(name) || "$blockSelf".equals(name);
+      return Symbols.SELF == name || Symbols.BLOCK_SELF == name;
     }
 
     public ExpressionNode getSelfReadNode(final int contextLevel,
@@ -160,7 +162,7 @@ public abstract class Variable {
   public abstract static class Local extends Variable {
     @CompilationFinal private FrameSlot slot;
 
-    Local(final String name, final SourceSection source) {
+    Local(final SSymbol name, final SourceSection source) {
       super(name, source);
     }
 
@@ -221,7 +223,7 @@ public abstract class Variable {
   }
 
   public static final class MutableLocal extends Local {
-    MutableLocal(final String name, final SourceSection source) {
+    MutableLocal(final SSymbol name, final SourceSection source) {
       super(name, source);
     }
 
@@ -232,7 +234,7 @@ public abstract class Variable {
   }
 
   public static final class ImmutableLocal extends Local {
-    ImmutableLocal(final String name, final SourceSection source) {
+    ImmutableLocal(final SSymbol name, final SourceSection source) {
       super(name, source);
     }
 
@@ -250,7 +252,7 @@ public abstract class Variable {
   public static final class Internal extends Variable {
     @CompilationFinal private FrameSlot slot;
 
-    public Internal(final String name) {
+    public Internal(final SSymbol name) {
       super(name, null);
     }
 

--- a/src/som/instrumentation/MessageSendNodeWrapper.java
+++ b/src/som/instrumentation/MessageSendNodeWrapper.java
@@ -10,6 +10,8 @@ import com.oracle.truffle.api.source.SourceSection;
 import bd.nodes.PreevaluatedExpression;
 import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.MessageSendNode.AbstractMessageSendNode;
+import som.vmobjects.SSymbol;
+import tools.Send;
 
 
 // TODO: see whether we can get the code generator to do this for us, there is some issue with the pre-evaluated method stuff, but works for other node
@@ -78,6 +80,11 @@ public class MessageSendNodeWrapper
     @Override
     public SourceSection getSourceSection() {
       return delegate.getSourceSection();
+    }
+
+    @Override
+    public SSymbol getSelector() {
+      return ((Send) delegate).getSelector();
     }
   }
 }

--- a/src/som/interpreter/nodes/ArgumentReadNode.java
+++ b/src/som/interpreter/nodes/ArgumentReadNode.java
@@ -9,6 +9,8 @@ import som.compiler.Variable.Argument;
 import som.interpreter.InliningVisitor;
 import som.interpreter.SArguments;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
+import som.vmobjects.SSymbol;
+import tools.Send;
 import tools.debugger.Tags.ArgumentTag;
 import tools.debugger.Tags.KeywordTag;
 import tools.dym.Tags.LocalArgRead;
@@ -17,7 +19,7 @@ import tools.dym.Tags.LocalArgRead;
 public abstract class ArgumentReadNode {
 
   @Instrumentable(factory = LocalArgumentReadNodeWrapper.class)
-  public static class LocalArgumentReadNode extends ExprWithTagsNode {
+  public static class LocalArgumentReadNode extends ExprWithTagsNode implements Send {
     protected final int      argumentIndex;
     protected final Argument arg;
 
@@ -44,6 +46,11 @@ public abstract class ArgumentReadNode {
 
     public Argument getArg() {
       return arg;
+    }
+
+    @Override
+    public final SSymbol getSelector() {
+      return arg.name;
     }
 
     @Override
@@ -118,7 +125,7 @@ public abstract class ArgumentReadNode {
     }
   }
 
-  public static class NonLocalArgumentReadNode extends ContextualNode {
+  public static class NonLocalArgumentReadNode extends ContextualNode implements Send {
     protected final int      argumentIndex;
     protected final Argument arg;
 
@@ -134,6 +141,11 @@ public abstract class ArgumentReadNode {
 
     public final Argument getArg() {
       return arg;
+    }
+
+    @Override
+    public final SSymbol getSelector() {
+      return arg.name;
     }
 
     @Override

--- a/src/som/interpreter/nodes/LocalVariableNode.java
+++ b/src/som/interpreter/nodes/LocalVariableNode.java
@@ -11,12 +11,14 @@ import som.compiler.Variable.Local;
 import som.interpreter.InliningVisitor;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
 import som.vm.constants.Nil;
+import som.vmobjects.SSymbol;
+import tools.Send;
 import tools.debugger.Tags.LocalVariableTag;
 import tools.dym.Tags.LocalVarRead;
 import tools.dym.Tags.LocalVarWrite;
 
 
-public abstract class LocalVariableNode extends ExprWithTagsNode {
+public abstract class LocalVariableNode extends ExprWithTagsNode implements Send {
   protected final FrameSlot slot;
   protected final Local     var;
 
@@ -27,6 +29,11 @@ public abstract class LocalVariableNode extends ExprWithTagsNode {
 
   public final Local getLocal() {
     return var;
+  }
+
+  @Override
+  public final SSymbol getSelector() {
+    return var.name;
   }
 
   @Override

--- a/src/som/interpreter/nodes/MessageSendNode.java
+++ b/src/som/interpreter/nodes/MessageSendNode.java
@@ -27,6 +27,7 @@ import som.interpreter.nodes.nary.EagerlySpecializableNode;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
 import som.vm.Primitives;
 import som.vmobjects.SSymbol;
+import tools.Send;
 import tools.SourceCoordinate;
 import tools.dym.Tags.VirtualInvoke;
 
@@ -105,7 +106,7 @@ public final class MessageSendNode {
   }
 
   public abstract static class AbstractMessageSendNode extends ExprWithTagsNode
-      implements PreevaluatedExpression {
+      implements PreevaluatedExpression, Send {
 
     @Children protected final ExpressionNode[] argumentNodes;
 
@@ -156,6 +157,7 @@ public final class MessageSendNode {
       return "UninitMsgSend(" + selector.toString() + ")";
     }
 
+    @Override
     public SSymbol getSelector() {
       return selector;
     }
@@ -289,6 +291,11 @@ public final class MessageSendNode {
       super(arguments);
       this.selector = selector;
       this.dispatchNode = dispatchNode;
+    }
+
+    @Override
+    public SSymbol getSelector() {
+      return selector;
     }
 
     @Override

--- a/src/som/interpreter/nodes/NonLocalVariableNode.java
+++ b/src/som/interpreter/nodes/NonLocalVariableNode.java
@@ -12,12 +12,14 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import som.compiler.Variable.Local;
 import som.interpreter.InliningVisitor;
 import som.vm.constants.Nil;
+import som.vmobjects.SSymbol;
+import tools.Send;
 import tools.debugger.Tags.LocalVariableTag;
 import tools.dym.Tags.LocalVarRead;
 import tools.dym.Tags.LocalVarWrite;
 
 
-public abstract class NonLocalVariableNode extends ContextualNode {
+public abstract class NonLocalVariableNode extends ContextualNode implements Send {
 
   protected final FrameSlot slot;
   protected final Local     var;
@@ -30,6 +32,11 @@ public abstract class NonLocalVariableNode extends ContextualNode {
 
   public final Local getLocal() {
     return var;
+  }
+
+  @Override
+  public final SSymbol getSelector() {
+    return var.name;
   }
 
   @Override

--- a/src/som/interpreter/nodes/nary/EagerPrimitiveNode.java
+++ b/src/som/interpreter/nodes/nary/EagerPrimitiveNode.java
@@ -3,10 +3,11 @@ package som.interpreter.nodes.nary;
 import bd.nodes.EagerPrimitive;
 import som.interpreter.nodes.ExpressionNode;
 import som.vmobjects.SSymbol;
+import tools.Send;
 
 
 public abstract class EagerPrimitiveNode extends ExpressionNode
-    implements EagerPrimitive {
+    implements EagerPrimitive, Send {
   protected final SSymbol selector;
 
   protected EagerPrimitiveNode(final SSymbol selector) {

--- a/src/som/interpreter/nodes/specialized/IntToDoInlinedLiteralsNode.java
+++ b/src/som/interpreter/nodes/specialized/IntToDoInlinedLiteralsNode.java
@@ -93,7 +93,8 @@ public abstract class IntToDoInlinedLiteralsNode extends ExprWithTagsNode {
     }
 
     if (CompilerDirectives.inInterpreter()) {
-      loopFrequency = Math.max(0.0, Math.max(loopFrequency, (to - from) / (to - from + 1.0)));
+      loopFrequency = Math.min(1.0,
+          Math.max(0.0, Math.max(loopFrequency, (to - from) / (to - from + 1.0))));
     }
 
     for (long i = from + 1; CompilerDirectives.injectBranchProbability(loopFrequency,

--- a/src/som/primitives/EqualsEqualsPrim.java
+++ b/src/som/primitives/EqualsEqualsPrim.java
@@ -8,6 +8,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 
 import bd.primitives.Primitive;
 import som.interpreter.actors.SFarReference;
+import som.primitives.threading.TaskThreads.SomForkJoinTask;
 import som.primitives.threading.TaskThreads.SomThreadTask;
 import som.vmobjects.SArray.SMutableArray;
 import som.vmobjects.SBlock;
@@ -54,6 +55,11 @@ public abstract class EqualsEqualsPrim extends ComparisonPrim {
 
   @Specialization
   public final boolean doThread(final SomThreadTask left, final Object right) {
+    return left == right;
+  }
+
+  @Specialization
+  public final boolean doThread(final SomForkJoinTask left, final Object right) {
     return left == right;
   }
 

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -1,7 +1,6 @@
 package som.primitives;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 
 import com.oracle.truffle.api.CompilerDirectives;
@@ -67,7 +66,7 @@ public final class SystemPrims {
     try {
       module = vm.loadModule(path);
       return module.instantiateModuleClass();
-    } catch (IOException e) {
+    } catch (Throwable e) {
       // TODO: convert to SOM exception
       throw new RuntimeException(e);
     }

--- a/src/som/vm/Symbols.java
+++ b/src/som/vm/Symbols.java
@@ -33,6 +33,11 @@ public final class Symbols {
   public static final SSymbol METACLASS       = symbolFor("Metaclass");
   public static final SSymbol METACLASS_CLASS = symbolFor("Metaclass class");
 
+  public static final SSymbol SUPER = symbolFor("super");
+
+  public static final SSymbol SELF       = symbolFor("self");
+  public static final SSymbol BLOCK_SELF = symbolFor("$blockSelf");
+
   public static final SSymbol Nil    = symbolFor("Nil");
   public static final SSymbol Kernel = symbolFor("Kernel");
 }

--- a/src/som/vmobjects/SInvokable.java
+++ b/src/som/vmobjects/SInvokable.java
@@ -131,6 +131,14 @@ public class SInvokable extends SAbstractObject implements Dispatchable {
     return holder;
   }
 
+  /**
+   * This method is meant for the language server,
+   * it doesn't check whether the holder is set.
+   */
+  public final MixinDefinition getHolderUnsafe() {
+    return holder;
+  }
+
   public final void setHolder(final MixinDefinition value) {
     assert value != null;
     transferToInterpreterAndInvalidate("SMethod.setHolder");

--- a/src/tools/Send.java
+++ b/src/tools/Send.java
@@ -1,0 +1,12 @@
+package tools;
+
+import som.vmobjects.SSymbol;
+
+
+/**
+ * Nodes implementing this interface represent a send, as per Newspeak spec which includes
+ * local reads/writes etc.
+ */
+public interface Send {
+  SSymbol getSelector();
+}

--- a/src/tools/debugger/FrontendConnector.java
+++ b/src/tools/debugger/FrontendConnector.java
@@ -50,6 +50,7 @@ import tools.debugger.message.SourceMessage.SourceData;
 import tools.debugger.message.StackTraceResponse;
 import tools.debugger.message.StoppedMessage;
 import tools.debugger.message.SymbolMessage;
+import tools.debugger.message.VariablesRequest.FilterType;
 import tools.debugger.message.VariablesResponse;
 import tools.debugger.session.Breakpoints;
 import tools.debugger.session.LineBreakpoint;
@@ -284,8 +285,9 @@ public class FrontendConnector {
   }
 
   public void sendVariables(final long varRef, final int requestId,
-      final Suspension suspension) {
-    send(VariablesResponse.create(varRef, requestId, suspension));
+      final Suspension suspension, final FilterType filter, final Long start,
+      final Long count) {
+    send(VariablesResponse.create(varRef, requestId, suspension, filter, start, count));
   }
 
   public void sendStoppedMessage(final Suspension suspension) {

--- a/src/tools/debugger/frontend/Suspension.java
+++ b/src/tools/debugger/frontend/Suspension.java
@@ -22,6 +22,7 @@ import tools.debugger.entities.EntityType;
 import tools.debugger.entities.SteppingType;
 import tools.debugger.frontend.ApplicationThreadTask.Resume;
 import tools.debugger.frontend.ApplicationThreadTask.SendStackTrace;
+import tools.debugger.message.VariablesRequest.FilterType;
 
 
 /**
@@ -127,8 +128,8 @@ public class Suspension {
   }
 
   public void sendVariables(final long varRef, final FrontendConnector frontend,
-      final int requestId) {
-    frontend.sendVariables(varRef, requestId, this);
+      final int requestId, final FilterType filter, final Long start, final Long count) {
+    frontend.sendVariables(varRef, requestId, this, filter, start, count);
   }
 
   private void submitTask(final ApplicationThreadTask task) {

--- a/src/tools/debugger/message/StepMessage.java
+++ b/src/tools/debugger/message/StepMessage.java
@@ -23,6 +23,7 @@ public class StepMessage extends IncommingMessage {
   @Override
   public void process(final FrontendConnector connector, final WebSocket conn) {
     Suspension susp = connector.getSuspension(activityId);
+    assert susp != null : "Failed to get suspension for activityId: " + activityId;
     step.process(susp);
     susp.resume();
   }

--- a/src/tools/debugger/message/VariablesRequest.java
+++ b/src/tools/debugger/message/VariablesRequest.java
@@ -2,6 +2,8 @@ package tools.debugger.message;
 
 import org.java_websocket.WebSocket;
 
+import com.google.gson.annotations.SerializedName;
+
 import tools.TraceData;
 import tools.debugger.FrontendConnector;
 import tools.debugger.frontend.Suspension;
@@ -12,15 +14,30 @@ public final class VariablesRequest extends Request {
 
   private final long variablesReference;
 
-  VariablesRequest(final int requestId, final long variablesReference) {
+  private final FilterType filter;
+  private final Long       start;
+  private final Long       count;
+
+  public enum FilterType {
+    @SerializedName("indexed")
+    INDEXED,
+    @SerializedName("named")
+    NAMED
+  }
+
+  VariablesRequest(final int requestId, final long variablesReference, final FilterType filter,
+      final Long start, final Long count) {
     super(requestId);
     assert TraceData.isWithinJSIntValueRange(variablesReference);
     this.variablesReference = variablesReference;
+    this.filter = filter;
+    this.start = start;
+    this.count = count;
   }
 
   @Override
   public void process(final FrontendConnector connector, final WebSocket conn) {
     Suspension suspension = connector.getSuspensionForGlobalId(variablesReference);
-    suspension.sendVariables(variablesReference, connector, requestId);
+    suspension.sendVariables(variablesReference, connector, requestId, filter, start, count);
   }
 }

--- a/src/tools/debugger/message/VariablesResponse.java
+++ b/src/tools/debugger/message/VariablesResponse.java
@@ -15,6 +15,7 @@ import tools.TraceData;
 import tools.debugger.frontend.RuntimeScope;
 import tools.debugger.frontend.Suspension;
 import tools.debugger.message.Message.Response;
+import tools.debugger.message.VariablesRequest.FilterType;
 
 
 @SuppressWarnings("unused")
@@ -50,22 +51,26 @@ public final class VariablesResponse extends Response {
   }
 
   public static VariablesResponse create(final long globalVarRef, final int requestId,
-      final Suspension suspension) {
+      final Suspension suspension, final FilterType filter, final Long start,
+      final Long count) {
     Object scopeOrObject = suspension.getScopeOrObject(globalVarRef);
     ArrayList<Variable> results;
     if (scopeOrObject instanceof RuntimeScope) {
+      assert start == null || start == 0 : "Don't support starting from non-0 index";
       results = createFromScope((RuntimeScope) scopeOrObject, suspension);
     } else {
-      results = createFromObject(scopeOrObject, suspension);
+      results = createFromObject(scopeOrObject, suspension, filter, start, count);
     }
     return new VariablesResponse(requestId, globalVarRef, results.toArray(new Variable[0]));
   }
 
   private static ArrayList<Variable> createFromObject(final Object obj,
-      final Suspension suspension) {
+      final Suspension suspension, final FilterType filter, final Long start,
+      final Long count) {
     ArrayList<Variable> results = new ArrayList<>();
 
     if (obj instanceof SObject) {
+      assert start == null || start == 0 : "Don't support starting from non-0 index";
       SObject o = (SObject) obj;
       for (Entry<SlotDefinition, StorageLocation> e : o.getObjectLayout().getStorageLocations()
                                                        .entrySet()) {
@@ -73,11 +78,14 @@ public final class VariablesResponse extends Response {
             e.getKey().getName().getString(), e.getValue().read(o), suspension));
       }
     } else {
+      int startIdx = start == null ? 0 : (int) (long) start;
+
       assert obj instanceof SArray;
       SArray arr = (SArray) obj;
       Object storage = arr.getStoragePlain();
       if (storage instanceof Integer) {
-        for (int i = 0; i < (int) storage; i += 1) {
+        long numItems = count == null ? (int) storage : count;
+        for (int i = startIdx; i < numItems; i += 1) {
           results.add(createVariable("" + (i + 1), Nil.nilObject, suspension));
         }
       } else {
@@ -85,8 +93,8 @@ public final class VariablesResponse extends Response {
           storage = ((PartiallyEmptyArray) storage).getStorage();
         }
 
-        int length = Array.getLength(storage);
-        for (int i = 0; i < length; i += 1) {
+        long numItems = count == null ? Array.getLength(storage) : count;
+        for (int i = startIdx; i < numItems; i += 1) {
           results.add(createVariable("" + (i + 1), Array.get(storage, i), suspension));
         }
       }

--- a/src/tools/debugger/message/VariablesResponse.java
+++ b/src/tools/debugger/message/VariablesResponse.java
@@ -74,8 +74,9 @@ public final class VariablesResponse extends Response {
       SObject o = (SObject) obj;
       for (Entry<SlotDefinition, StorageLocation> e : o.getObjectLayout().getStorageLocations()
                                                        .entrySet()) {
-        results.add(createVariable(
-            e.getKey().getName().getString(), e.getValue().read(o), suspension));
+        results.add(
+            createVariable(e.getKey().getName().getString(), e.getValue().read(o),
+                suspension));
       }
     } else {
       int startIdx = start == null ? 0 : (int) (long) start;
@@ -108,7 +109,7 @@ public final class VariablesResponse extends Response {
     for (som.compiler.Variable v : scope.getVariables()) {
       if (!v.isInternal()) {
         Object val = scope.read(v);
-        results.add(createVariable(v.name, val, suspension));
+        results.add(createVariable(v.name.getString(), val, suspension));
       }
     }
     return results;


### PR DESCRIPTION
This PR combines a few minor fixes with some improvements for LSP support and debugging:

Debugger
 - added support for transmitting arrays partially (i.e., indexes 0 to 100, 400 to 550 etc, as used by some IDEs)

LSP Support
 - added getters to query information
 - use SSymbol for variables as well, ensures consistency with all other constructs (@richard-roberts this is something we briefly discussed)
 - added interface for message sends (`Send`) to get their selector
 - allow overriding `selector()` to make sure source sections can be handled properly

Bug fixes:
 - added missing specialization for `#==` prim
 - make sure loop frequency is never larger than 1.0
 - catch all throwables when loading a module