### PR TITLE
Added classic tinyBenchmarks known from Smalltalks

### DIFF
--- a/core-lib/Benchmarks/TinyBenchmarks.ns
+++ b/core-lib/Benchmarks/TinyBenchmarks.ns
@@ -1,0 +1,113 @@
+class TinyBenchmarks usingPlatform: platform = Value (
+| private system = platform system.
+  private Array  = platform kernel Array.
+|)(
+  private class Time = ()() : (
+    public millisecondsToRun: timedBlock = (
+      | start = system ticks. |
+      timedBlock value.
+      ^ (system ticks - start) / 1000
+    )
+  )
+
+  (* Handy bytecode-heavy benchmark *)
+  private benchmark: n = (
+    (* (500000 // time to run) = approx bytecodes per second *)
+    (* 5000000 // (Time millisecondsToRun: [10 benchmark]) * 1000 *)
+    (* 3059000 on a Mac 8100/100 *)
+    | size flags prime k count |
+    size:: 8190.
+    1 to: n do:
+        [:iter |
+        count:: 0.
+        flags:: Array new: size withAll: true.
+        1 to: size do:
+            [:i | (flags at: i) ifTrue:
+                [prime:: i + 1.
+                k:: i + prime.
+                [k <= size] whileTrue:
+                    [flags at: k put: false.
+                    k:: k + prime].
+                count:: count + 1]]].
+    ^ count
+  )
+
+  (* Handy send-heavy benchmark *)
+  private benchFib: n = (
+    (* (result // seconds to run) = approx calls per second *)
+    (* | r t |
+      t := Time millisecondsToRun: [r := 26 benchFib].
+      (r * 1000) // t *)
+    (* 138000 on a Mac 8100/100 *)
+    ^ n < 2
+         ifTrue: [ 1 ]
+         ifFalse: [(benchFib: n - 1) + (benchFib: (n - 2)) + 1]
+  )
+
+  private tinyBenchmarks = (
+    (* Report the results of running the two tiny Squeak benchmarks.
+       ar 9/10/1999: Adjusted to run at least 1 sec to get more stable results *)
+    (* 0 tinyBenchmarks *)
+    (* On a 292 MHz G3 Mac: 23,000,000 bytecodes/sec; 980,000 sends/sec *)
+    (* On a 400 MHz PII/Win98:  18,000,000 bytecodes/sec; 1,100,000 sends/sec *)
+    (* On a 2800 MHz i7:  1,200,000,000 bytecodes/sec; 25,000,000 sends/sec *)
+    (* On a 2800 MHz i7 (CogVM):  1,700,000,000 bytecodes/sec; 260,000,000 sends/sec *)
+    | t1 t2 r n1 n2 |
+    n1:: 1.
+
+    (* [ | start = system ticks. |
+      benchmark: n1.
+      t1:: system ticks - start.
+      t1 < 1000 ] whileTrue: [ n1:: n1 * 2]. *)
+    [ t1:: Time millisecondsToRun: [ benchmark: n1 ].
+      t1 < 1000 ] whileTrue: [ n1:: n1 * 2]. (* Note: #benchmark's runtime is about O(n) *)
+
+    n2:: 28.
+    (* [ | start = system ticks. |
+      r:: benchFib: n2.
+      t2:: system ticks - start.
+      t2 < 1000 ] whileTrue: [ n2:: n2 + 1 ]. *)
+
+    [ t2:: Time millisecondsToRun: [ r:: benchFib: n2 ].
+      t2 < 1000 ] whileTrue: [ n2:: n2 + 1 ].
+
+    (* Note: #benchFib's runtime is about O(k^n),
+       where k is the golden number = (1 + 5 sqrt) / 2 = 1.618.... *)
+
+    (* ^ ((n1 * 500000 * 1000) // t1 significantDigits: 2) asStringWithCommas, ' bytecodes/sec; ',
+      ((r * 1000) // t2 significantDigits: 2) asStringWithCommas, ' sends/sec' *)
+    ^ (tbFormat: ((n1 * 500000 * 1000) / t1)) + ' bytecodes/sec; ' +
+      (tbFormat: ((r * 1000) / t2)) + ' sends/sec'
+  )
+
+  private tbFormat: num = (
+    | nZeros val trailing prev |
+    prev:: 0.
+    val:: num.
+    nZeros:: -1.
+    [ val > 10 ] whileTrue: [
+      prev:: val % 10.
+      val:: val / 10.
+      nZeros:: nZeros + 1 ].
+
+    trailing:: ''.
+    1 to: nZeros do: [:i |
+      trailing:: '0' + trailing.
+      i % 3 = 0 ifTrue: [ trailing:: ',' + trailing. ] ].
+
+    trailing:: prev asString + trailing.
+    nZeros + 1 % 3 = 0 ifTrue: [ trailing:: ',' + trailing ].
+    ^ val asString + trailing.
+  )
+
+  public main: args = (
+    | num = (args at: 2) asInteger. |
+    'Running Classic #tinyBenchmarks' println.
+    ('' + num + ' times') println.
+
+    num timesRepeat: [
+      tinyBenchmarks println ].
+
+    ^ 0
+  )
+)


### PR DESCRIPTION
This adds the classic `#tinyBenchmarks` known from Smalltalks.

Run as $ ./som core-lib/Benchmarks/TinyBenchmarks.ns 20
