### PR TITLE
Handle System>>#exit: properly for async apps

### DIFF
--- a/src/som/vm/ObjectSystem.java
+++ b/src/som/vm/ObjectSystem.java
@@ -341,7 +341,7 @@ public final class ObjectSystem {
   private void handlePromiseResult(final SPromise promise) {
     int emptyFJPool = 0;
     while (emptyFJPool < 120) {
-      if (promise.isCompleted() || vm.shouldExit()) {
+      if (promise.isCompleted()) {
         if (vm.isAvoidingExit()) {
           return;
         }
@@ -351,6 +351,13 @@ public final class ObjectSystem {
         } else {
           vm.shutdownAndExit(0);
         }
+      }
+
+      if (vm.shouldExit()) {
+        if (vm.isAvoidingExit()) {
+          return;
+        }
+        vm.shutdownAndExit(vm.lastExitCode());
       }
 
       try {


### PR DESCRIPTION
VM didn’t exit with the correct error code in case the main method returned a promise.

@daumayr this seems like something you might have run into, and not gotten the correct exit code from tests. We probably want to look into having integration tests for this at some point, because it feels like we have been a few bugs around VM exit already