### PR TITLE
Simplify setup and use of Graal, and JDK 9 Support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,22 +16,22 @@ build_and_test_job:
   stage: build-and-test
   tags: [benchmarks, infinity]
   script:
-    - ant checkstyle
-    - ant eclipseformat-check
-    - timeout 5m ant unit-tests som-tests
+    - ant -Dskip.graal=true checkstyle
+    - ant -Dskip.graal=true eclipseformat-check
+    - timeout 5m ant -Dskip.graal=true unit-tests som-tests
 
 kompos_and_dym_tests:
   stage: full-test
   tags: [benchmarks, infinity]
   script:
-    - ant jacoco-lib compile dynamic-metrics-tests superinstructions-tests
+    - ant -Dskip.graal=true jacoco-lib compile dynamic-metrics-tests superinstructions-tests
     - cd tools/kompos && npm install . && npm -s run verify && npm test
 
 replay_tests:
   stage: full-test
   tags: [benchmarks, infinity]
   script:
-    - timeout 10m ant replay-tests
+    - timeout 10m ant -Dskip.graal=true replay-tests
 
 
 benchmark_savina_job:
@@ -39,7 +39,7 @@ benchmark_savina_job:
   tags: [benchmarks, infinity]
   allow_failure: true
   script:
-    - ant compile
+    - ant -Dskip.graal=true compile
     - export EXP=`if [[ "$CI_BUILD_REF_NAME" = "master" ]]; then echo "SOMns-Savina"; else echo "SOMns-Savina-exp"; fi`; rebench -d --without-nice -c --commit-id="$CI_BUILD_REF" --environment="Infinity Ubuntu" --project=SOMns-Savina --branch=master codespeed.conf $EXP
 
 benchmark_job:
@@ -47,7 +47,7 @@ benchmark_job:
   tags: [benchmarks, infinity]
   allow_failure: true
   script:
-    - ant compile
+    - ant -Dskip.graal=true compile
     - export EXP=`if [[ "$CI_BUILD_REF_NAME" = "master" ]]; then echo "SOMns"; else echo "SOMns-exp"; fi`; rebench -d --without-nice -c --commit-id="$CI_BUILD_REF" --environment="Infinity Ubuntu" --project=SOMns --branch=master codespeed.conf $EXP
 
 benchmark_interp_job:
@@ -55,7 +55,7 @@ benchmark_interp_job:
   tags: [benchmarks, infinity]
   allow_failure: true
   script:
-    - ant compile
+    - ant -Dskip.graal=true compile
     - export EXP=`if [[ "$CI_BUILD_REF_NAME" = "master" ]]; then echo "SOMns-interp"; else echo "SOMns-interp-exp"; fi`; rebench -d --without-nice -c --commit-id="$CI_BUILD_REF" --environment="Infinity Ubuntu" --project=SOMns --branch=master codespeed.conf $EXP
 
 benchmark_nightly_job:
@@ -65,6 +65,6 @@ benchmark_nightly_job:
   only:
     - triggers
   script:
-    - ant compile
+    - ant -Dskip.graal=true compile
     - rebench -d --without-nice -c --commit-id="$CI_BUILD_REF" --environment="Infinity Ubuntu" --project=SOMns --branch=master codespeed.conf nightly
     - rebench -d --without-nice -c --commit-id="$CI_BUILD_REF" --environment="Infinity Ubuntu" --project=SOMns --branch=master codespeed.conf SOMns-Savina-tracing

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,24 @@ matrix:
     - env: TASK=kompos-tests
     - env: TASK=replay1-tests
     - env: TASK=replay2-tests
+
+    - os:   linux
+      dist: trusty
+      jdk:  oraclejdk9
+      env:  TASK=unit-tests
+
+    - os: osx
+      osx_image: xcode9.2
+      language: generic
+      env:  TASK=unit-tests
+
   allow_failures:
     - env: TASK=replay1-tests
     - env: TASK=replay2-tests
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap caskroom/versions; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask reinstall java && brew install ant; export JAVA_HOME=`/usr/libexec/java_home`; fi
 
 install: |
   if [ "$TASK" = "checkstyle" ]
@@ -32,10 +47,12 @@ install: |
     tar -C ${TRAVIS_BUILD_DIR}/.. -xzf ${ECLIPSE_TAR}
     export ECLIPSE_EXE=${TRAVIS_BUILD_DIR}/../eclipse/eclipse
   fi
+  export SG=-Dskip.graal=true
 
 script:
