### PR TITLE
Make debugger tests less racy

### DIFF
--- a/tools/kompos/tests/actor2.ns
+++ b/tools/kompos/tests/actor2.ns
@@ -1,0 +1,161 @@
+(* A second little actor system in addition to Actor.
+   *)
+class Actor2 usingPlatform: platform = Value (
+| private actors = platform actors.
+  private system = platform system.
+  private Exception = platform kernel Exception.
+|)(
+
+  private class ActA new: resolver = (
+  | private resolver = resolver. |
+  )(
+    public doSelfSend = (
+      'ActA.doSelfSend' println.
+      self <-: doSelfSend2.
+      ^ self
+    )
+
+    public doSelfSend2 = (
+      'ActA.doSelfSend2' println.
+      self <-: finish.
+      ^ self
+    )
+
+    public finish = (
+      resolver resolve: #done
+    )
+  )
+
+  private class ActB new: actA = (
+  | private actA = actA. |
+  )(
+    public doSendToA = (
+      actA <-: finish.
+      ^ self
+    )
+  )
+
+  private class ActC new: resolver = (
+  | private resolver = resolver. |
+  )(
+    public doSelfSend = (
+      self <-: msg
+        whenResolved: [:r |
+          'doSelfSend whenResolved: ' print.
+          r println.
+          resolver resolve: #done. ]
+    )
+
+    public msg = ( ^ 42 )
+
+    public makePromise = (
+      | pp |
+      'ActC.makePromise' println.
+      pp:: actors createPromisePair.
+      pp promise whenResolved: [:r |
+        'makePromise whenResolved' println. resolver resolve: #done. ].
+
+      'makePromise after whenResolved' println.
+
+      pp resolve: #done.
+    )
+
+    public whenResolved = (
+      | p p2 |
+      p:: self <-: msg.
+      p2:: p whenResolved: [:r |
+        'whenResolved whenResolved' println ].
+
+      p2 whenResolved: [:r |
+        'whenResolved whenResolved2' println.
+        resolver resolve: #done. ].
+
+      'whenResolved after whenResolved' println.
+    )
+
+    public whenResolvedError = (
+      | p p2 |
+      p:: self <-: msg.
+      p2:: p whenResolved: [:r |
+        'whenResolved whenResolved' println ] onError: [:e| ('-Error: ' + e) println ].
+
+      p2 whenResolved: [:r |
+        'whenResolved whenResolved2' println.
+        resolver resolve: #done. ].
+
+      'whenResolved after whenResolved' println.
+    )
+
+    public error = (
+      Exception signal.
+    )
+
+    public onError = (
+      | p p2 |
+      p:: self <-: error.
+      p2:: p onError: [:e |
+        ('-Error: ' + e) println ].
+
+      p2 whenResolved: [:r |
+        'onError whenResolved' println.
+        resolver resolve: #done. ].
+
+      'onError after whenResolved' println.
+    )
+  )
+
+  public stepToMessageReceiverOnSameActor: completionPP = (
+    | a = (actors createActorFromValue: ActA) <-: new: completionPP resolver. |
+    a <-: doSelfSend.
+  )
+
+  public stepToMessageReceiverOnOtherActor: completionPP = (
+    | a = (actors createActorFromValue: ActA) <-: new: completionPP resolver.
+      b = (actors createActorFromValue: ActB) <-: new: a. |
+    b <-: doSendToA.
+  )
+
+  public returnFromTurnToPromiseResolutionForSelfSend: completionPP = (
+    | c = (actors createActorFromValue: ActC) <-: new: completionPP resolver. |
+    c <-: doSelfSend.
+  )
+
+  public stepToResolutionExplicitPromise: completionPP = (
+    | c = (actors createActorFromValue: ActC) <-: new: completionPP resolver. |
+    c <-: makePromise.
+  )
+
+  public stepToResolutionOfWhenResolved: completionPP = (
+    | c = (actors createActorFromValue: ActC) <-: new: completionPP resolver. |
+    c <-: whenResolved.
+  )
+
+  public stepToResolutionOfWhenResolvedError: completionPP = (
+    | c = (actors createActorFromValue: ActC) <-: new: completionPP resolver. |
+    c <-: whenResolvedError.
+  )
+
+  public stepToResolutionOnError: completionPP = (
+    | c = (actors createActorFromValue: ActC) <-: new: completionPP resolver. |
+    c <-: onError.
+  )
+
+  public main: args = (
+    | completionPP a test |
+    'Actor breakpoint tests' println.
+
+    completionPP:: actors createPromisePair.
+    test:: args at: 2.
+    ('Run test: ' + test) println.
+
+    test = 'stepToMessageReceiverOnSameActor' ifTrue: [ stepToMessageReceiverOnSameActor: completionPP ].
+    test = 'stepToMessageReceiverOnOtherActor' ifTrue: [ stepToMessageReceiverOnOtherActor: completionPP ].
+    test = 'returnFromTurnToPromiseResolutionForSelfSend' ifTrue: [ returnFromTurnToPromiseResolutionForSelfSend: completionPP ].
+    test = 'stepToResolutionExplicitPromise' ifTrue: [ stepToResolutionExplicitPromise: completionPP ].
+    test = 'stepToResolutionOfWhenResolved' ifTrue: [ stepToResolutionOfWhenResolved: completionPP ].
+    test = 'stepToResolutionOfWhenResolvedError' ifTrue: [ stepToResolutionOfWhenResolvedError: completionPP ].
+    test = 'stepToResolutionOnError' ifTrue: [ stepToResolutionOnError: completionPP ].
+
+    ^ completionPP promise
+  )
+)

--- a/tools/kompos/tests/pingpong.ns
+++ b/tools/kompos/tests/pingpong.ns
@@ -1,4 +1,4 @@
-class PingPongApp usingPlatform: platform = Value (
+class PingPong usingPlatform: platform = Value (
 | private actors = platform actors.
   private system = platform system.
   private Exception = platform kernel Exception.

--- a/tools/kompos/tests/som-integration.ts
+++ b/tools/kompos/tests/som-integration.ts
@@ -28,8 +28,8 @@ describe("Stack trace output", () => {
 \tBlock>>#on:do:                               Kernel.ns::\n\
 \tvmMirror>>#exceptionDo:catch:onException:    ExceptionDoOnPrimFactory::\n\
 \tPlatform>>#λstart@@                       Platform.ns::\n\
-\tPingPongApp>>#main:                          pingpong.ns::\n\
-\tPingPongApp>>#testDNU                        pingpong.ns::\n\
+\tPingPong>>#main:                             pingpong.ns::\n\
+\tPingPong>>#testDNU                           pingpong.ns::\n\
 ERROR: MessageNotUnderstood(Integer>>#foobar)\n");
   });
 
@@ -40,8 +40,8 @@ ERROR: MessageNotUnderstood(Integer>>#foobar)\n");
 \tBlock>>#on:do:                               Kernel.ns::\n\
 \tvmMirror>>#exceptionDo:catch:onException:    ExceptionDoOnPrimFactory::\n\
 \tPlatform>>#λstart@@                       Platform.ns::\n\
-\tPingPongApp>>#main:                          pingpong.ns::\n\
-\tPingPongApp>>#testPrintStackTrace            pingpong.ns::\n");
+\tPingPong>>#main:                             pingpong.ns::\n\
+\tPingPong>>#testPrintStackTrace               pingpong.ns::\n");
   });
 });
 
@@ -64,7 +64,7 @@ describe("Language Debugger Integration", function() {
 
     it("should halt on expected source section", () => {
       return ctrl.stackPs[0].then(msg => {
-        expectStack(msg.stackFrames, 6, "PingPongApp>>#testHalt", 106);
+        expectStack(msg.stackFrames, 6, "PingPong>>#testHalt", 106);
       });
     });
   });

--- a/tools/kompos/tests/stm.ts
+++ b/tools/kompos/tests/stm.ts
@@ -1,111 +1,143 @@
 import { expect } from "chai";
 import { resolve } from "path";
 
-import { BreakpointType, SteppingType } from "./somns-support";
-import { TestConnection, HandleStoppedAndGetStackTrace, expectStack } from "./test-setup";
-import { createSectionBreakpointData, StackTraceResponse } from "../src/messages";
+import { BreakpointType as BT, SteppingType as ST } from "./somns-support";
+import { TestConnection, TestController } from "./test-setup";
+import { createSectionBreakpointData, createLineBreakpointData } from "../src/messages";
+import { Test, expectStops } from "./stepping";
 
 const STM_FILE = resolve("tests/stm.ns");
 const STM_URI = "file:" + STM_FILE;
 
 describe("Setting STM Breakpoints", () => {
   let conn: TestConnection;
-  let ctrl: HandleStoppedAndGetStackTrace;
 
   const closeConnectionAfterSuite = (done) => {
     conn.fullyConnected.then(_ => { conn.close(done); });
     conn.fullyConnected.catch(reason => done(reason));
   };
 
-  before("Start SOMns and Connect", () => {
-    const beforeBp = createSectionBreakpointData(STM_URI, 11, 8, 74,
-      BreakpointType.ATOMIC_BEFORE, true);
-    const commitBp = createSectionBreakpointData(STM_URI, 11, 8, 74,
-      BreakpointType.ATOMIC_BEFORE_COMMIT, true);
-    conn = new TestConnection(null, null, STM_FILE);
-    ctrl = new HandleStoppedAndGetStackTrace(
-      [beforeBp, commitBp], conn, conn.fullyConnected, 6);
-  });
-
-  after(closeConnectionAfterSuite);
-
-  const thread1 = [
-    { s: 6, n: "STM>>#doCount:", l: 11 },
-    // line 13 is ok, because the bp uses source section of whole block
-    { s: 7, n: "STM>>#λdoCount@11@16", l: 13 },
-    { s: 6, n: "STM>>#doCount:", l: 17 },
+  const steppingTests: Test[] = [
+    {
+      title: "stepping to message receiver on same actor",
+      test: STM_FILE,
+      initialBreakpoints: [
+        createLineBreakpointData(STM_URI, 39, true),
+        createSectionBreakpointData(STM_URI, 11, 8, 74, BT.ATOMIC_BEFORE, true),
+        createSectionBreakpointData(STM_URI, 11, 8, 74, BT.ATOMIC_BEFORE_COMMIT, true)],
+      initialStop: {
+        line: 39,
+        methodName: "STM>>#main:",
+        stackHeight: 5,
+        activity: "main"
+      },
+      steps: [
+        {
+          type: ST.RESUME,
+          activity: "main",
+          stops: [{
+            line: 11,
+            methodName: "STM>>#doCount:",
+            stackHeight: 6,
+            activity: "main"
+          },
+          {
+            line: 11,
+            methodName: "STM>>#doCount:",
+            stackHeight: 2,
+            activity: "thread2"
+          }]
+        },
+        {
+          type: ST.RESUME,
+          activity: "main",
+          stops: [{
+            line: 13,
+            methodName: "STM>>#λdoCount@11@16",
+            stackHeight: 7,
+            activity: "main"
+          }]
+        },
+        {
+          type: ST.RESUME,
+          activity: "thread2",
+          stops: [{
+            line: 13,
+            methodName: "STM>>#λdoCount@11@16",
+            stackHeight: 3,
+            activity: "thread2"
+          }]
+        },
+        {
+          type: ST.STEP_OVER,
+          activity: "main",
+          stops: [{
+            line: 17,
+            methodName: "STM>>#doCount:",
+            stackHeight: 6,
+            activity: "main"
+          }]
+        },
+        {
+          type: ST.RESUME,
+          activity: "thread2",
+          stops: [{
+            line: 13,
+            methodName: "STM>>#λdoCount@11@16",
+            stackHeight: 3,
+            activity: "thread2"
+          }]
+        }
+      ]
+    }
   ];
 
-  const thread2 = [
-    { s: 2, n: "STM>>#doCount:", l: 11 },
-    { s: 3, n: "STM>>#λdoCount@11@16", l: 13 },
-    { s: 3, n: "STM>>#λdoCount@11@16", l: 13 },
-  ];
+  for (const suite of steppingTests) {
+    if (suite.skip) {
+      describe.skip(suite.title, () => {
+        if (!suite.steps) { return; }
+        suite.steps.forEach(step => {
+          const desc = step.desc ? step.desc : `do ${step.type} on ${step.activity}.`;
+          it.skip(desc, () => { });
+        });
+      });
+      continue;
+    }
 
-  let actId = 0;
-  it("should break on #atomic, 1st time, and resume", () => {
-    return ctrl.stackPs[0].then(msg => {
-      actId = msg.activityId;
-      conn.sendDebuggerAction(SteppingType.RESUME, ctrl.stoppedActivities[msg.requestId]);
+    describe(suite.title, () => {
+      let ctrl: TestController;
 
-      const exp = (msg.activityId === 0 ? thread1 : thread2)[0];
-      return expectStack(msg.stackFrames, exp.s, exp.n, exp.l);
+      before("Start SOMns and Connect", () => {
+        const arg = suite.testArg ? [suite.testArg] : null;
+        conn = new TestConnection(arg, false, suite.test);
+        ctrl = new TestController(suite, conn, conn.fullyConnected);
+      });
+
+      after(closeConnectionAfterSuite);
+
+      it("should stop initially at breakpoint", () => {
+        return ctrl.stopsDoneForStep.then(stops => {
+          expect(stops).has.lengthOf(1);
+          expect(stops[0]).to.deep.equal(suite.initialStop);
+        });
+      });
+
+
+      describe("should", () => {
+        if (!suite.steps) { return; }
+
+        suite.steps.forEach(step => {
+          const expectedStops = step.stops ? step.stops.length : 0;
+          const desc = step.desc ? step.desc : `do ${step.type} on ${step.activity} and stop ${expectedStops} times.`;
+          it(desc, () => {
+            const stopPs = ctrl.doNextStep(step.type, step.activity, step.stops);
+
+            return stopPs.then(allStops => {
+              expectStops(allStops, step.stops);
+            });
+          });
+        });
+      });
     });
-  });
-
-  it("should break on #atomic, 2nd time, and resume", () => {
-    return ctrl.stackPs[1].then(msg => {
-      expect(msg.activityId).not.equal(actId);
-      conn.sendDebuggerAction(SteppingType.RESUME, ctrl.stoppedActivities[msg.requestId]);
-
-      const exp = (msg.activityId === 0 ? thread1 : thread2)[0];
-      return expectStack(msg.stackFrames, exp.s, exp.n, exp.l);
-    });
-  });
-
-  let postponedAct = null;
-
-  it("should stop before commit, two times, and single step", () => {
-    const handler = function(msg: StackTraceResponse) {
-      if (msg.activityId === 0) {
-        conn.sendDebuggerAction(SteppingType.STEP_INTO, ctrl.stoppedActivities[msg.requestId]);
-      } else {
-        postponedAct = ctrl.stoppedActivities[msg.requestId];
-      }
-
-      const exp = (msg.activityId === 0 ? thread1 : thread2)[1];
-      return expectStack(msg.stackFrames, exp.s, exp.n, exp.l);
-    };
-
-    const p1 = ctrl.stackPs[2].then(msg => {
-      return handler(msg);
-    });
-    const p2 = ctrl.stackPs[3].then(msg => {
-      return handler(msg);
-    });
-    return Promise.all([p1, p2]);
-  });
-
-  it("1st thread should stop before next operation, 2nd thread should retry transaction", () => {
-    const handle = function(msg: StackTraceResponse) {
-      if (msg.activityId === 0) {
-        console.assert(postponedAct !== null);
-        conn.sendDebuggerAction(SteppingType.STEP_INTO, postponedAct);
-
-        const exp = thread1[2];
-        return expectStack(msg.stackFrames, exp.s, exp.n, exp.l);
-      } else {
-        const exp = thread2[2];
-        return expectStack(msg.stackFrames, exp.s, exp.n, exp.l);
-      }
-    };
-
-    const p1 = ctrl.stackPs[4].then(msg => {
-      return handle(msg);
-    });
-    const p2 = ctrl.stackPs[5].then(msg => {
-      return handle(msg);
-    });
-    return Promise.all([p1, p2]);
-  });
+  }
 });

--- a/tools/kompos/tests/test-setup.ts
+++ b/tools/kompos/tests/test-setup.ts
@@ -19,7 +19,9 @@ export const SOM = SOM_BASEPATH + "som";
 export const PING_PONG_FILE = resolve("tests/pingpong.ns");
 export const PING_PONG_URI = "file:" + PING_PONG_FILE;
 export const ACTOR_FILE = resolve("tests/actor.ns")
+export const ACTOR2_FILE = resolve("tests/actor2.ns")
 export const ACTOR_URI = "file:" + ACTOR_FILE;
+export const ACTOR2_URI = "file:" + ACTOR2_FILE;
 
 const PRINT_SOM_OUTPUT = false;
 const PRINT_CMD_LINE = false;


### PR DESCRIPTION
This PR changes more of the debugger tests to use the stepping DSL, which should make them more robust, and hopefully easier to maintain.

@daumayr, this should hopefully reduce the number of failing builds. The only thing that's hopefully still failing often is the replay. We should really look into that.