### PR TITLE
Support JDK 10 and added testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,18 +25,32 @@ matrix:
       jdk:  oraclejdk9
       env:  TASK=unit-tests
 
+    - os:   linux
+      dist: trusty
+      jdk:  oraclejdk8
+      env:  TASK=unit-tests JDK=10
+      before_install: |
+        mkdir jdk10
+        cd jdk10
+        wget https://download.java.net/java/GA/jdk10/10/binaries/openjdk-10_linux-x64_bin.tar.gz
+        tar -xzf openjdk-10_linux-x64_bin.tar.gz
+        export JAVA_HOME=`pwd`/jdk-10
+        export PATH=${JAVA_HOME}/bin:$PATH
+        cd ..
+
     - os: osx
       osx_image: xcode9.2
       language: generic
       env:  TASK=unit-tests
+      before_install: |
+        brew tap caskroom/versions
+        brew cask reinstall java
+        brew install ant
+        export JAVA_HOME=`/usr/libexec/java_home`
 
   allow_failures:
     - env: TASK=replay1-tests
     - env: TASK=replay2-tests
-
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap caskroom/versions; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask reinstall java && brew install ant; export JAVA_HOME=`/usr/libexec/java_home`; fi
 
 install: |
   if [ "$TASK" = "checkstyle" ]

--- a/build.xml
+++ b/build.xml
@@ -41,6 +41,18 @@
         <pathelement location="${truffle.build}/truffle-dsl-processor.jar" />
         <pathelement location="${truffle.build}/truffle-tck.jar" />
     </path>
+    
+    <condition property="is.atLeastJava9" value="true" else="false">
+      <or>
+        <matches string="${java.version}" pattern="^9"/>
+        <matches string="${java.version}" pattern="^1[0-9]"/>
+      </or>
+    </condition>
+    <echo>
+        ant.java.version: ${ant.java.version}
+        java.version:     ${java.version}
+        is.atLeastJava9:  ${is.atLeastJava9}
+    </echo>
 
     <target name="clean" description="Remove build directories and generated code">
         <delete dir="${build.dir}"/>
@@ -59,12 +71,6 @@
         <ant dir="${bd.dir}" useNativeBasedir="true" target="clean" inheritAll="false"/>
     </target>
 
-    <target name="check-java">
-      <condition property="is.java9" value="true" else="false">
-        <matches string="${java.version}" pattern="^9\."/>
-      </condition>
-    </target>
-
     <target name="check-truffle-available">
         <available file="${lib.dir}/truffle/.git" property="truffle.present"/>
     </target>
@@ -81,8 +87,8 @@
         </exec>
     </target>
 
-    <target name="build-graal" description="Build the embedded Graal" unless="skip.graal" depends="check-java">
-      <echo unless:true="${is.java9}" level="warning">
+    <target name="build-graal" description="Build the embedded Graal" unless="skip.graal">
+      <echo unless:true="${is.atLeastJava9}" level="warning">
           The used JDK needs to have JVMCI support, which is the case for Java 9.
           If Java 8 is needed, see
           http://www.oracle.com/technetwork/oracle-labs/program-languages/downloads/index.html
@@ -98,11 +104,14 @@
     </target>
 
     <target name="bd-libs"> <!-- implicit dependency on truffle-libs -->
-        <ant dir="${bd.dir}" useNativeBasedir="true" target="libs-junit" inheritAll="false"/>
+        <ant dir="${bd.dir}" useNativeBasedir="true" target="libs-junit" inheritAll="false">
+            <property name="force.java8"   value="${is.atLeastJava9}" />
+        </ant>
         <ant dir="${bd.dir}" useNativeBasedir="true" target="compile-nodeps" inheritAll="false">
             <property name="sdk.build"   value="${sdk.build}" />
             <property name="truffle.dir" value="${truffle.dir}" />
             <property name="truffle.build" value="${truffle.build}" />
+            <property name="force.java8"   value="${is.atLeastJava9}" />
         </ant>
     </target>
 
@@ -198,7 +207,7 @@
             dest="${lib.dir}/codacy-coverage-reporter.jar" />
     </target>
 
