### PR TITLE
Update Kompos dependencies, and missing fields for partial arrays in debugger

### DIFF
--- a/tools/kompos/package.json
+++ b/tools/kompos/package.json
@@ -15,31 +15,31 @@
     "url": "https://github.com/smarr/SOMns.git"
   },
   "engines": {
-    "node": "^7.0.5"
+    "node": "^8.0.57"
   },
   "dependencies": {
     "@types/bootstrap": "^3.3.34",
-    "@types/chai": "^4.0.1",
+    "@types/chai": "^4.0.8",
     "@types/d3": "^3.5.36",
-    "@types/jquery": "^3.2.5",
-    "@types/mocha": "^2.2.41",
-    "@types/node": "^8.0.4",
-    "@types/ws": "^3.0.0",
+    "@types/jquery": "^3.2.16",
+    "@types/mocha": "^2.2.44",
+    "@types/node": "^8.0.57",
+    "@types/ws": "^3.2.1",
     "bootstrap": "^4.0.0-alpha.6",
     "d3": "^3.5.17",
     "font-awesome": "^4.7.0",
     "jquery": "^3.2.1",
     "node-define": "^0.1.1",
-    "requirejs": "^2.3.3",
-    "ws": "^3.0.0",
+    "requirejs": "^2.3.5",
+    "ws": "^3.3.2",
     "zenscroll": "^4.0.0"
   },
   "devDependencies": {
-    "chai": "^4.0.2",
-    "mocha": "^3.4.2",
-    "tslint": "^5.4.3",
-    "typescript": "2.4.1",
-    "typescript-formatter": "^5.2.0"
+    "chai": "^4.1.2",
+    "mocha": "^4.0.1",
+    "tslint": "^5.8.0",
+    "typescript": "2.6.2",
+    "typescript-formatter": "^7.0.0"
   },
   "scripts": {
     "postinstall": "npm run compile",

--- a/tools/kompos/src/messages.ts
+++ b/tools/kompos/src/messages.ts
@@ -332,6 +332,15 @@ export interface VariablesRequest {
 
   /** Reference of the variable container/scope. */
   variablesReference: number;
+
+  /** Filter child variables */
+  filter?: "indexed" | "named";
+
+  /** Optional start index. */
+  start?: number;
+
+  /** Optional number of elements to be returned. */
+  count?: number;
 }
 
 export interface VariablesResponse {

--- a/tools/kompos/src/process-view.ts
+++ b/tools/kompos/src/process-view.ts
@@ -316,12 +316,12 @@ class Message extends EmptyMessage {
   private visualization: d3.Selection<SVGElement>;
   private anchor: d3.Selection<SVGElement>;
 
-  private readonly sendOp: SendOp;
+  // private readonly sendOp: SendOp;
 
   constructor(senderActor: ActorHeading, targetActor: ActorHeading,
-    sendOp: SendOp, senderTurn: TurnNode) {
+    _sendOp: SendOp, senderTurn: TurnNode) {
     super();
-    this.sendOp = sendOp;
+    // this.sendOp = sendOp;
     this.sender = senderTurn;
     this.target = new TurnNode(targetActor, this);
 

--- a/tools/kompos/src/system-view.ts
+++ b/tools/kompos/src/system-view.ts
@@ -4,7 +4,7 @@
 import { ActivityType } from "./messages";
 import * as d3 from "d3";
 import { TraceDataUpdate } from "./execution-data";
-import { ActivityNode, EntityLink, SystemViewData, PassiveEntityNode } from "./system-view-data";
+import { ActivityNode, EntityLink, SystemViewData, PassiveEntityNode, EntityNode } from "./system-view-data";
 import { KomposMetaModel } from "./meta-model";
 
 // Tango Color Scheme: http://emilis.info/other/extended_tango/
@@ -132,17 +132,19 @@ export class SystemView {
   private forceLayoutUpdateIteration() {
     // draw directed edges with proper padding from node centers
     this.entityLinks.attr("d", (d: EntityLink) => {
-      const deltaX = d.target.x - d.source.x,
-        deltaY = d.target.y - d.source.y,
+      const target = <EntityNode> d.target;
+      const source = <EntityNode> d.source;
+      const deltaX = target.x - source.x,
+        deltaY = target.y - source.y,
         dist = Math.sqrt(deltaX * deltaX + deltaY * deltaY),
         normX = deltaX / dist,
         normY = deltaY / dist,
         sourcePadding = d.left ? 17 : 12,
         targetPadding = d.right ? 17 : 12,
-        sourceX = d.source.x + (sourcePadding * normX),
-        sourceY = d.source.y + (sourcePadding * normY),
-        targetX = d.target.x - (targetPadding * normX),
-        targetY = d.target.y - (targetPadding * normY);
+        sourceX = source.x + (sourcePadding * normX),
+        sourceY = source.y + (sourcePadding * normY),
+        targetX = target.x - (targetPadding * normX),
+        targetY = target.y - (targetPadding * normY);
       return `M${sourceX},${sourceY}L${targetX},${targetY}`;
     });
 

--- a/tools/kompos/src/trace-parser.ts
+++ b/tools/kompos/src/trace-parser.ts
@@ -198,8 +198,8 @@ export class TraceParser {
 
     let currentActivityId = null;
     let currentScopeId = null;
-    let currentImplThreadId = null;
-    let currentActivityBufferId = null;
+    // let currentImplThreadId = null;
+    // let currentActivityBufferId = null;
 
     let prevMarker = null;
 
@@ -232,13 +232,13 @@ export class TraceParser {
           i = this.readReceiveOp(i, data, currentActivityId, currentScopeId);
           break;
         case TraceRecords.ImplThread: {
-          currentImplThreadId = this.readLong(data, i + 1);
+          /* currentImplThreadId = */ this.readLong(data, i + 1);
           i += RECORD_SIZE.ImplThread;
           break;
         }
         case TraceRecords.ImplThreadCurrentActivity: {
           currentActivityId = this.readLong(data, i + 1);
-          currentActivityBufferId = data.getUint32(i + 9);
+          /* currentActivityBufferId = */ data.getUint32(i + 9);
           i += RECORD_SIZE.ImplThreadCurrentActivity;
           break;
         }

--- a/tools/kompos/src/view.ts
+++ b/tools/kompos/src/view.ts
@@ -192,12 +192,12 @@ class BeginMethodDef extends SectionMarker {
 }
 
 class End extends SectionMarker {
-  private section: SourceCoordinate;
+  // private section: SourceCoordinate;
   private len: number;
 
-  constructor(section: SourceCoordinate, length: number) {
+  constructor(_section: SourceCoordinate, length: number) {
     super(End);
-    this.section = section;
+    // this.section = section;
     this.len = length;
   }
 

--- a/tools/kompos/tests/basic-protocol.ts
+++ b/tools/kompos/tests/basic-protocol.ts
@@ -114,158 +114,158 @@ describe("Basic Protocol", function() {
 
   const breakpointTests = {
     "setting a line breakpoint":
-    [{
-      test: "accept line breakpoint, and halt on expected line",
-      breakpoint: createLineBreakpointData(PING_PONG_URI, 92, true),
-      stackLength: 6,
-      topMethod: "PingPong>>#benchmark",
-      line: 92
-    }],
+      [{
+        test: "accept line breakpoint, and halt on expected line",
+        breakpoint: createLineBreakpointData(PING_PONG_URI, 92, true),
+        stackLength: 6,
+        topMethod: "PingPong>>#benchmark",
+        line: 92
+      }],
 
     "setting a source section sender breakpoint":
-    [{
-      test: "accept send breakpoint, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 23, 14, 3, BT.MSG_SENDER, true),
-      stackLength: 2,
-      topMethod: "Ping>>#ping",
-      line: 23
-    }],
+      [{
+        test: "accept send breakpoint, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 23, 14, 3, BT.MSG_SENDER, true),
+        stackLength: 2,
+        topMethod: "Ping>>#ping",
+        line: 23
+      }],
 
     "setting a source section asynchronous method before execution breakpoint":
-    [{
-      test: "accept async method before execution breakpoint, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 22, 9, 203, BT.ASYNC_MSG_BEFORE_EXEC, true),
-      stackLength: 1,
-      topMethod: "Ping>>#ping",
-      line: 22
-    }],
+      [{
+        test: "accept async method before execution breakpoint, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 22, 9, 203, BT.ASYNC_MSG_BEFORE_EXEC, true),
+        stackLength: 1,
+        topMethod: "Ping>>#ping",
+        line: 22
+      }],
 
     "setting a source section asynchronous message after execution breakpoint":
-    [{
-      test: "accept async message after execution breakpoint, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 69, 9, 87, BT.ASYNC_MSG_AFTER_EXEC, true),
-      stackLength: 1,
-      topMethod: "Pong>>#ping:",
-      line: 69
-    }],
+      [{
+        test: "accept async message after execution breakpoint, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 69, 9, 87, BT.ASYNC_MSG_AFTER_EXEC, true),
+        stackLength: 1,
+        topMethod: "Pong>>#ping:",
+        line: 69
+      }],
 
     "setting a source section receiver breakpoint":
-    [{
-      test: "accept send breakpoint, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 23, 14, 3, BT.MSG_RECEIVER, true),
-      stackLength: 1,
-      topMethod: "Pong>>#ping:",
-      line: 69
-    }],
+      [{
+        test: "accept send breakpoint, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 23, 14, 3, BT.MSG_RECEIVER, true),
+        stackLength: 1,
+        topMethod: "Pong>>#ping:",
+        line: 69
+      }],
 
     "setting a source section promise resolver breakpoint":
-    [{
-      test: "for normal resolution, accept promise resolver breakpoint, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 95, 16, 3, BT.PROMISE_RESOLVER, true),
-      stackLength: 1,
-      topMethod: "Ping>>#start",
-      line: 16
-    },
-    {
-      test: "for null resolution, accept promise resolver breakpoint for null resolution, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 23, 14, 3, BT.PROMISE_RESOLVER, true),
-      stackLength: 1,
-      topMethod: "Pong>>#ping:",
-      line: 69
-    },
-    {
-      test: "for chained resolution, accept promise resolver breakpoint for chained resolution, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 26, 19, 3, BT.PROMISE_RESOLVER, true),
-      stackLength: 1,
-      topMethod: "Ping>>#validate:",
-      line: 33
-    },
-    {
-      test: "on unresolved explicit promise, accept promise resolver breakpoint on unresolved explicit promise, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 92, 29, 17, BT.PROMISE_RESOLVER, true),
-      stackLength: 1,
-      topMethod: "Pong>>#stop",
-      line: 80
-    },
-    {
-      test: "on resolved explicit promise, accept promise resolution breakpoint on resolved explicit promise, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 41, 21, 17, BT.PROMISE_RESOLUTION, true),
-      stackLength: 1,
-      topMethod: "Thing>>#println",
-      line: 71
-    },
-    {
-      test: "on resolved explicit promise, accept promise resolver breakpoint on resolved explicit promise, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 41, 21, 17, BT.PROMISE_RESOLVER, true),
-      stackLength: 1,
-      topMethod: "Ping>>#validNumber:",
-      line: 49
-    },
-    {
-      test: "on whenResolved, accept promise resolver breakpoint on whenResolved, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 27, 17, 32, BT.PROMISE_RESOLVER, true),
-      stackLength: 1,
-      topMethod: "Ping>>#λping@27@31:",
-      line: 27
-    },
-    {
-      test: "onError, accept promise resolver breakpoint onError, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 78, 18, 50, BT.PROMISE_RESOLVER, true),
-      stackLength: 1,
-      topMethod: "Pong>>#λstop@78@27:",
-      line: 78
-    },
-    {
-      test: "whenResolvedOnError, accept promise resolver breakpoint whenResolvedOnError, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 34, 17, 91, BT.PROMISE_RESOLVER, true),
-      stackLength: 1,
-      topMethod: "Ping>>#λvalidate@34@77:",
-      line: 34
-    }],
+      [{
+        test: "for normal resolution, accept promise resolver breakpoint, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 95, 16, 3, BT.PROMISE_RESOLVER, true),
+        stackLength: 1,
+        topMethod: "Ping>>#start",
+        line: 16
+      },
+      {
+        test: "for null resolution, accept promise resolver breakpoint for null resolution, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 23, 14, 3, BT.PROMISE_RESOLVER, true),
+        stackLength: 1,
+        topMethod: "Pong>>#ping:",
+        line: 69
+      },
+      {
+        test: "for chained resolution, accept promise resolver breakpoint for chained resolution, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 26, 19, 3, BT.PROMISE_RESOLVER, true),
+        stackLength: 1,
+        topMethod: "Ping>>#validate:",
+        line: 33
+      },
+      {
+        test: "on unresolved explicit promise, accept promise resolver breakpoint on unresolved explicit promise, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 92, 29, 17, BT.PROMISE_RESOLVER, true),
+        stackLength: 1,
+        topMethod: "Pong>>#stop",
+        line: 80
+      },
+      {
+        test: "on resolved explicit promise, accept promise resolution breakpoint on resolved explicit promise, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 41, 21, 17, BT.PROMISE_RESOLUTION, true),
+        stackLength: 1,
+        topMethod: "Thing>>#println",
+        line: 71
+      },
+      {
+        test: "on resolved explicit promise, accept promise resolver breakpoint on resolved explicit promise, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 41, 21, 17, BT.PROMISE_RESOLVER, true),
+        stackLength: 1,
+        topMethod: "Ping>>#validNumber:",
+        line: 49
+      },
+      {
+        test: "on whenResolved, accept promise resolver breakpoint on whenResolved, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 27, 17, 32, BT.PROMISE_RESOLVER, true),
+        stackLength: 1,
+        topMethod: "Ping>>#λping@27@31:",
+        line: 27
+      },
+      {
+        test: "onError, accept promise resolver breakpoint onError, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 78, 18, 50, BT.PROMISE_RESOLVER, true),
+        stackLength: 1,
+        topMethod: "Pong>>#λstop@78@27:",
+        line: 78
+      },
+      {
+        test: "whenResolvedOnError, accept promise resolver breakpoint whenResolvedOnError, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 34, 17, 91, BT.PROMISE_RESOLVER, true),
+        stackLength: 1,
+        topMethod: "Ping>>#λvalidate@34@77:",
+        line: 34
+      }],
 
     "setting a source section promise resolution breakpoint":
-    [{
-      test: "for normal resolution, accept promise resolution breakpoint, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 95, 16, 3, BT.PROMISE_RESOLUTION, true),
-      stackLength: 1,
-      topMethod: "Thing>>#println",
-      line: 71
-    },
-    {
-      test: "for chained resolution, accept promise resolution breakpoint for chained resolution, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 26, 19, 3, BT.PROMISE_RESOLUTION, true),
-      stackLength: 1,
-      topMethod: "Ping>>#λping@27@31:",
-      line: 27
-    },
-    {
-      test: "on unresolved explicit promise, accept promise resolution breakpoint on unresolved explicit promise, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 92, 29, 17, BT.PROMISE_RESOLUTION, true),
-      stackLength: 1,
-      topMethod: "PingPong>>#λbenchmark@97@44:",
-      line: 98
-    },
-    {
-      test: "on whenResolved, accept promise resolution breakpoint on whenResolved, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 27, 17, 32, BT.PROMISE_RESOLUTION, true),
-      stackLength: 1,
-      topMethod: "Thing>>#println",
-      line: 71
-    },
-    {
-      test: "onError, accept promise resolution breakpoint onError, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 78, 18, 50, BT.PROMISE_RESOLUTION, true),
-      stackLength: 1,
-      topMethod: "Thing>>#println",
-      line: 71
-    },
-    {
-      test: "whenResolvedOnError, accept promise resolution breakpoint on whenResolvedOnError, and halt on expected source section",
-      breakpoint: createSectionBreakpointData(PING_PONG_URI, 34, 17, 91, BT.PROMISE_RESOLUTION, true),
-      stackLength: 1,
-      topMethod: "Thing>>#println",
-      line: 71
-    }]
+      [{
+        test: "for normal resolution, accept promise resolution breakpoint, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 95, 16, 3, BT.PROMISE_RESOLUTION, true),
+        stackLength: 1,
+        topMethod: "Thing>>#println",
+        line: 71
+      },
+      {
+        test: "for chained resolution, accept promise resolution breakpoint for chained resolution, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 26, 19, 3, BT.PROMISE_RESOLUTION, true),
+        stackLength: 1,
+        topMethod: "Ping>>#λping@27@31:",
+        line: 27
+      },
+      {
+        test: "on unresolved explicit promise, accept promise resolution breakpoint on unresolved explicit promise, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 92, 29, 17, BT.PROMISE_RESOLUTION, true),
+        stackLength: 1,
+        topMethod: "PingPong>>#λbenchmark@97@44:",
+        line: 98
+      },
+      {
+        test: "on whenResolved, accept promise resolution breakpoint on whenResolved, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 27, 17, 32, BT.PROMISE_RESOLUTION, true),
+        stackLength: 1,
+        topMethod: "Thing>>#println",
+        line: 71
+      },
+      {
+        test: "onError, accept promise resolution breakpoint onError, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 78, 18, 50, BT.PROMISE_RESOLUTION, true),
+        stackLength: 1,
+        topMethod: "Thing>>#println",
+        line: 71
+      },
+      {
+        test: "whenResolvedOnError, accept promise resolution breakpoint on whenResolvedOnError, and halt on expected source section",
+        breakpoint: createSectionBreakpointData(PING_PONG_URI, 34, 17, 91, BT.PROMISE_RESOLUTION, true),
+        stackLength: 1,
+        topMethod: "Thing>>#println",
+        line: 71
+      }]
   };
 
   for (const suiteName in breakpointTests) {


### PR DESCRIPTION
- fixed compilation issues with newer package versions and linting/static analysis
- added field definitions for the debugger variable request messages, which was changed to allow for partial array transmission in the debugger