### PR TITLE
Reduce race-related stack overflows, and handled invalid layouts in ClassSlotAccessNode

### DIFF
--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -653,8 +653,8 @@ public final class MixinDefinition {
       CachedSlotRead read = super.createNode(loc, guard, next, isSet);
       CachedSlotWrite write = loc.getWriteNode(this, guard, next, isSet);
 
-      ClassSlotAccessNode node = new ClassSlotAccessNode(mixinDefinition,
-          read, write);
+      ClassSlotAccessNode node =
+          new ClassSlotAccessNode(mixinDefinition, loc.getSlot(), read, write);
       return node;
     }
 

--- a/src/som/interpreter/nodes/dispatch/ClassSlotAccessNode.java
+++ b/src/som/interpreter/nodes/dispatch/ClassSlotAccessNode.java
@@ -4,8 +4,10 @@ import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 
 import som.compiler.MixinDefinition;
+import som.compiler.MixinDefinition.SlotDefinition;
 import som.interpreter.Invokable;
 import som.interpreter.nodes.InstantiationNode.ClassInstantiationNode;
 import som.interpreter.nodes.InstantiationNodeFactory.ClassInstantiationNodeGen;
@@ -25,14 +27,16 @@ import som.vmobjects.SObject;
  * object, where the initialized class object is cached.
  */
 public final class ClassSlotAccessNode extends CachedSlotRead {
-  private final MixinDefinition           mixinDef;
+  private final MixinDefinition mixinDef;
+  private final SlotDefinition  slotDef;
+
   @Child protected DirectCallNode         superclassAndMixinResolver;
   @Child protected ClassInstantiationNode instantiation;
 
   @Child protected CachedSlotRead  read;
   @Child protected CachedSlotWrite write;
 
-  public ClassSlotAccessNode(final MixinDefinition mixinDef,
+  public ClassSlotAccessNode(final MixinDefinition mixinDef, final SlotDefinition slotDef,
       final CachedSlotRead read, final CachedSlotWrite write) {
     super(SlotAccess.CLASS_READ, read.guard, read.nextInCache);
 
@@ -40,6 +44,7 @@ public final class ClassSlotAccessNode extends CachedSlotRead {
     this.read = read;
     this.write = write;
     this.mixinDef = mixinDef;
+    this.slotDef = slotDef;
     this.instantiation = ClassInstantiationNodeGen.create(mixinDef);
   }
 
@@ -56,18 +61,45 @@ public final class ClassSlotAccessNode extends CachedSlotRead {
     }
 
     synchronized (rcvr) {
-      cachedValue = read.read(rcvr);
+      try {
+        // recheck guard under synchronized, don't want to access object if
+        // layout might have changed, we are going to slow path in that case
+        read.guard.entryMatches(rcvr);
+        cachedValue = read.read(rcvr);
+      } catch (InvalidAssumptionException e) {
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        cachedValue = rcvr.readSlot(slotDef);
+      }
 
       // check whether cache is initialized with class object
       if (cachedValue == Nil.nilObject) {
-        SClass classObject = instantiateClassObject(rcvr);
-        write.doWrite(rcvr, classObject);
-        return classObject;
+        return instantiateAndWriteUnsynced(rcvr);
       } else {
         assert cachedValue instanceof SClass;
         return (SClass) cachedValue;
       }
     }
+  }
+
+  /**
+   * Caller needs to hold lock on {@code this}.
+   */
+  private SClass instantiateAndWriteUnsynced(final SObject rcvr) {
+    SClass classObject = instantiateClassObject(rcvr);
+
+    try {
+      // recheck guard under synchronized, don't want to access object if
+      // layout might have changed
+      //
+      // at this point the guard will fail, if it failed for the read guard,
+      // but we simply recheck here to avoid impact on fast path
+      write.guard.entryMatches(rcvr);
+      write.doWrite(rcvr, classObject);
+    } catch (InvalidAssumptionException e) {
+      CompilerDirectives.transferToInterpreterAndInvalidate();
+      rcvr.writeSlot(slotDef, classObject);
+    }
+    return classObject;
   }
 
   private void createResolverCallTargets() {

--- a/src/som/interpreter/objectstorage/StorageLocation.java
+++ b/src/som/interpreter/objectstorage/StorageLocation.java
@@ -61,6 +61,10 @@ public abstract class StorageLocation {
     this.slot = slot;
   }
 
+  public SlotDefinition getSlot() {
+    return slot;
+  }
+
   /**
    * @return true, if it is an object location, false otherwise.
    */

--- a/tests/java/som/tests/BasicInterpreterTests.java
+++ b/tests/java/som/tests/BasicInterpreterTests.java
@@ -117,15 +117,15 @@ public class BasicInterpreterTests {
         {"BlockInlining4", "test", 33, Long.class, null},
         {"BlockInlining5", "test", 33, Long.class, null},
 
-        {"Lookup", "testClassMethodsNotBlockingOuterMethods", 42, Long.class, UNSAFE_OM},
-        {"Lookup", "testExplicitOuterInInitializer", 182, Long.class, UNSAFE_OM},
-        {"Lookup", "testImplicitOuterInInitializer", 182, Long.class, UNSAFE_OM},
-        {"Lookup", "testImplicitSend", 42, Long.class, UNSAFE_OM},
-        {"Lookup", "testSiblingLookupA", 42, Long.class, UNSAFE_OM},
-        {"Lookup", "testSiblingLookupB", 43, Long.class, UNSAFE_OM},
-        {"Lookup", "testNesting1", 91, Long.class, UNSAFE_OM},
-        {"Lookup", "testNesting2", 182, Long.class, UNSAFE_OM},
-        {"Lookup", "testNesting3", 364, Long.class, UNSAFE_OM},
+        {"Lookup", "testClassMethodsNotBlockingOuterMethods", 42, Long.class, null},
+        {"Lookup", "testExplicitOuterInInitializer", 182, Long.class, null},
+        {"Lookup", "testImplicitOuterInInitializer", 182, Long.class, null},
+        {"Lookup", "testImplicitSend", 42, Long.class, null},
+        {"Lookup", "testSiblingLookupA", 42, Long.class, null},
+        {"Lookup", "testSiblingLookupB", 43, Long.class, null},
+        {"Lookup", "testNesting1", 91, Long.class, null},
+        {"Lookup", "testNesting2", 182, Long.class, null},
+        {"Lookup", "testNesting3", 364, Long.class, null},
         {"Lookup", "testInner18", 999, Long.class, UNSAFE_OM},
 
         {"Lookup", "testImplicitReceiverSendToPrivateMethod", 55, Long.class, null},
@@ -154,7 +154,7 @@ public class BasicInterpreterTests {
         {"ObjectCreation", "testImmutableRead", 3, Long.class, null},
         {"ObjectCreation", "testImmutableReadInner", 42, Long.class, null},
 
-        {"Parser", "testOuterInKeyword", 32 * 32 * 32, Long.class, UNSAFE_OM},
+        {"Parser", "testOuterInKeyword", 32 * 32 * 32, Long.class, null},
         {"Parser", "testOuterWithKeyword", 3 * 4, Long.class, null},
         {"Parser", "testOuterInheritancePrefix", 32, Long.class, null},
 
@@ -165,11 +165,11 @@ public class BasicInterpreterTests {
 
         {"Exceptions", "testSignalOnDo", 4, Long.class, null},
         {"Exceptions", "testSignalOnDoMethod", 5, Long.class, null},
-        {"Exceptions", "testNestedSignalOnDo", 22, Long.class, UNSAFE_OM},
-        {"Exceptions", "testSignalOnDoMethod", 5, Long.class, UNSAFE_OM},
-        {"Exceptions", "testCustomExceptionSignalOnDo", 343, Long.class, UNSAFE_OM},
-        {"Exceptions", "testEnsure", 444, Long.class, UNSAFE_OM},
-        {"Exceptions", "testEnsureWithSignal", 66, Long.class, UNSAFE_OM},
+        {"Exceptions", "testNestedSignalOnDo", 22, Long.class, null},
+        {"Exceptions", "testSignalOnDoMethod", 5, Long.class, null},
+        {"Exceptions", "testCustomExceptionSignalOnDo", 343, Long.class, null},
+        {"Exceptions", "testEnsure", 444, Long.class, null},
+        {"Exceptions", "testEnsureWithSignal", 66, Long.class, null},
 
         {"FieldAccess", "inheritanceOfLocalClass", 33, Long.class, null},
     });


### PR DESCRIPTION
If multiple threads mutate objects from the same class, it can happen that the object layout gets invalidated by another thread while we try to access it.

In the worst case, this can lead to stack overflows, because our interpreter tries repeatedly to find a valid object layout while creating dispatch chains, or interacting with the object layout in other nodes, which use recursive fallbacks.

A bad case I saw during debugging was that class loading occurred while initializing a new object layout. This delayed the availability of a valid layout long enough to see stack overflows.

To reduce the chance of this happening, I added a busy loop to wait that our lookup getLayoutForInstancesToUpdateObject() actually returns a valid layout. It might still be invalidate before use again, but hopefully this happens now less often, and prevents stack overflows.

This is likely related to https://github.com/smarr/SOMns/issues/85

@daumayr probably relevant for you, you might still have seen such races in your benchmarks

This change introduces a busy loop, for which we might want to add `Thread.onSpinWait()` once we can use [JDK 9](https://github.com/smarr/SOMns/issues/241).