-  - if [ "$TASK" = "core-tests" ]; then ant core-tests && ant coverage; fi
-  - if [ "$TASK" = "checkstyle" ]; then ant checkstyle && ant eclipseformat-check && cd tools/kompos && nvm install 7 && npm install && npm run lint; fi
-  - if [ "$TASK" = "kompos-tests" ]; then nvm install 8 && ant && cd tools/kompos && npm -s run verify && npm test; fi
-  - if [ "$TASK" = "replay1-tests" ]; then ant compile && ./tests/replay/test.sh 1; fi
-  - if [ "$TASK" = "replay2-tests" ]; then ant compile && ./tests/replay/test.sh 2; fi
+  - if [ "$TASK" = "core-tests"    ]; then ant $SG core-tests    && ant $SG coverage; fi
+  - if [ "$TASK" = "checkstyle"    ]; then ant $SG checkstyle    && ant $SG eclipseformat-check && cd tools/kompos && nvm install 7 && npm install && npm run lint; fi
+  - if [ "$TASK" = "kompos-tests"  ]; then nvm install 8         && ant $SG && cd tools/kompos && npm -s run verify && npm test; fi
+  - if [ "$TASK" = "replay1-tests" ]; then ant $SG compile       && ./tests/replay/test.sh 1; fi
+  - if [ "$TASK" = "replay2-tests" ]; then ant $SG compile       && ./tests/replay/test.sh 2; fi
+  - if [ "$TASK" = "unit-tests"    ]; then ant compile           && ./som core-lib/TestSuite/TestRunner.ns; fi

--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@ SOMns - A Simple Newspeak Implementation
 Introduction
 ------------
 
-Newspeak is a dynamic, class-based, purely object-oriented language in the
+Newspeak is a dynamic, class-based, object-oriented language in the
 tradition of Smalltalk and Self. SOMns is an implementation of the [Newspeak
-Specification Version 0.0.95][spec] derived from the [SOM][SOM](Simple Object
-Machine) class libraries, and based on the [TruffleSOM][TSOM]. Thus, SOMns is
+Specification Version 0.0.95][spec] derived from the [SOM][SOM] (Simple Object
+Machine) class libraries, and based on [TruffleSOM][TSOM]. It is
 implemented using the [Truffle framework][T] and runs on the JVM platform.
+
+Truffle provides just-in-time compilation based on the Graal compiler,
+which enables SOMns to reach [performance that is on par][AWFY] with
+state-of-the-art VMs for dynamic languages, including V8.
 
 A simple Hello World program looks like:
 
@@ -21,32 +25,11 @@ class Hello usingPlatform: platform = (
 )
 ```
 
-Implementation and Deviations from the Specification
-----------------------------------------------------
-
-SOMns is implemented as [self-optimizing AST interpreter][SOAI] using the
-Truffle framework. Thus, it can utilize the Truffle support for just-in-time
-compilation to optimize the execution performance at runtime. It is completely
-file-based and does not have support for images. The parser is written in Java
-and creates a custom AST that is geared towards representing the executable
-semantics.
-
-The overall goal is to be compliant with the specification, but include only
-absolutely necessary features. The current list of intended deviations from
-the specifications are as follows:
-
- - the mixin support of slots is not yet complete, see deactivate tests in core-lib/TestSuite/MixinTests.ns
-
- - simultaneous slots clauses are not fully supported (spec. 6.3.2)
-
- - object literals currently require a keyword prefix `objL`, to work around
-   parser limitations
-
 Obtaining and Running SOMns
 ---------------------------
 
-This is a brief guide, a more comprehensive overview for users or developers is
-available in the `docs` folder and on [ReadTheDocs](http://somns.readthedocs.io/en/dev/).
+The basic requirements for SOMns are a system with Java 9 or later, git, ant,
+and Python. Windows is currently not supported, but we test on Linux and macOS.
 
 To checkout the code:
 
@@ -60,69 +43,66 @@ Afterwards, the simple Hello World program is executed with:
 
     ./som core-lib/Hello.ns
 
-Information on previous authors are included in the AUTHORS file. This code is
-distributed under the MIT License. Please see the LICENSE file for details.
+To get an impression of the benefit o
+
+For testing on the command line, the full command is
+`./som core-lib/Benchmarks/Harness.ns Mandelbrot 500 0 500`
+
+Additionally, there are JUnit tests and `ant test` for executing the test suite.
+
+
+A more comprehensive setup guide is available in the `docs` folder and on
+[ReadTheDocs][RTD].
+
+
+Implementation and Deviations from the Specification
+----------------------------------------------------
+
+Compared to other Newspeaks and Smalltalks, it is completely file-based
+and does not have support for images.
+Instead of using customary bytecodes, SOMns is implemented as
+[self-optimizing AST interpreter][SOAI] using the Truffle framework.
+
+The overall goal is to be compliant with the specification, but include only
+absolutely necessary features. The current list of intended deviations from
+the specifications are as follows:
+
+ - the mixin support of slots is not yet complete, see deactivate tests in core-lib/TestSuite/MixinTests.ns
+
+ - simultaneous slots clauses are not fully supported (spec. 6.3.2)
+
+ - object literals currently require a keyword prefix `objL`, to work around
+   parser limitations
+
+
+License and Author Information
+------------------------------
+
+This code is distributed under the MIT License. Please see the LICENSE file for
+details. All contributions to the project are implicitly assumed to be under the
+MIT License. If this is not desired, we ask that it is stated explicitly.
+Information on previous authors are included in the AUTHORS file.
 
 Setup Development Environment with Eclipse and VS Code
 ------------------------------------------------------
 
-1. Install JDK 1.8 and Eclipse Mars (or later)
+SOMns code is best written using our VS Code plugin, which provides support
+for typical IDE features such as code navigation and compilation, as well as
+a debugger. The [SOMns][vscode] support can then be installed via the Marketplace.
 
-2. Download the project from Github
-   `git clone https://github.com/smarr/SOMns.git`
+For the development of SOMns itself, we typically use Eclipse.
+A complete guide on how to setup a workspace is available in the `docs` folder
+and on [ReadTheDocs][RTD].
 