-    <target name="java8-on-java9" description="Support Java 9" if="${is.java9}" depends="check-java">
+    <target name="java8-on-java9" description="Support Java 9 or later" if="${is.atLeastJava9}">
       <mkdir dir="${classes.dir}" />
       <javac includeantruntime="false" srcdir="${lib.dir}/java8" destdir="${classes.dir}" debug="true">
         <compilerarg line="--release 8" />
@@ -214,17 +223,17 @@
           <compilerarg line="-s ${src_gen.dir}" />
           <compilerarg line="-XDignore.symbol.file" />
           <compilerarg line="-Xlint:all" />
-          <compilerarg line="--release 8" if:true="${is.java9}" />
+          <compilerarg line="--release 8" if:true="${is.atLeastJava9}" />
         </javac>
         <javac includeantruntime="false" srcdir="${src_gen.dir}" destdir="${classes.dir}" debug="true">
           <classpath refid="project.classpath" />
           <compilerarg line="-s ${src_gen.dir}" />
           <compilerarg line="-Xlint:all" />
-          <compilerarg line="--release 8" if:true="${is.java9}" />
+          <compilerarg line="--release 8" if:true="${is.atLeastJava9}" />
         </javac>
         <javac includeantruntime="false" srcdir="${unit.dir}" destdir="${classes.dir}" debug="true">
           <classpath refid="project.classpath" />
-          <compilerarg line="--release 8" if:true="${is.java9}" />
+          <compilerarg line="--release 8" if:true="${is.atLeastJava9}" />
         </javac>
     </target>
 

--- a/docs/basic-setup.md
+++ b/docs/basic-setup.md
@@ -4,7 +4,7 @@ A brief overview for a basic development setup for SOMns.
 
 ## Minimal Software Requirements
 
-SOMns requires Java 9, uses Ant as a build system, git as
+SOMns works on Java 9 or 10, uses Ant as a build system, git as
 source control system, and Python for a launcher script.
 
 We test SOMns on Linux and macOS. Windows is not currently supported.

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -41,7 +41,7 @@ Eclipse Project outline.
 SOMns is currently developed with Eclipse. While other Java IDEs can also be
 used, for brevity, we'll focus on Eclipse only.
 
