### PR TITLE
Fix outer traversal to use lexical chain

### DIFF
--- a/core-lib/TestSuite/LanguageTests.ns
+++ b/core-lib/TestSuite/LanguageTests.ns
@@ -901,4 +901,85 @@ class LanguageTests usingPlatform: platform testFramework: minitest = Value (
       assert: 54          equals: o operand.
     )
   ) : ( TEST_CONTEXT = () )
+
+  (* OuterLexicalTraversal tests that the traversal of outer objects
+     follows the lexical chain of outer objects, i.e., the outer
+     objects corresponding to the source code structure.
+     Note, the lexical chain can be different from the chain of outer objects
+     of the concrete classes of objects, because the concrete classes might
+     be defined in another lexical scope. *)
+  public class OuterLexicalTraversal = TestContext ()(
+
+    class TraversalTarget = ()(
+      public test = ( ^ #found )
+    )
+
+    (* Nested classes to test outer traversal *)
+    class A = (| local = #local. |)(
+      public class B = ()(
+        public class C = ()(
+          public accessTarget = (
+            ^ TraversalTarget new test
+          )
+
+          public localTarget = ( ^ local )
+        )
+      )
+    )
+
+    (* Sublclasses with different outer from their super classes *)
+    class BSubClass = getB ()()
+    class CSubClass = getC ()()
+
+    class AnotherA = A (
+    | local = #overridden.
+      public accessCnt ::= 0. |
+    )(
+      public class B = superB ()(
+        public class C = superC ()(
+          public accessTarget = (
+            accessCnt:: accessCnt + 1.
+            ^ super accessTarget
+          )
+        )
+
+        superC = ( ^ super C )
+      )
+
+      superB = ( ^ super B )
+    )
+
+    (* This time, we add another scope aroud it, at the concrete class *)
+    class OtherScope = ()(
+      public class AnotherA = A ( | local = #overridden2. | )()
+    )
+
+    (* Helper methods to have unary message to get super classes *)
+    getB = ( ^ A new B )
+    getC = ( ^ A new B new C )
+
+    public testOuterTraversalWithShorterOuterPathOnActualClass = (
+      assert: #found equals: A new B new C new accessTarget.
+      assert: #found equals: BSubClass new C new accessTarget.
+      assert: #found equals: CSubClass new accessTarget.
+
+      assert: #local equals: A new B new C new localTarget.
+      assert: #local equals: BSubClass new C new localTarget.
+      assert: #local equals: CSubClass new localTarget.
+    )
+
+    public testOuterTraversalWithOverridingOfInnerClasses = (
+      | aa = AnotherA new. |
+      assert: 0 equals: aa accessCnt.
+      assert: #found      equals: aa B new C new accessTarget.
+      assert: 1 equals: aa accessCnt.
+      assert: #overridden equals: aa B new C new localTarget.
+      assert: 1 equals: aa accessCnt.
+    )
+
+    public testOuterTraversalWithExtraOtherScope = (
+      assert: #found       equals: OtherScope new AnotherA new B new C new accessTarget.
+      assert: #overridden2 equals: OtherScope new AnotherA new B new C new localTarget.
+    )
+  ) : ( TEST_CONTEXT = () )
 )


### PR DESCRIPTION
TODO: implement fix @richard-roberts, this is currently only the test documenting the broken behavior. (because of laziness the PR still contains elements of the release preparation)

This test demonstrates that our traversal of outer objects currently
does follow the bottom of the chain of outer objects, i.e., the outer
object of the most concrete class, instead of following the lexical chain
defined by the lexical scopes.

A solution to this issue probable needs to adapt the outer object read to take the full and correct lexical chain into account.
Roughly something like this:

```java
  @ExplodeLoop
  private Object getEnclosingObject(final SClass lexicalClass) {
    int ctxLevel = contextLevel - 1; // 0 is already covered with specialization
    SObjectWithClass enclosing = lexicalClass.getEnclosingObject();

    while (ctxLevel > 0) {
      ctxLevel--;
      
      SClass cls = enclosing.getSOMClass();
      // TODO: cls = lexicalClass(cls, ctxMixinId[ctx]);
      
      enclosing = cls.getEnclosingObject();
    }
    return enclosingObj.profile(enclosing);
  }
```