### PR TITLE
Adopt Economic collections of GraalVM to ensure insertion order

### DIFF
--- a/src/som/compiler/MethodBuilder.java
+++ b/src/som/compiler/MethodBuilder.java
@@ -28,9 +28,9 @@ import static som.interpreter.SNodeFactory.createCatchNonLocalReturn;
 import static som.vm.Symbols.symbolFor;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
+
+import org.graalvm.collections.EconomicMap;
 
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlotKind;
@@ -82,8 +82,8 @@ public final class MethodBuilder extends ScopeBuilder<MethodScope>
   private boolean accessesVariablesOfOuterScope;
   private boolean accessesLocalOfOuterScope;
 
-  private final LinkedHashMap<SSymbol, Argument> arguments = new LinkedHashMap<>();
-  private final LinkedHashMap<SSymbol, Local>    locals    = new LinkedHashMap<>();
+  private final EconomicMap<SSymbol, Argument> arguments = EconomicMap.create();
+  private final EconomicMap<SSymbol, Local>    locals    = EconomicMap.create();
 
   private Internal frameOnStackVar;
 
@@ -138,8 +138,8 @@ public final class MethodBuilder extends ScopeBuilder<MethodScope>
     return language;
   }
 
-  public Collection<Argument> getArguments() {
-    return arguments.values();
+  public Iterable<Argument> getArguments() {
+    return arguments.getValues();
   }
 
   /**
@@ -307,12 +307,12 @@ public final class MethodBuilder extends ScopeBuilder<MethodScope>
   public void setVarsOnMethodScope() {
     Variable[] vars = new Variable[arguments.size() + locals.size()];
     int i = 0;
-    for (Argument a : arguments.values()) {
+    for (Argument a : arguments.getValues()) {
       vars[i] = a;
       i += 1;
     }
 
-    for (Local l : locals.values()) {
+    for (Local l : locals.getValues()) {
       vars[i] = l;
       i += 1;
     }
@@ -493,7 +493,7 @@ public final class MethodBuilder extends ScopeBuilder<MethodScope>
 
   @Override
   protected boolean isImmutable() {
-    for (Local l : locals.values()) {
+    for (Local l : locals.getValues()) {
       if (l.isMutable()) {
         return false;
       }

--- a/src/som/compiler/MethodBuilder.java
+++ b/src/som/compiler/MethodBuilder.java
@@ -457,10 +457,6 @@ public final class MethodBuilder extends ScopeBuilder<MethodScope>
     return 1 + outer.getContextLevel(varName);
   }
 
-  public Local getEmbeddedLocal(final String embeddedName) {
-    return locals.get(embeddedName);
-  }
-
   /**
    * A variable is either an argument or a temporary in the lexical scope
    * of methods (only in methods).

--- a/src/som/compiler/MixinBuilder.java
+++ b/src/som/compiler/MixinBuilder.java
@@ -27,10 +27,9 @@ package som.compiler;
 import static som.vm.Symbols.symbolFor;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
+
+import org.graalvm.collections.EconomicMap;
 
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -86,15 +85,14 @@ public final class MixinBuilder extends ScopeBuilder<MixinScope> {
 
   @SuppressWarnings("unused") private String mixinComment;
 
-  private final HashMap<SSymbol, SlotDefinition>     slots         = new HashMap<>();
-  private final LinkedHashMap<SSymbol, Dispatchable> dispatchables = new LinkedHashMap<>();
+  private final EconomicMap<SSymbol, SlotDefinition> slots         = EconomicMap.create();
+  private final EconomicMap<SSymbol, Dispatchable>   dispatchables = EconomicMap.create();
 
-  private final HashMap<SSymbol, SInvokable> factoryMethods =
-      new HashMap<SSymbol, SInvokable>();
+  private final EconomicMap<SSymbol, SInvokable> factoryMethods = EconomicMap.create();
 
   private boolean allSlotsAreImmutable = true;
 
-  private final LinkedHashMap<SSymbol, MixinDefinition> embeddedMixins = new LinkedHashMap<>();
+  private final EconomicMap<SSymbol, MixinDefinition> embeddedMixins = EconomicMap.create();
 
   private boolean classSide;
 
@@ -474,13 +472,13 @@ public final class MixinBuilder extends ScopeBuilder<MixinScope> {
 
   private void setHolders(final MixinDefinition clsDef) {
     assert clsDef != null;
-    for (Dispatchable disp : dispatchables.values()) {
+    for (Dispatchable disp : dispatchables.getValues()) {
       if (disp instanceof SInvokable) {
         ((SInvokable) disp).setHolder(clsDef);
       }
     }
 
-    for (SInvokable invok : factoryMethods.values()) {
+    for (SInvokable invok : factoryMethods.getValues()) {
       invok.setHolder(clsDef);
     }
   }
@@ -586,8 +584,8 @@ public final class MixinBuilder extends ScopeBuilder<MixinScope> {
   protected List<ExpressionNode> createPrimaryFactoryArgumentRead(
       final ExpressionNode objectInstantiationExpr) {
     // then, call the initializer on it
-    Collection<Argument> arguments = primaryFactoryMethod.getArguments();
-    List<ExpressionNode> args = new ArrayList<>(arguments.size());
+    Iterable<Argument> arguments = primaryFactoryMethod.getArguments();
+    List<ExpressionNode> args = new ArrayList<>();
     args.add(objectInstantiationExpr);
 
     for (Argument arg : arguments) {

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -3,10 +3,11 @@ package som.compiler;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map.Entry;
+
+import org.graalvm.collections.EconomicSet;
 
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerAsserts;
@@ -289,7 +290,7 @@ public final class MixinDefinition {
       assert mixins.length > 1;
     }
 
-    HashSet<SlotDefinition> instanceSlots = new HashSet<>();
+    EconomicSet<SlotDefinition> instanceSlots = EconomicSet.create();
     addSlots(instanceSlots, superClass);
     HashMap<SSymbol, Dispatchable> dispatchables = new HashMap<>();
 
@@ -328,7 +329,7 @@ public final class MixinDefinition {
     return classFactory;
   }
 
-  protected boolean hasOnlyImmutableFields(final HashSet<SlotDefinition> instanceSlots) {
+  protected boolean hasOnlyImmutableFields(final EconomicSet<SlotDefinition> instanceSlots) {
     if (instanceSlots == null) {
       return true;
     }
@@ -344,7 +345,7 @@ public final class MixinDefinition {
   }
 
   private boolean[] determineSlotsAndDispatchables(final Object[] mixins,
-      final HashSet<SlotDefinition> instanceSlots,
+      final EconomicSet<SlotDefinition> instanceSlots,
       final HashMap<SSymbol, Dispatchable> dispatchables) {
     boolean mixinsIncludeValue = false;
     boolean mixinsIncludeTransferObject = false;
@@ -447,13 +448,13 @@ public final class MixinDefinition {
         body, AccessModifier.PRIVATE, initializerSource);
   }
 
-  private void addSlots(final HashSet<SlotDefinition> instanceSlots,
+  private void addSlots(final EconomicSet<SlotDefinition> instanceSlots,
       final SClass clazz) {
     if (clazz == null) {
       return;
     }
 
-    HashSet<SlotDefinition> slots = clazz.getInstanceSlots();
+    EconomicSet<SlotDefinition> slots = clazz.getInstanceSlots();
     if (slots == null) {
       return;
     }

--- a/src/som/interop/InteropDispatch.java
+++ b/src/som/interop/InteropDispatch.java
@@ -1,6 +1,6 @@
 package som.interop;
 
-import java.util.Map.Entry;
+import org.graalvm.collections.MapCursor;
 
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -38,7 +38,8 @@ public abstract class InteropDispatch extends Node {
       final int numArgs) {
     Dispatchable disp = null;
     while (disp == null && cls != null) {
-      for (Entry<SSymbol, Dispatchable> e : cls.getDispatchables().entrySet()) {
+      MapCursor<SSymbol, Dispatchable> e = cls.getDispatchables().getEntries();
+      while (e.advance()) {
         SSymbol sel = e.getKey();
         if (sel.getNumberOfSignatureArguments() == numArgs &&
             sel.getString().startsWith(prefix)) {

--- a/src/som/interpreter/LexicalScope.java
+++ b/src/som/interpreter/LexicalScope.java
@@ -1,7 +1,8 @@
 package som.interpreter;
 
 import java.util.Arrays;
-import java.util.HashMap;
+
+import org.graalvm.collections.EconomicMap;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
@@ -42,7 +43,7 @@ public abstract class LexicalScope {
   // super sends. seems like we currently have two similar ways to solve
   // similar problems, instead of a single one
   public static final class MixinScope extends LexicalScope {
-    private HashMap<SSymbol, Dispatchable> slotsClassesAndMethods;
+    private EconomicMap<SSymbol, Dispatchable> slotsClassesAndMethods;
 
     @CompilationFinal private MixinDefinition mixinDefinition;
 
@@ -87,7 +88,7 @@ public abstract class LexicalScope {
       return outerScope.getMethodScope();
     }
 
-    public HashMap<SSymbol, Dispatchable> getDispatchables() {
+    public EconomicMap<SSymbol, Dispatchable> getDispatchables() {
       return slotsClassesAndMethods;
     }
 
@@ -97,8 +98,9 @@ public abstract class LexicalScope {
       mixinDefinition = def;
 
       if (classSide) {
-        HashMap<SSymbol, ? extends Dispatchable> disps = mixinDefinition.getFactoryMethods();
-        slotsClassesAndMethods = (HashMap<SSymbol, Dispatchable>) disps;
+        EconomicMap<SSymbol, ? extends Dispatchable> disps =
+            mixinDefinition.getFactoryMethods();
+        slotsClassesAndMethods = (EconomicMap<SSymbol, Dispatchable>) disps;
       } else {
         slotsClassesAndMethods = mixinDefinition.getInstanceDispatchables();
       }

--- a/src/som/interpreter/actors/TransferObject.java
+++ b/src/som/interpreter/actors/TransferObject.java
@@ -3,6 +3,11 @@ package som.interpreter.actors;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.graalvm.collections.EconomicMap;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+
 import som.compiler.MixinDefinition.SlotDefinition;
 import som.interpreter.objectstorage.ObjectLayout;
 import som.interpreter.objectstorage.StorageLocation;
@@ -15,9 +20,6 @@ import som.vmobjects.SArray.STransferArray;
 import som.vmobjects.SObject;
 import som.vmobjects.SObjectWithClass;
 import som.vmobjects.SObjectWithClass.SObjectWithoutFields;
-
-import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 
 
 public final class TransferObject {
@@ -53,7 +55,7 @@ public final class TransferObject {
     assert !obj.isValue() : "TransferObjects can't be Values";
 
     ObjectLayout layout = obj.getObjectLayout();
-    HashMap<SlotDefinition, StorageLocation> fields = layout.getStorageLocations();
+    EconomicMap<SlotDefinition, StorageLocation> fields = layout.getStorageLocations();
     SObject newObj = obj.cloneBasics();
 
     Map<SAbstractObject, SAbstractObject> transferMap =
@@ -63,7 +65,7 @@ public final class TransferObject {
         obj) : "The algorithm should not transfer an object twice.";
     transferMap.put(obj, newObj);
 
-    for (StorageLocation location : fields.values()) {
+    for (StorageLocation location : fields.getValues()) {
       if (location.isObjectLocation()) {
         Object orgObj = location.read(obj);
 

--- a/src/som/interpreter/objectstorage/ClassFactory.java
+++ b/src/som/interpreter/objectstorage/ClassFactory.java
@@ -1,7 +1,6 @@
 package som.interpreter.objectstorage;
 
-import java.util.HashMap;
-
+import org.graalvm.collections.EconomicMap;
 import org.graalvm.collections.EconomicSet;
 
 import com.oracle.truffle.api.CompilerAsserts;
@@ -49,8 +48,8 @@ public final class ClassFactory {
 
   private final MixinDefinition mixinDef;
 
-  private final EconomicSet<SlotDefinition>    instanceSlots;
-  private final HashMap<SSymbol, Dispatchable> dispatchables;
+  private final EconomicSet<SlotDefinition>        instanceSlots;
+  private final EconomicMap<SSymbol, Dispatchable> dispatchables;
 
   private final boolean hasOnlyImmutableFields;
 
@@ -60,7 +59,7 @@ public final class ClassFactory {
 
   public ClassFactory(final SSymbol name, final MixinDefinition mixinDef,
       final EconomicSet<SlotDefinition> instanceSlots,
-      final HashMap<SSymbol, Dispatchable> dispatchables,
+      final EconomicMap<SSymbol, Dispatchable> dispatchables,
       final boolean declaredAsValue,
       final boolean isTransferObject,
       final boolean isArray,

--- a/src/som/interpreter/objectstorage/ClassFactory.java
+++ b/src/som/interpreter/objectstorage/ClassFactory.java
@@ -1,7 +1,8 @@
 package som.interpreter.objectstorage;
 
 import java.util.HashMap;
-import java.util.HashSet;
+
+import org.graalvm.collections.EconomicSet;
 
 import com.oracle.truffle.api.CompilerAsserts;
 
@@ -48,7 +49,7 @@ public final class ClassFactory {
 
   private final MixinDefinition mixinDef;
 
-  private final HashSet<SlotDefinition>        instanceSlots;
+  private final EconomicSet<SlotDefinition>    instanceSlots;
   private final HashMap<SSymbol, Dispatchable> dispatchables;
 
   private final boolean hasOnlyImmutableFields;
@@ -58,7 +59,7 @@ public final class ClassFactory {
   private final ClassFactory classClassFactory;
 
   public ClassFactory(final SSymbol name, final MixinDefinition mixinDef,
-      final HashSet<SlotDefinition> instanceSlots,
+      final EconomicSet<SlotDefinition> instanceSlots,
       final HashMap<SSymbol, Dispatchable> dispatchables,
       final boolean declaredAsValue,
       final boolean isTransferObject,

--- a/src/som/primitives/MirrorPrims.java
+++ b/src/som/primitives/MirrorPrims.java
@@ -170,7 +170,7 @@ public abstract class MirrorPrims {
       MixinDefinition def = (MixinDefinition) mixinHandle;
 
       ArrayList<SInvokable> methods = new ArrayList<SInvokable>();
-      for (Dispatchable disp : def.getInstanceDispatchables().values()) {
+      for (Dispatchable disp : def.getInstanceDispatchables().getValues()) {
         if (disp instanceof SInvokable) {
           methods.add((SInvokable) disp);
         }

--- a/src/som/vm/ObjectSystem.java
+++ b/src/som/vm/ObjectSystem.java
@@ -4,11 +4,10 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+
+import org.graalvm.collections.EconomicMap;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
@@ -46,7 +45,7 @@ import tools.language.StructuralProbe;
 
 public final class ObjectSystem {
 
-  private final Map<URI, MixinDefinition> loadedModules;
+  private final EconomicMap<URI, MixinDefinition> loadedModules;
 
   @CompilationFinal private MixinDefinition platformModule;
   @CompilationFinal private MixinDefinition kernelModule;
@@ -74,7 +73,7 @@ public final class ObjectSystem {
         Primitives.getInlinableNodes(), Primitives.getInlinableFactories());
     this.compiler = compiler;
     structuralProbe = probe;
-    loadedModules = new LinkedHashMap<>();
+    loadedModules = EconomicMap.create();
     this.vm = vm;
   }
 
@@ -134,7 +133,7 @@ public final class ObjectSystem {
   }
 
   private SObjectWithoutFields constructVmMirror() {
-    HashMap<SSymbol, Dispatchable> vmMirrorMethods = primitives.takeVmMirrorPrimitives();
+    EconomicMap<SSymbol, Dispatchable> vmMirrorMethods = primitives.takeVmMirrorPrimitives();
     MixinScope scope = new MixinScope(null);
 
     MixinDefinition vmMirrorDef = new MixinDefinition(

--- a/src/som/vm/Primitives.java
+++ b/src/som/vm/Primitives.java
@@ -1,8 +1,9 @@
 package som.vm;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+
+import org.graalvm.collections.EconomicMap;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.dsl.NodeFactory;
@@ -107,12 +108,12 @@ import som.vmobjects.SSymbol;
 
 public class Primitives extends PrimitiveLoader<VM, ExpressionNode, SSymbol> {
 
-  private HashMap<SSymbol, Dispatchable> vmMirrorPrimitives;
-  private final SomLanguage              lang;
+  private EconomicMap<SSymbol, Dispatchable> vmMirrorPrimitives;
+  private final SomLanguage                  lang;
 
   public Primitives(final SomLanguage lang) {
     super(Symbols.PROVIDER, lang.getVM());
-    vmMirrorPrimitives = new HashMap<>();
+    vmMirrorPrimitives = EconomicMap.create();
     this.lang = lang;
     initialize();
   }
@@ -148,9 +149,9 @@ public class Primitives extends PrimitiveLoader<VM, ExpressionNode, SSymbol> {
         primMethodNode, null);
   }
 
-  public HashMap<SSymbol, Dispatchable> takeVmMirrorPrimitives() {
+  public EconomicMap<SSymbol, Dispatchable> takeVmMirrorPrimitives() {
     assert vmMirrorPrimitives != null : "vmMirrorPrimitives can only be obtained once";
-    HashMap<SSymbol, Dispatchable> result = vmMirrorPrimitives;
+    EconomicMap<SSymbol, Dispatchable> result = vmMirrorPrimitives;
     vmMirrorPrimitives = null;
     return result;
   }

--- a/src/som/vmobjects/SClass.java
+++ b/src/som/vmobjects/SClass.java
@@ -26,8 +26,9 @@ package som.vmobjects;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
+
+import org.graalvm.collections.EconomicSet;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
@@ -54,9 +55,9 @@ public final class SClass extends SObjectWithClass {
   @CompilationFinal private SSymbol name;
 
   @CompilationFinal private HashMap<SSymbol, Dispatchable> dispatchables;
-  @CompilationFinal private HashSet<SlotDefinition>        slots;        // includes slots of
-                                                                         // super classes and
-                                                                         // mixins
+
+  // includes slots of super classes and mixins
+  @CompilationFinal private EconomicSet<SlotDefinition> slots;
 
   @CompilationFinal private MixinDefinition mixinDef;
   @CompilationFinal private boolean         declaredAsValue;
@@ -136,7 +137,7 @@ public final class SClass extends SObjectWithClass {
     return layout;
   }
 
-  public HashSet<SlotDefinition> getInstanceSlots() {
+  public EconomicSet<SlotDefinition> getInstanceSlots() {
     return slots;
   }
 
@@ -173,7 +174,7 @@ public final class SClass extends SObjectWithClass {
   }
 
   public void initializeStructure(final MixinDefinition mixinDef,
-      final HashSet<SlotDefinition> slots,
+      final EconomicSet<SlotDefinition> slots,
       final HashMap<SSymbol, Dispatchable> dispatchables,
       final boolean declaredAsValue, final boolean isTransferObject,
       final boolean isArray,

--- a/src/som/vmobjects/SClass.java
+++ b/src/som/vmobjects/SClass.java
@@ -25,9 +25,8 @@
 package som.vmobjects;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 
+import org.graalvm.collections.EconomicMap;
 import org.graalvm.collections.EconomicSet;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
@@ -54,7 +53,7 @@ public final class SClass extends SObjectWithClass {
   @CompilationFinal private SClass  superclass;
   @CompilationFinal private SSymbol name;
 
-  @CompilationFinal private HashMap<SSymbol, Dispatchable> dispatchables;
+  @CompilationFinal private EconomicMap<SSymbol, Dispatchable> dispatchables;
 
   // includes slots of super classes and mixins
   @CompilationFinal private EconomicSet<SlotDefinition> slots;
@@ -175,7 +174,7 @@ public final class SClass extends SObjectWithClass {
 
   public void initializeStructure(final MixinDefinition mixinDef,
       final EconomicSet<SlotDefinition> slots,
-      final HashMap<SSymbol, Dispatchable> dispatchables,
+      final EconomicMap<SSymbol, Dispatchable> dispatchables,
       final boolean declaredAsValue, final boolean isTransferObject,
       final boolean isArray,
       final ClassFactory classFactory) {
@@ -268,7 +267,7 @@ public final class SClass extends SObjectWithClass {
   @TruffleBoundary
   public SInvokable[] getMethods() {
     ArrayList<SInvokable> methods = new ArrayList<SInvokable>();
-    for (Dispatchable disp : dispatchables.values()) {
+    for (Dispatchable disp : dispatchables.getValues()) {
       if (disp instanceof SInvokable) {
         methods.add((SInvokable) disp);
       }
@@ -280,7 +279,7 @@ public final class SClass extends SObjectWithClass {
   public SClass[] getNestedClasses(final SObjectWithClass instance) {
     VM.thisMethodNeedsToBeOptimized("Not optimized, we do unrecorded invokes here");
     ArrayList<SClass> classes = new ArrayList<SClass>();
-    for (Dispatchable disp : dispatchables.values()) {
+    for (Dispatchable disp : dispatchables.getValues()) {
       if (disp instanceof ClassSlotDefinition) {
         classes.add((SClass) disp.invoke(null, new Object[] {instance}));
       }
@@ -288,7 +287,7 @@ public final class SClass extends SObjectWithClass {
     return classes.toArray(new SClass[classes.size()]);
   }
 
-  public Map<SSymbol, Dispatchable> getDispatchables() {
+  public EconomicMap<SSymbol, Dispatchable> getDispatchables() {
     return dispatchables;
   }
 

--- a/src/tools/debugger/message/VariablesResponse.java
+++ b/src/tools/debugger/message/VariablesResponse.java
@@ -2,7 +2,8 @@ package tools.debugger.message;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Map.Entry;
+
+import org.graalvm.collections.MapCursor;
 
 import som.compiler.MixinDefinition.SlotDefinition;
 import som.interpreter.Types;
@@ -72,11 +73,11 @@ public final class VariablesResponse extends Response {
     if (obj instanceof SObject) {
       assert start == null || start == 0 : "Don't support starting from non-0 index";
       SObject o = (SObject) obj;
-      for (Entry<SlotDefinition, StorageLocation> e : o.getObjectLayout().getStorageLocations()
-                                                       .entrySet()) {
-        results.add(
-            createVariable(e.getKey().getName().getString(), e.getValue().read(o),
-                suspension));
+      MapCursor<SlotDefinition, StorageLocation> e =
+          o.getObjectLayout().getStorageLocations().getEntries();
+      while (e.advance()) {
+        results.add(createVariable(e.getKey().getName().getString(), e.getValue().read(o),
+            suspension));
       }
     } else {
       int startIdx = start == null ? 0 : (int) (long) start;

--- a/src/tools/dym/DynamicMetrics.java
+++ b/src/tools/dym/DynamicMetrics.java
@@ -459,7 +459,7 @@ public class DynamicMetrics extends TruffleInstrument {
     for (MixinDefinition mixin : classes) {
       graphPrinter.beginGroup(mixin.getName().getString());
 
-      for (Dispatchable disp : mixin.getInstanceDispatchables().values()) {
+      for (Dispatchable disp : mixin.getInstanceDispatchables().getValues()) {
         if (disp instanceof SInvokable) {
           SInvokable i = (SInvokable) disp;
           graphPrinter.beginGraph(i.toString()).visit(i.getCallTarget().getRootNode());

--- a/src/tools/dym/MetricsCsvWriter.java
+++ b/src/tools/dym/MetricsCsvWriter.java
@@ -12,6 +12,8 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import org.graalvm.collections.EconomicMap;
+
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -495,8 +497,8 @@ public final class MetricsCsvWriter {
   private int numExecutedMethods(final MixinDefinition mixin,
       final Collection<InvocationProfile> profiles) {
     int numMethodsExecuted = 0;
-    Map<SSymbol, Dispatchable> disps = mixin.getInstanceDispatchables();
-    for (Dispatchable d : disps.values()) {
+    EconomicMap<SSymbol, Dispatchable> disps = mixin.getInstanceDispatchables();
+    for (Dispatchable d : disps.getValues()) {
       if (d instanceof SInvokable) {
         int invokeCount = methodInvocationCount(((SInvokable) d), profiles);
         if (invokeCount > 0) {
@@ -610,12 +612,22 @@ public final class MetricsCsvWriter {
     return sortedSet;
   }
 
+  private static <K, V> boolean contains(final EconomicMap<K, V> map, final V val) {
+    for (V v : map.getValues()) {
+      if (v.equals(val)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   private static int compare(final SInvokable a, final SInvokable b) {
     if (a.getHolder() == b.getHolder()) {
       int result = a.toString().compareTo(b.toString());
       if (result == 0 && a != b) {
         assert a.getHolder() != null : "TODO: need to handle this case";
-        if (a.getHolder().getInstanceDispatchables().values().contains(a)) {
+        if (contains(a.getHolder().getInstanceDispatchables(), a)) {
           return -1;
         } else {
           return 1;


### PR DESCRIPTION
Some of the problems with object layouts, races, and incorrect object updates are possibly caused by using hash maps that do not guarantee insertion order, causing random order changes and possibly changing usage of memory in objects.

By using `EconomicMap` and `EconomicSet` from the GraalVM, we get an efficient data structure that also guarantees insertion order.
This isn't a total fix, but should avoid some rare corner cases.
It also might be a bit more memory efficient.

(this PR was originally started with a different purpose, but oh well...)