-At the time of writing, I am using [Eclipse Neon 4.6](https://eclipse.org/downloads/).
+At the time of writing, I am using [Eclipse Oxygen 4.7](https://eclipse.org/downloads/).
 Please also install the **Eclipse Checkstyle Plugin** from the [Eclipse Marketplace](http://eclipse-cs.sourceforge.net/#!/install).
 
 For development, we also need to setup all Eclipse projects:
@@ -84,7 +84,7 @@ in Eclipse. After starting SOMns, it should tell you that it is waiting on port
 
 A brief list of steps:
 
-1. Install software dependencies: Ant, git, Java 9, Eclipse 4.6 (or later),
+1. Install software dependencies: Ant, git, Java 10, Eclipse 4.7 (or later),
    VS Code 1.21 (or later), Node.js, NPM, Graal JIT compiler
 
 2. Create Truffle Eclipse projects: `ant ideinit`

--- a/src/som/primitives/ActivitySpawn.java
+++ b/src/som/primitives/ActivitySpawn.java
@@ -17,8 +17,8 @@ import som.VM;
 import som.interpreter.nodes.nary.BinaryComplexOperation.BinarySystemOperation;
 import som.interpreter.nodes.nary.TernaryExpressionNode.TernarySystemOperation;
 import som.primitives.ObjectPrims.IsValue;
+import som.primitives.arrays.ToArgumentsArrayFactory;
 import som.primitives.arrays.ToArgumentsArrayNode;
-import som.primitives.arrays.ToArgumentsArrayNodeFactory;
 import som.primitives.processes.ChannelPrimitives;
 import som.primitives.processes.ChannelPrimitives.Process;
 import som.primitives.processes.ChannelPrimitives.TracingProcess;
@@ -165,11 +165,11 @@ public abstract class ActivitySpawn {
   @NodeChild(value = "argArr", type = ToArgumentsArrayNode.class,
       executeWith = {"secondArg", "firstArg"})
   @Primitive(primitive = "threading:threadSpawn:with:",
-      extraChild = ToArgumentsArrayNodeFactory.class)
+      extraChild = ToArgumentsArrayFactory.class)
   @Primitive(primitive = "threading:taskSpawn:with:",
-      extraChild = ToArgumentsArrayNodeFactory.class)
-  @Primitive(primitive = "proc:spawn:with:", extraChild = ToArgumentsArrayNodeFactory.class)
-  @Primitive(selector = "spawn:with:", extraChild = ToArgumentsArrayNodeFactory.class)
+      extraChild = ToArgumentsArrayFactory.class)
+  @Primitive(primitive = "proc:spawn:with:", extraChild = ToArgumentsArrayFactory.class)
+  @Primitive(selector = "spawn:with:", extraChild = ToArgumentsArrayFactory.class)
   public abstract static class SpawnWithPrim extends TernarySystemOperation {
     @CompilationFinal private ForkJoinPool forkJoinPool;
     @CompilationFinal private ForkJoinPool processesPool;

--- a/src/som/primitives/MethodPrims.java
+++ b/src/som/primitives/MethodPrims.java
@@ -12,8 +12,8 @@ import som.interpreter.nodes.ExpressionNode;
 import som.interpreter.nodes.dispatch.InvokeOnCache;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
+import som.primitives.arrays.ToArgumentsArrayFactory;
 import som.primitives.arrays.ToArgumentsArrayNode;
-import som.primitives.arrays.ToArgumentsArrayNodeFactory;
 import som.vmobjects.SAbstractObject;
 import som.vmobjects.SArray;
 import som.vmobjects.SInvokable;
@@ -38,7 +38,7 @@ public final class MethodPrims {
       @NodeChild(value = "argArr", type = ToArgumentsArrayNode.class,
           executeWith = {"somArr", "target"})})
   @Primitive(selector = "invokeOn:with:", noWrapper = true,
-      extraChild = ToArgumentsArrayNodeFactory.class)
+      extraChild = ToArgumentsArrayFactory.class)
   public abstract static class InvokeOnPrim extends ExprWithTagsNode
       implements PreevaluatedExpression {
     @Child private InvokeOnCache callNode = InvokeOnCache.create();

--- a/src/som/primitives/arrays/ToArgumentsArrayFactory.java
+++ b/src/som/primitives/arrays/ToArgumentsArrayFactory.java
@@ -1,0 +1,40 @@
+package som.primitives.arrays;
+
+import java.util.List;
+
+import com.oracle.truffle.api.dsl.NodeFactory;
+import com.oracle.truffle.api.nodes.Node;
+
+
+/**
+ * This class is a work around for a JDK 10 javac issue, as discussed here:
+ * https://markmail.org/thread/v3kqlmtwfsokfaod.
+ *
+ * TODO: remove this class, and use normal factory directly
+ */
+public final class ToArgumentsArrayFactory implements NodeFactory<ToArgumentsArrayNode> {
+
+  public static NodeFactory<ToArgumentsArrayNode> getInstance() {
+    return ToArgumentsArrayNodeFactory.getInstance();
+  }
+
+  @Override
+  public ToArgumentsArrayNode createNode(final Object... arguments) {
+    throw new UnsupportedOperationException("Should never be called");
+  }
+
+  @Override
+  public Class<ToArgumentsArrayNode> getNodeClass() {
+    throw new UnsupportedOperationException("Should never be called");
+  }
+
+  @Override
+  public List<List<Class<?>>> getNodeSignatures() {
+    throw new UnsupportedOperationException("Should never be called");
+  }
+
+  @Override
+  public List<Class<? extends Node>> getExecutionSignature() {
+    throw new UnsupportedOperationException("Should never be called");
+  }
+}


### PR DESCRIPTION
This change adds support for JDK 10 in `build.xml` and works around a [JDK 10 bug](https://bugs.openjdk.java.net/browse/JDK-8200163) (we track the bug here via #241).

Because of an issue in `javac`, we need to provide a concrete `ToArgumentsArrayFactory`, which we can reference in annotations. Because of the bug, `javac` would abort before generating the actual factory.