-3. Run `ant compile` on the command line, or via Eclipse, to make sure that all
-   libraries are loaded and available.
 
-4. Create Truffle Eclipse projects with `ant ideinit`.
+Development Status
+------------------
 
-5. Import SOMns project and the Truffle projects into Eclipse
+Active development of SOMns happens on the `dev` branch [![Build Status](https://travis-ci.org/smarr/SOMns.png?branch=dev)](https://travis-ci.org/smarr/SOMns/tree/dev).
 
-6. For debugging the interpreter, create a run configuration with the
-   Mandelbrot benchmark.
-   In option Run Configurations go to Java Application/SOMns and select tab
-   arguments, enter:
+The latest release is reflected by the `master` branch [![Build Status](https://travis-ci.org/smarr/SOMns.png?branch=master)](https://travis-ci.org/smarr/SOMns).
 
-   In Program arguments:
-     `core-lib/Benchmarks/Harness.ns Mandelbrot 2 0 500`
-
-   In VM arguments:
-     `-ea -esa`
-
-For testing on the command line, the full command is
-`./som -G core-lib/Benchmarks/Harness.ns Mandelbrot 2 0 500`
-
-Additionally, there are JUnit tests and `ant test` for executing the test suite.
-
-To use VS Code as IDE and debugger for SOMns programs,
-it needs to be installed manually from: https://code.visualstudio.com/Download
-
-The [SOMns](https://marketplace.visualstudio.com/items?itemName=MetaConcProject.SOMns) support can then be installed via the Marketplace.
-
-### Instructions for Ubuntu
-
-```bash
-sudo add-apt-repository ppa:webupd8team/java
-curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
-sudo apt install oracle-java8-installer git ant npm nodejs
-
-git clone --recursive https://github.com/smarr/GraalBasic.git
-cd GraalBasic
-yes "n" | ./build.sh
-cd ..
-
-git clone https://github.com/smarr/SOMns.git
-cd SOMns
-ant       ## build SOMns
-ant tests ## run all tests
-
-ant ideinit ## Generate all Truffle Eclipse projects
-```
-
-Build Status
-------------
-
-The current build status is: [![Build Status](https://travis-ci.org/smarr/SOMns.png?branch=master)](https://travis-ci.org/smarr/SOMns)
+Changes and releases are documented in our [CHANGELOG.md][cl].
 
 Academic Work
 -------------
@@ -132,6 +112,8 @@ and their interactions. Here, we collect related papers:
 
  - [A Concurrency-Agnostic Protocol for Multi-Paradigm Concurrent Debugging Tools](http://stefan-marr.de/papers/dls-marr-et-al-concurrency-agnostic-protocol-for-debugging/),
    S. Marr, C. Torres Lopez, D. Aumayr, E. Gonzalez Boix, H. Mössenböck; Dynamic Language Symposium'17.
+
+ - [Few Versatile vs. Many Specialized Collections: How to design a collection library for exploratory programming?](http://stefan-marr.de/papers/px-marr-daloze-few-versatile-vs-many-specialized-collections/) S. Marr, B. Daloze ; Programming Experience Workshop, PX/18.
 
  - [Kómpos: A Platform for Debugging Complex Concurrent Applications](http://stefan-marr.de/downloads/progdemo-marr-et-al-kompos-a-platform-for-debugging-complex-concurrent-applications.pdf),
    S. Marr, C. Torres Lopez, D. Aumayr, E. Gonzalez Boix, H. Mössenböck; Demonstration at the &lt;Programming&gt;'17 conference.
@@ -152,3 +134,7 @@ and their interactions. Here, we collect related papers:
  [SOAI]:http://lafo.ssw.uni-linz.ac.at/papers/2012_DLS_SelfOptimizingASTInterpreters.pdf
  [T]:   http://ssw.uni-linz.ac.at/Research/Projects/JVM/Truffle.html
  [spec]:http://bracha.org/newspeak-spec.pdf
+ [AWFY]:https://github.com/smarr/are-we-fast-yet
+ [RTD]: http://somns.readthedocs.io/en/dev/
+ [vscode]: https://marketplace.visualstudio.com/items?itemName=MetaConcProject.SOMns
+ [cl]:  https://github.com/smarr/SOMns/blob/dev/CHANGELOG.md

--- a/build.xml
+++ b/build.xml
@@ -172,7 +172,20 @@
             dest="${lib.dir}/codacy-coverage-reporter.jar" />
     </target>
 
-    <target name="compile-som" description="Compile SOMns">
+    <target name="check-java">
+      <condition property="is.java9">
+        <equals arg1="${ant.java.version}" arg2="1.9"/>
+      </condition>
+    </target>
+
+    <target name="java8-on-java9" description="Support Java 9" unless="is.java9" depends="check-java">
+      <mkdir dir="${classes.dir}" />
+      <javac includeantruntime="false" srcdir="${lib.dir}/java8" destdir="${classes.dir}" debug="true">
+        <compilerarg line="--release 8" />
+      </javac>
+    </target>
+
+    <target name="compile-som" description="Compile SOMns" depends="java8-on-java9">
         <mkdir dir="${build.dir}"/>
         <mkdir dir="${classes.dir}" />
         <mkdir dir="${src_gen.dir}" />
@@ -181,14 +194,17 @@
           <compilerarg line="-s ${src_gen.dir}" />
           <compilerarg line="-XDignore.symbol.file" />
           <compilerarg line="-Xlint:all" />
+          <compilerarg line="--release 8" />
         </javac>
         <javac includeantruntime="false" srcdir="${src_gen.dir}" destdir="${classes.dir}" debug="true">
           <classpath refid="project.classpath" />
           <compilerarg line="-s ${src_gen.dir}" />
           <compilerarg line="-Xlint:all" />
+          <compilerarg line="--release 8" />
         </javac>
         <javac includeantruntime="false" srcdir="${unit.dir}" destdir="${classes.dir}" debug="true">
           <classpath refid="project.classpath" />
+          <compilerarg line="--release 8" />
         </javac>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -1,4 +1,6 @@
 <project name="som" basedir="." default="compile-all"
+    xmlns:unless="ant:unless"
+    xmlns:if="ant:if"
     xmlns:jacoco="antlib:org.jacoco.ant">
 
     <property name="src.dir"     value="src"/>
@@ -7,6 +9,7 @@
     <property name="bd.dir"      location="${lib.dir}/black-diamonds/" />
     <property name="unit.dir"    value="tests/java" />
     <property name="kompos.dir"  value="tools/kompos" />
+    <property name="graal.dir"   location="${lib.dir}/truffle/compiler" />
     <property name="truffle.dir" location="${lib.dir}/truffle/truffle" />
     <property name="sdk.dir"     location="${lib.dir}/truffle/sdk" />
     <property name="sdk.build"   location="${sdk.dir}/mxbuild/dists" />
@@ -55,6 +58,12 @@
         <delete dir="${kompos.dir}/node_modules"/>
     </target>
 
+    <target name="check-java">
+      <condition property="is.java9" value="true" else="false">
+        <matches string="${java.version}" pattern="^9\."/>
+      </condition>
+    </target>
+
     <target name="check-truffle-available">
         <available file="${lib.dir}/truffle/.git" property="truffle.present"/>
     </target>
@@ -64,11 +73,27 @@
       </exec>
     </target>
 
-    <target name="truffle-libs" unless="skip.libs" depends="truffle">
+    <target name="truffle-libs" unless="skip.libs" depends="truffle,build-graal">
         <exec executable="${mx.cmd}" dir="${truffle.dir}" failonerror="true">
             <arg value="build"/>
             <arg value="--no-native"/>
         </exec>
+    </target>
+
+    <target name="build-graal" description="Build the embedded Graal" unless="skip.graal" depends="check-java">
+      <echo unless:true="${is.java9}" level="warning">
+          The used JDK needs to have JVMCI support, which is the case for Java 9.
+          If Java 8 is needed, see
+          http://www.oracle.com/technetwork/oracle-labs/program-languages/downloads/index.html
+          for a JVMCI JDK Download.
+      </echo>
+      
+      <exec executable="${mx.cmd}" dir="${graal.dir}" failonerror="true">
+        <arg value="build" />
+      </exec>
+      <exec executable="${mx.cmd}" dir="${sdk.dir}" failonerror="true">
+        <arg value="build" />
+      </exec>
     </target>
 
     <target name="bd-libs"> <!-- implicit dependency on truffle-libs -->
@@ -172,13 +197,7 @@
             dest="${lib.dir}/codacy-coverage-reporter.jar" />
     </target>
 
-    <target name="check-java">
-      <condition property="is.java9">
-        <equals arg1="${ant.java.version}" arg2="1.9"/>
-      </condition>
-    </target>
-
-    <target name="java8-on-java9" description="Support Java 9" unless="is.java9" depends="check-java">
+    <target name="java8-on-java9" description="Support Java 9" if="${is.java9}" depends="check-java">
       <mkdir dir="${classes.dir}" />
       <javac includeantruntime="false" srcdir="${lib.dir}/java8" destdir="${classes.dir}" debug="true">
         <compilerarg line="--release 8" />
@@ -194,17 +213,17 @@
           <compilerarg line="-s ${src_gen.dir}" />
           <compilerarg line="-XDignore.symbol.file" />
           <compilerarg line="-Xlint:all" />
-          <compilerarg line="--release 8" />
+          <compilerarg line="--release 8" if:true="${is.java9}" />
         </javac>
         <javac includeantruntime="false" srcdir="${src_gen.dir}" destdir="${classes.dir}" debug="true">
           <classpath refid="project.classpath" />
           <compilerarg line="-s ${src_gen.dir}" />
           <compilerarg line="-Xlint:all" />
-          <compilerarg line="--release 8" />
+          <compilerarg line="--release 8" if:true="${is.java9}" />
         </javac>
         <javac includeantruntime="false" srcdir="${unit.dir}" destdir="${classes.dir}" debug="true">
           <classpath refid="project.classpath" />
-          <compilerarg line="--release 8" />
+          <compilerarg line="--release 8" if:true="${is.java9}" />
         </javac>
     </target>
 

--- a/codespeed.conf
+++ b/codespeed.conf
@@ -576,7 +576,7 @@ virtual_machines:
     SOMns-graal:
         path: .
         binary: som
-        args: "-t1 "
+        args: "-t1 -EG "
     # without restricting the number of actor threads
     SOMns-interp-tn:
         path: .
@@ -586,7 +586,7 @@ virtual_machines:
     SOMns-graal-tn:
         path: .
         binary: som
-        args: " "
+        args: "-EG "
     SOMns-interp-exp:
         path: .
         binary: som
@@ -594,7 +594,7 @@ virtual_machines:
     SOMns-graal-exp:
         path: .
         binary: som
-        args: "-t1 "
+        args: "-t1 -EG "
 
     # with actor tracing
     SOMns-interp-at:
@@ -626,27 +626,27 @@ virtual_machines:
     SOMns-graal-at:
         path: .
         binary: som
-        args: "-at -TF "
+        args: "-at -TF -EG "
 
     SOMns-graal-at-mt:
         path: .
         binary: som
-        args: "-at -TF -atcfg=mp:pc "
+        args: "-at -TF -EG -atcfg=mp:pc "
 
     SOMns-graal-at-mp:
         path: .
         binary: som
-        args: "-at -TF -atcfg=mt:pc "
+        args: "-at -TF -EG -atcfg=mt:pc "
 
     SOMns-graal-at-pc:
         path: .
         binary: som
-        args: "-at -TF -atcfg=mt:mp "
+        args: "-at -TF -EG -atcfg=mt:mp "
 
     SOMns-graal-at-min:
         path: .
         binary: som
-        args: "-at -TF -atcfg=mt:mp:pc "
+        args: "-at -TF -EG -atcfg=mt:mp:pc "
 
 # define the benchmarks to be executed for a re-executable benchmark run
 experiments:

--- a/docs/basic-setup.md
+++ b/docs/basic-setup.md
@@ -4,25 +4,41 @@ A brief overview for a basic development setup for SOMns.
 
 ## Minimal Software Requirements
 
-SOMns is implemented in Java 8, uses Ant as a build system, git as
+SOMns requires Java 9, uses Ant as a build system, git as
 source control system, and Python for a launcher script.
+
+We test SOMns on Linux and macOS. Windows is not currently supported.
 
 On Ubuntu, the following instructions will install the necessary dependencies:
 
 ```bash
 sudo add-apt-repository ppa:webupd8team/java
-sudo apt install oracle-java8-installer git ant
+sudo apt install oracle-java9-installer git ant
 ```
+
+On macOS, the relevant dependencies can be installed, for instance with
+[Homebrew](https://brew.sh/):
+
+```bash
+brew tap caskroom/versions
+brew cask install java
+brew install ant
+export JAVA_HOME=`/usr/libexec/java_home`
+```
+
+MacPorts or other Linux package manager should allow the installation of
+dependencies with similar instructions.
+
 
 ## Getting the Code and Running Hello World
 
-To checkout the code:
+After the dependencies are installed, the code can be checked out with:
 
 ```bash
 git clone https://github.com/smarr/SOMns.git
 ```
 
-Then, SOMns can be build with Ant:
+Then, SOMns can be built with Ant:
 
 ```bash
 cd SOMns
@@ -32,5 +48,5 @@ ant compile  ## will also download dependencies
 Afterwards, the simple Hello World program is executed with:
 
 ```bash
-./som -G core-lib/Hello.ns
+./som core-lib/Hello.ns
 ```

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,37 +1,33 @@
 # A Complete Development Setup
 
 The [Basic User Setup](basic-setup) gives a brief set of instructions to be able
-to run SOMns programs. However, it does not include the setup of Graal to enable
-just-in-time compilation, and Node.js to work on the Kompos Web Debugger.
-
-For these two, we need to install additional dependencies.
-Specifically, we need:
-
- - the GraalBasic setup
- - Node.js
+to run SOMns programs. However, it does not include the setup of Node.js,
+which is needed for the Kómpos Web Debugger.
 
 On Ubuntu, the necessary software can be installed with:
 
 ```bash
-## First, installing Node.js and the Node Package Manager (NPM)
+## First, register the Node.js package repository
 curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash -
 sudo apt install npm nodejs
-
-## Second, installing and compiling the Graal JIT Compiler
-cd .. ## leaving the SOMns folder
-git clone --recursive https://github.com/smarr/GraalBasic.git
-cd GraalBasic
-yes "n" | ./build.sh
-cd ../SOMns
-ant ## to ensure everything is compiled
 ```
 
-At this point, it should be possible to use Graal to run SOMns by dropping the
-`-G` option from the command line:
+With Homebrew, it can be installed with:
 
 ```bash
-./som core-lib/Hello.ns
+brew install node
 ```
+
+With this being completed, the default target of Ant should complete
+successfully:
+
+```bash
+ant
+```
+
+This will compile SOMns, but also the Kómpos Web Debugger, which can also be
+compiled by invoking the target directly: `ant kompos`
+
 
 <figure style="float: right; margin-right: -100px">
 <img style="width: 200px;" src="../eclipse-project-outline.png" alt="Eclipse Project outline" />
@@ -40,7 +36,7 @@ Eclipse Project outline.
 </figcaption>
 </figure>
 
-## Eclipse to Develop the Interpreter
+## Using Eclipse to Develop the Interpreter
 
 SOMns is currently developed with Eclipse. While other Java IDEs can also be
 used, for brevity, we'll focus on Eclipse only.
@@ -88,8 +84,8 @@ in Eclipse. After starting SOMns, it should tell you that it is waiting on port
 
 A brief list of steps:
 
-1. Install software dependencies: ant, git, Java 8, Eclipse 4.6 (or later),
-   VS Code 1.8 (or later), Node.js, NPM, Graal JIT compiler
+1. Install software dependencies: Ant, git, Java 9, Eclipse 4.6 (or later),
+   VS Code 1.21 (or later), Node.js, NPM, Graal JIT compiler
 
 2. Create Truffle Eclipse projects: `ant ideinit`
 

--- a/libs/java8/Unsafe.java
+++ b/libs/java8/Unsafe.java
@@ -1,0 +1,25 @@
+package sun.misc;
+
+import java.lang.reflect.Field;
+
+
+// Hack to compile on Java 9 with `--release 8`
+public final class Unsafe {
+  public static Unsafe getUnsafe() {
+    return null;
+  }
+
+  public native long objectFieldOffset(Field f);
+
+  public native Object getObject(Object o, long offset);
+
+  public native void putObject(Object o, long offset, Object value);
+
+  public native long getLong(Object o, long offset);
+
+  public native void putLong(Object o, long offset, long value);
+
+  public native double getDouble(Object o, long offset);
+
+  public native void putDouble(Object o, long offset, double value);
+}

--- a/som
+++ b/som
@@ -5,6 +5,8 @@ import os
 import shlex
 
 BASE_DIR    = os.path.dirname(os.path.realpath(__file__))
+TRUFFLE_DIR = BASE_DIR + '/libs/truffle'
+JAVA_HOME   = os.getenv('JAVA_HOME',  None)
 JVMCI_BIN   = os.getenv('JVMCI_BIN',  None)
 GRAAL_HOME  = os.getenv('GRAAL_HOME',  None)
 GRAAL_FLAGS = os.getenv('GRAAL_FLAGS', None)
@@ -12,6 +14,9 @@ GRAAL_FLAGS = os.getenv('GRAAL_FLAGS', None)
 GRAAL_LOCATIONS = ['~/.local/graal-core/',
                    BASE_DIR + '/../graal/graal-jvmci-8']
 
+##
+## Defining Argument Parsing
+##
 parser = argparse.ArgumentParser(
     description='Helper script to run SOMns with/without Graal')
 
@@ -96,6 +101,8 @@ parser.add_argument('-C', '--no-compilation', help='disable Truffle compilation'
                     dest='no_compilation', action='store_true', default=False)
 parser.add_argument('-G', '--interpreter', help='run without Graal',
                     dest='interpreter', action='store_true', default=False)
+parser.add_argument('-EG', '--no-embedded-graal', help='run without the embedded Graal',
+                    dest='embedded_graal', action='store_false', default=True)
 parser.add_argument('-X', '--java-interpreter', help='run without Graal, and only the Java interpreter',
                     dest='java_interpreter', action='store_true', default=False)
 parser.add_argument('-T', '--no-trace', help='do not print truffle compilation info',
@@ -126,8 +133,6 @@ if len(sys.argv) < 2:
 
 args = parser.parse_args()
 
-JAVA_ARGS = ['-d64', '-server']
-
 if args.dynamic_metrics:
     args.interpreter = True
 
@@ -135,7 +140,12 @@ if args.java_interpreter:
     args.interpreter = True
 
 graal_home = GRAAL_HOME
-java_bin = JVMCI_BIN
+java_bin = None
+
+if JAVA_HOME:
+  java_bin = JAVA_HOME + '/bin/java'
+if JVMCI_BIN:
+  java_bin = JVMCI_BIN
 
 if not java_bin:
   if not graal_home:
@@ -156,22 +166,60 @@ if java_bin is graal_home or not os.path.isfile(java_bin):
     print "No compatible JDK found. Please set the GRAAL_HOME or JVMCI_BIN environment variables."
     sys.exit(1)
 
-BOOT_CLASSPATH = ('-Xbootclasspath/a:'
-             + BASE_DIR + '/build/classes:'
-             + BASE_DIR + '/libs/black-diamonds/build/classes:'
-             + BASE_DIR + '/libs/truffle/sdk/mxbuild/dists/graal-sdk.jar:'
-             + BASE_DIR + '/libs/truffle/truffle/mxbuild/dists/truffle-api.jar:'
-             + BASE_DIR + '/libs/truffle/truffle/mxbuild/dists/truffle-debug.jar:'
-             + BASE_DIR + '/libs/somns-deps.jar')
+JAVA_MAJOR_VERSION = None
+try:
+  j_ver_str = os.popen(java_bin + " -version 2>&1").read()
+  j_arr = j_ver_str.split("\"")
+  if j_arr[1].startswith("1.8"):
+    JAVA_MAJOR_VERSION = 8
+  else:
+    JAVA_MAJOR_VERSION = int(j_arr[1].split(".")[0])
+except:
+  pass
 
-SOM_ARGS = [BOOT_CLASSPATH,
-            '-Dbd.settings=som.vm.VmSettings', 'som.VM',
+##
+## Defining Necessary Parameter Bits
+##
+
+CLASSPATH = (BASE_DIR + '/build/classes:'
+           + BASE_DIR + '/libs/black-diamonds/build/classes:'
+           + TRUFFLE_DIR + '/truffle/mxbuild/dists/truffle-debug.jar:'
+           + BASE_DIR + '/libs/somns-deps.jar')
+
+BOOT_CLASSPATH = ('-Xbootclasspath/a:'
+             + TRUFFLE_DIR + '/sdk/mxbuild/dists/graal-sdk.jar:'
+             + TRUFFLE_DIR + '/truffle/mxbuild/dists/truffle-api.jar')
+
+GRAAL_JAVA_8_FLAGS = ['-Djvmci.Compiler=graal',
+  '-Djvmci.class.path.append=' + TRUFFLE_DIR + '/compiler/mxbuild/dists/graal.jar']
+
+GRAAL_JAVA_9_FLAGS = [
+  '--module-path=' + TRUFFLE_DIR + '/sdk/mxbuild/modules/org.graalvm.graal_sdk.jar:' +
+       TRUFFLE_DIR + '/truffle/mxbuild/modules/com.oracle.truffle.truffle_api.jar',
+  '--upgrade-module-path=' + TRUFFLE_DIR + '/compiler/mxbuild/modules/jdk.internal.vm.compiler.jar']
+
+SOM_ARGS = ['-Dbd.settings=som.vm.VmSettings', 'som.VM',
             '--platform', args.som_platform, '--kernel', args.som_kernel]
 
 # == Compiler Settings
 TWEAK_INLINING = ['-Dgraal.TruffleCompilationThreshold=191',
                   '-Dgraal.TruffleInliningMaxCallerSize=10000',
                   '-Dgraal.TruffleSplittingMaxCalleeSize=100000']
+
+GRAAL_JVMCI_FLAGS = ['-XX:+UnlockExperimentalVMOptions', '-XX:+EnableJVMCI', '-XX:-UseJVMCICompiler']
+
+JAVA_ARGS = ['-server']
+
+if JAVA_MAJOR_VERSION == 8:
+  JAVA_ARGS += ['-d64']
+  GRAAL_EMBEDDED_FLAGS = GRAAL_JAVA_8_FLAGS
+
+if JAVA_MAJOR_VERSION > 8:
+  GRAAL_EMBEDDED_FLAGS = GRAAL_JAVA_9_FLAGS
+
+##
+## Processing Parameters and Assembling Command Line
+##
 
 if not args.interpreter and GRAAL_FLAGS:
     flags = shlex.split(str.strip(GRAAL_FLAGS))
@@ -181,8 +229,9 @@ else:
 if args.interpreter:
     flags += ['-Dtruffle.TruffleRuntime=com.oracle.truffle.api.impl.DefaultTruffleRuntime']
 else:
-    flags += ['-server', '-XX:+UnlockExperimentalVMOptions', '-XX:+EnableJVMCI',
-              '-Djvmci.Compiler=graal', '-XX:-UseJVMCICompiler']
+  flags += GRAAL_JVMCI_FLAGS
+  if args.embedded_graal:
+    flags += GRAAL_EMBEDDED_FLAGS
 
 if args.som_dnu:
     flags += ['-Dsom.printStackTraceOnDNU=true']
@@ -316,7 +365,7 @@ if args.java_args:
 
 flags += ['-Dsom.tools=' + BASE_DIR + '/tools']
 
-all_args = JAVA_ARGS + flags + SOM_ARGS + args.args
+all_args = JAVA_ARGS + ['-classpath', CLASSPATH] + [BOOT_CLASSPATH] + flags + SOM_ARGS + args.args
 
 if args.verbose:
     print "CMD: " + java_bin + ' ' + ' '.join(all_args)

--- a/src/som/compiler/MethodBuilder.java
+++ b/src/som/compiler/MethodBuilder.java
@@ -34,7 +34,6 @@ import java.util.List;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.source.SourceSection;
-import com.sun.istack.internal.NotNull;
 
 import som.compiler.MixinBuilder.MixinDefinitionError;
 import som.compiler.MixinBuilder.MixinDefinitionId;
@@ -504,14 +503,14 @@ public final class MethodBuilder {
     return (Argument) getVariable(Symbols.SELF);
   }
 
-  public ExpressionNode getSuperReadNode(@NotNull final SourceSection source) {
+  public ExpressionNode getSuperReadNode(final SourceSection source) {
     assert source != null;
     MixinBuilder holder = getEnclosingMixinBuilder();
     return getSelf().getSuperReadNode(getOuterSelfContextLevel(),
         holder.getMixinId(), holder.isClassSide(), source);
   }
 
-  public ExpressionNode getSelfRead(@NotNull final SourceSection source) {
+  public ExpressionNode getSelfRead(final SourceSection source) {
     assert source != null;
     MixinBuilder holder = getEnclosingMixinBuilder();
     MixinDefinitionId mixinId = holder == null ? null : holder.getMixinId();

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -16,7 +16,6 @@ import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
-import com.sun.istack.internal.Nullable;
 
 import som.VM;
 import som.compiler.MixinBuilder.MixinDefinitionId;
@@ -85,7 +84,7 @@ public final class MixinDefinition {
   private final boolean outerScopeIsImmutable;
   private final boolean isModule;
 
-  @Nullable private final LinkedHashMap<SSymbol, MixinDefinition> nestedMixinDefinitions;
+  private final LinkedHashMap<SSymbol, MixinDefinition> nestedMixinDefinitions;
 
   public MixinDefinition(final SSymbol name, final SourceSection nameSection,
       final SSymbol primaryFactoryName,

--- a/src/som/interpreter/actors/SPromise.java
+++ b/src/som/interpreter/actors/SPromise.java
@@ -6,7 +6,6 @@ import java.util.concurrent.ForkJoinPool;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.source.SourceSection;
-import com.sun.istack.internal.NotNull;
 
 import som.interpreter.actors.EventualMessage.PromiseMessage;
 import som.primitives.TimerPrim;
@@ -70,7 +69,7 @@ public class SPromise extends SObjectWithClass {
    */
   private boolean haltOnResolution;
 
-  protected SPromise(@NotNull final Actor owner, final boolean haltOnResolver,
+  protected SPromise(final Actor owner, final boolean haltOnResolver,
       final boolean haltOnResolution) {
     super(promiseClass, promiseClass.getInstanceFactory());
     assert owner != null;
@@ -175,7 +174,7 @@ public class SPromise extends SObjectWithClass {
     msg.getTarget().send(msg, actorPool);
   }
 
-  public final synchronized void addChainedPromise(@NotNull final SPromise remote) {
+  public final synchronized void addChainedPromise(final SPromise remote) {
     assert remote != null;
     remote.resolutionState = Resolution.CHAINED;
     if (chainedPromise == null) {

--- a/src/tools/dym/profiles/OperationProfile.java
+++ b/src/tools/dym/profiles/OperationProfile.java
@@ -8,7 +8,6 @@ import java.util.Set;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.source.SourceSection;
-import com.sun.istack.internal.NotNull;
 
 
 public final class OperationProfile extends Counter {
@@ -19,9 +18,8 @@ public final class OperationProfile extends Counter {
   protected final int                     numArgsAndResult;
   protected final Map<Arguments, Integer> argumentTypes;
 
-  public OperationProfile(final SourceSection source,
-      @NotNull final String operation, final Set<Class<?>> tags,
-      final int numArgsAndResult) {
+  public OperationProfile(final SourceSection source, final String operation,
+      final Set<Class<?>> tags, final int numArgsAndResult) {
     super(source);
     this.numArgsAndResult = numArgsAndResult;
     this.operation = operation;


### PR DESCRIPTION
Currently, all documentation and the setup is advising people to use [GraalBasic](https://github.com/smarr/GraalBasic), which requires to compile a JVMCI-enabled HotSpot. (JVMCI is the Java Virtual Machine Compiler Interface, which enables the use of Graal)

The main reason for this setup is that it simplifies CI, and allows us to change Graal somewhat independently from the Truffle used by SOMns. This is important to be able to attribute performance changes correctly to the Graal compiler or something else.

Another reason is historical: Graal and Truffle used to be part of separate repositories.
However, now with Graal and Truffle being part of the same repo, we have the situation that SOMns always comes with its own Graal, which we do not actually use.

It seems also too complicated to build HotSpot  for many users.
Thus it would be desirable to avoid this extra hurdle and allow them to use prebuilt binaries.

### Options for how to use Graal

There are a two different options we could take here, and I'd like to hear your opinion: @daumayr @richard-roberts.

#### 1. keep using Graal external to SOMns as default

  **pro:** 
   - not much changes needed, the attached patch does just that. It adds an option to use the embedded Graal with an extra flag
   - can freely update Graal independently of Truffle (more predictable performance on CI, because we know when we change the compiler)

  **con:** it does not make it easier for people to use Graal

#### 2. use the embedded Graal per default
  **pro:** avoids having the Graal source externally, avoids mismatch issues
  **con:** means we either need an option to use external Graal, or bind ourselves to the Graal version of Truffle

~~Even with the support of using the embedded Graal, one hurdle for users is still the need for a JVMCI-enabled Java 8/HotSpot. In the long term, this is going to be fixed by supporting >Java 9.~~

~~In the mean time, it means people need to either compile HotSpot themselves, they need to download it from Oracle Labs, and accept their license, or we need to start building and hosting binaries ourselves. The later is not too complicated, and we could do an automatic download of the right binary depending on the operating system to shield the user somewhat from it.
@richard-roberts was also thinking of improving distribution issues more generally.
But, there remains work to be done.~~

### Java 9 Support

The most recent patch in this PR introduces support to build SOMns on JDK 9.
We do not have full Java 9 support, which would require more work, which currently is not very useful because of a [performance bug in Java](https://bugs.openjdk.java.net/browse/JDK-8189747).
However, with the ability to build on JDK 9, we can advise all users to simply use Java 9, which avoids any separate compilation of HotSpot.

Think this is the best way forward. We use the embedded Graal by default and add support for fallbacks. Note that all testing is still done on Java 8, and only basic functionality is tested on Java 9.