### PR TITLE
Move Actor mailbox loop to Truffle

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -80,7 +80,7 @@
       </exec>
     </target>
 
-    <target name="truffle-libs" unless="skip.libs" depends="truffle,build-graal">
+    <target name="truffle-libs" unless="skip.truffle" depends="truffle,build-graal">
         <exec executable="${mx.cmd}" dir="${truffle.dir}" failonerror="true">
             <arg value="build"/>
             <arg value="--no-native"/>

--- a/src/som/UncaughtExceptions.java
+++ b/src/som/UncaughtExceptions.java
@@ -22,9 +22,14 @@ public final class UncaughtExceptions implements UncaughtExceptionHandler {
       // Ignore those, we already signaled an error
       return;
     }
+
+    Output.errorPrintln("Uncaught exception on " + t.getName());
+
     TracingActivityThread thread = (TracingActivityThread) t;
-    Output.errorPrintln("Processing failed for: "
-        + thread.getActivity().toString());
+    if (thread.getActivity() != null) {
+      Output.errorPrintln("Processing failed for: "
+          + thread.getActivity().toString());
+    }
     e.printStackTrace();
 
     vm.requestExit(2);

--- a/src/som/VM.java
+++ b/src/som/VM.java
@@ -327,6 +327,8 @@ public final class VM {
   }
 
   public void initalize(final SomLanguage lang) throws IOException {
+    Actor.initializeActorSystem(language);
+
     assert objectSystem == null;
     objectSystem = new ObjectSystem(new SourcecodeCompiler(lang), structuralProbe, this);
     objectSystem.loadKernelAndPlatform(options.platformFile, options.kernelFile);

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -6,22 +6,16 @@ import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory;
 import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.RejectedExecutionException;
 
-import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
-import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.nodes.DirectCallNode;
-import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 
 import som.Output;
 import som.VM;
 import som.interpreter.SomLanguage;
-import som.interpreter.actors.ActorFactory.MessageCacheNodeGen;
 import som.interpreter.objectstorage.ObjectTransitionSafepoint;
 import som.primitives.ObjectPrims.IsValue;
 import som.vm.Activity;
@@ -217,38 +211,13 @@ public class Actor implements Activity {
 
     private ExecutorRootNode(final SomLanguage language) {
       super(language);
-      tracer = new TraceActorContextNode();
-      cache = MessageCacheNodeGen.create();
     }
-
-    @Child private TraceActorContextNode tracer;
-    @Child private MessageCache          cache;
 
     @Override
     public Object execute(final VirtualFrame frame) {
       ExecAllMessages executor = (ExecAllMessages) frame.getArguments()[0];
-      executor.doRun(tracer, cache);
+      executor.doRun();
       return null;
-    }
-  }
-
-  public abstract static class MessageCache extends Node {
-    public abstract void execute(CallTarget onReceive, EventualMessage msg);
-
-    protected static final DirectCallNode createCallNode(final CallTarget onReceive) {
-      return Truffle.getRuntime().createDirectCallNode(onReceive);
-    }
-
-    @Specialization(guards = "onReceive == cachedOnReceive", limit = "6")
-    public static void doCached(final CallTarget onReceive, final EventualMessage msg,
-        @Cached("onReceive") final CallTarget cachedOnReceive,
-        @Cached("createCallNode(onReceive)") final DirectCallNode call) {
-      call.call(new Object[] {msg});
-    }
-
-    @Specialization(replaces = "doCached")
-    public static void unCached(final CallTarget onReceive, final EventualMessage msg) {
-      onReceive.call(msg);
     }
   }
 
@@ -276,7 +245,7 @@ public class Actor implements Activity {
       executorRoot.call(this);
     }
 
-    void doRun(final TraceActorContextNode tracer, final MessageCache cache) {
+    void doRun() {
       ObjectTransitionSafepoint.INSTANCE.register();
 
       ActorProcessingThread t = (ActorProcessingThread) Thread.currentThread();
@@ -294,7 +263,7 @@ public class Actor implements Activity {
 
       try {
         while (getCurrentMessagesOrCompleteExecution()) {
-          processCurrentMessages(t, cache, dbg);
+          processCurrentMessages(t, dbg);
         }
       } finally {
         ObjectTransitionSafepoint.INSTANCE.unregister();
@@ -304,15 +273,15 @@ public class Actor implements Activity {
     }
 
     protected void processCurrentMessages(final ActorProcessingThread currentThread,
-        final MessageCache cache, final WebDebugger dbg) {
+        final WebDebugger dbg) {
       assert size > 0;
 
       try {
-        execute(firstMessage, cache, currentThread, dbg);
+        execute(firstMessage, currentThread, dbg);
 
         if (size > 1) {
           for (EventualMessage msg : mailboxExtension) {
-            execute(msg, cache, currentThread, dbg);
+            execute(msg, currentThread, dbg);
           }
         }
       } finally {
@@ -322,7 +291,7 @@ public class Actor implements Activity {
       }
     }
 
-    private void execute(final EventualMessage msg, final MessageCache cache,
+    private void execute(final EventualMessage msg,
         final ActorProcessingThread currentThread, final WebDebugger dbg) {
       currentThread.currentMessage = msg;
       if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
@@ -334,7 +303,7 @@ public class Actor implements Activity {
           ActorExecutionTrace.scopeStart(DynamicScopeType.TURN, msg.getMessageId(),
               msg.getTargetSourceSection());
         }
-        msg.execute(cache);
+        msg.execute();
       } finally {
         if (VmSettings.ACTOR_TRACING) {
           ActorExecutionTrace.scopeEnd(DynamicScopeType.TURN);

--- a/src/som/interpreter/actors/EventualMessage.java
+++ b/src/som/interpreter/actors/EventualMessage.java
@@ -7,7 +7,6 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.actors.Actor.ActorProcessingThread;
-import som.interpreter.actors.Actor.MessageCache;
 import som.interpreter.actors.ReceivedMessage.ReceivedCallback;
 import som.interpreter.actors.SPromise.SResolver;
 import som.vmobjects.SBlock;
@@ -305,15 +304,15 @@ public abstract class EventualMessage {
     }
   }
 
-  public final void execute(final MessageCache cache) {
+  public final void execute() {
     try {
-      executeMessage(cache);
+      executeMessage();
     } catch (ThreadDeath t) {
       throw t;
     }
   }
 
-  protected final void executeMessage(final MessageCache cache) {
+  protected final void executeMessage() {
     Object rcvrObj = args[0];
     assert rcvrObj != null;
 
@@ -322,7 +321,7 @@ public abstract class EventualMessage {
 
     assert onReceive.getRootNode() instanceof ReceivedMessage
         || onReceive.getRootNode() instanceof ReceivedCallback;
-    cache.execute(onReceive, this);
+    onReceive.call(this);
   }
 
   public static Actor getActorCurrentMessageIsExecutionOn() {

--- a/src/som/interpreter/actors/EventualMessage.java
+++ b/src/som/interpreter/actors/EventualMessage.java
@@ -7,6 +7,7 @@ import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
 import som.interpreter.actors.Actor.ActorProcessingThread;
+import som.interpreter.actors.Actor.MessageCache;
 import som.interpreter.actors.ReceivedMessage.ReceivedCallback;
 import som.interpreter.actors.SPromise.SResolver;
 import som.vmobjects.SBlock;
@@ -304,18 +305,15 @@ public abstract class EventualMessage {
     }
   }
 
-  public final void execute() {
+  public final void execute(final MessageCache cache) {
     try {
-      executeMessage();
+      executeMessage(cache);
     } catch (ThreadDeath t) {
       throw t;
     }
   }
 
-  protected final void executeMessage() {
-    VM.thisMethodNeedsToBeOptimized(
-        "Not Optimized! But also not sure it can be part of compilation anyway");
-
+  protected final void executeMessage(final MessageCache cache) {
     Object rcvrObj = args[0];
     assert rcvrObj != null;
 
@@ -324,7 +322,7 @@ public abstract class EventualMessage {
 
     assert onReceive.getRootNode() instanceof ReceivedMessage
         || onReceive.getRootNode() instanceof ReceivedCallback;
-    onReceive.call(this);
+    cache.execute(onReceive, this);
   }
 
   public static Actor getActorCurrentMessageIsExecutionOn() {

--- a/src/som/interpreter/actors/SPromise.java
+++ b/src/som/interpreter/actors/SPromise.java
@@ -5,6 +5,7 @@ import java.util.concurrent.ForkJoinPool;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.profiles.ValueProfile;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.interpreter.actors.EventualMessage.PromiseMessage;
@@ -307,7 +308,8 @@ public class SPromise extends SObjectWithClass {
     @TruffleBoundary
     protected static void resolveChainedPromisesUnsync(final Resolution type,
         final SPromise promise, final Object result, final Actor current,
-        final ForkJoinPool actorPool, final boolean haltOnResolution) {
+        final ForkJoinPool actorPool, final boolean haltOnResolution,
+        final ValueProfile whenResolvedProfile) {
       // TODO: we should change the implementation of chained promises to
       // always move all the handlers to the other promise, then we
       // don't need to worry about traversing the chain, which can
@@ -317,9 +319,9 @@ public class SPromise extends SObjectWithClass {
         Object wrapped = promise.chainedPromise.owner.wrapForUse(result, current, null);
         resolveAndTriggerListenersUnsynced(type, result, wrapped,
             promise.chainedPromise, current, actorPool,
-            promise.chainedPromise.haltOnResolution);
+            promise.chainedPromise.haltOnResolution, whenResolvedProfile);
         resolveMoreChainedPromisesUnsynced(type, promise, result, current,
-            actorPool, haltOnResolution);
+            actorPool, haltOnResolution, whenResolvedProfile);
       }
     }
 
@@ -329,13 +331,14 @@ public class SPromise extends SObjectWithClass {
     @TruffleBoundary
     private static void resolveMoreChainedPromisesUnsynced(final Resolution type,
         final SPromise promise, final Object result, final Actor current,
-        final ForkJoinPool actorPool, final boolean haltOnResolution) {
+        final ForkJoinPool actorPool, final boolean haltOnResolution,
+        final ValueProfile whenResolvedProfile) {
       if (promise.chainedPromiseExt != null) {
 
         for (SPromise p : promise.chainedPromiseExt) {
           Object wrapped = p.owner.wrapForUse(result, current, null);
           resolveAndTriggerListenersUnsynced(type, result, wrapped, p, current,
-              actorPool, haltOnResolution);
+              actorPool, haltOnResolution, whenResolvedProfile);
         }
       }
     }
@@ -346,9 +349,9 @@ public class SPromise extends SObjectWithClass {
      * If the promise was chained with other promises, the chained promises are also resolved.
      */
     protected static void resolveAndTriggerListenersUnsynced(final Resolution type,
-        final Object result, final Object wrapped, final SPromise p,
-        final Actor current, final ForkJoinPool actorPool,
-        final boolean haltOnResolution) {
+        final Object result, final Object wrapped, final SPromise p, final Actor current,
+        final ForkJoinPool actorPool, final boolean haltOnResolution,
+        final ValueProfile whenResolvedProfile) {
       assert !(result instanceof SPromise);
 
       if (VmSettings.PROMISE_RESOLUTION) {
@@ -390,12 +393,14 @@ public class SPromise extends SObjectWithClass {
         }
 
         if (type == Resolution.SUCCESSFUL) {
-          scheduleAllWhenResolvedUnsync(p, result, current, actorPool, haltOnResolution);
+          scheduleAllWhenResolvedUnsync(p, result, current, actorPool, haltOnResolution,
+              whenResolvedProfile);
         } else {
           assert type == Resolution.ERRONEOUS;
           scheduleAllOnErrorUnsync(p, result, current, actorPool, haltOnResolution);
         }
-        resolveChainedPromisesUnsync(type, p, result, current, actorPool, haltOnResolution);
+        resolveChainedPromisesUnsync(type, p, result, current, actorPool, haltOnResolution,
+            whenResolvedProfile);
       }
     }
 
@@ -403,11 +408,12 @@ public class SPromise extends SObjectWithClass {
      * Schedule all whenResolved callbacks for the promise.
      */
     protected static void scheduleAllWhenResolvedUnsync(final SPromise promise,
-        final Object result, final Actor current,
-        final ForkJoinPool actorPool, final boolean haltOnResolution) {
+        final Object result, final Actor current, final ForkJoinPool actorPool,
+        final boolean haltOnResolution, final ValueProfile whenResolvedProfile) {
       if (promise.whenResolved != null) {
-        promise.scheduleCallbacksOnResolution(result, promise.whenResolved,
-            current, actorPool, haltOnResolution);
+        promise.scheduleCallbacksOnResolution(result,
+            whenResolvedProfile.profile(promise.whenResolved), current, actorPool,
+            haltOnResolution);
         scheduleExtensions(promise, promise.whenResolvedExt, result, current,
             actorPool, haltOnResolution);
       }

--- a/src/som/interpreter/objectstorage/ObjectTransitionSafepoint.java
+++ b/src/som/interpreter/objectstorage/ObjectTransitionSafepoint.java
@@ -5,6 +5,7 @@ import java.util.concurrent.Phaser;
 import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 
@@ -55,9 +56,8 @@ public final class ObjectTransitionSafepoint {
    * in some way. Thus, all threads that access {@link SMutableObject} or
    * {@link SImmutableObject} at some point of their lifetime need to register.
    */
+  @TruffleBoundary
   public void register() {
-    CompilerAsserts.neverPartOfCompilation(
-        "Register is expect to be a rare operation and not part of compilation.");
     phaser.register();
   }
 
@@ -69,9 +69,8 @@ public final class ObjectTransitionSafepoint {
    * in some way. Thus, all threads that access {@link SMutableObject} or
    * {@link SImmutableObject} at some point of their lifetime need to register.
    */
+  @TruffleBoundary
   public void unregister() {
-    CompilerAsserts.neverPartOfCompilation(
-        "Unregister is expect to be a rare operation and not part of compilation.");
     phaser.arriveAndDeregister();
   }
 

--- a/src/som/primitives/TimerPrim.java
+++ b/src/som/primitives/TimerPrim.java
@@ -8,6 +8,7 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.profiles.ValueProfile;
 
 import bd.primitives.Primitive;
 import som.VM;
@@ -27,6 +28,8 @@ public abstract class TimerPrim extends BinarySystemOperation {
 
   @Child protected WrapReferenceNode wrapper = WrapReferenceNodeGen.create();
 
+  private final ValueProfile whenResolvedProfile = ValueProfile.createClassProfile();
+
   @Override
   public final TimerPrim initialize(final VM vm) {
     super.initialize(vm);
@@ -45,7 +48,7 @@ public abstract class TimerPrim extends BinarySystemOperation {
       public void run() {
         ResolvePromiseNode.resolve(Resolution.SUCCESSFUL, wrapper,
             resolver.getPromise(), true,
-            resolver.getPromise().getOwner(), actorPool, false);
+            resolver.getPromise().getOwner(), actorPool, false, whenResolvedProfile);
       }
     }, timeout);
     return true;

--- a/src/som/vmobjects/SArray.java
+++ b/src/som/vmobjects/SArray.java
@@ -21,12 +21,12 @@ public abstract class SArray extends SAbstractObject {
   protected Object       storage;
   protected final SClass clazz;
 
-  public SArray(final long length, final SClass clazz) {
+  protected SArray(final long length, final SClass clazz) {
     storage = (int) length;
     this.clazz = clazz;
   }
 
-  public SArray(final Object storage, final SClass clazz) {
+  protected SArray(final Object storage, final SClass clazz) {
     assert !(storage instanceof Long);
     assert storage != null;
     this.storage = storage;
@@ -201,7 +201,7 @@ public abstract class SArray extends SAbstractObject {
 
     /**
      * Creates and empty array, using the EMPTY strategy.
-     * 
+     *
      * @param length
      */
     public SMutableArray(final long length, final SClass clazz) {
@@ -264,7 +264,7 @@ public abstract class SArray extends SAbstractObject {
     /**
      * For internal use only, specifically, for SClass.
      * There we now, it is either empty, or of OBJECT type.
-     * 
+     *
      * @param value
      * @return new mutable array extended by value
      */

--- a/src/tools/concurrency/TracingActors.java
+++ b/src/tools/concurrency/TracingActors.java
@@ -279,7 +279,7 @@ public class TracingActors {
 
       @Override
       protected void processCurrentMessages(final ActorProcessingThread currentThread,
-          final MessageCache cache, final WebDebugger dbg) {
+          final WebDebugger dbg) {
         assert actor instanceof ReplayActor;
         assert size > 0;
 
@@ -289,7 +289,7 @@ public class TracingActors {
         for (EventualMessage msg : todo) {
           currentThread.currentMessage = msg;
           handleBreakpointsAndStepping(firstMessage, dbg, a);
-          msg.execute(cache);
+          msg.execute();
         }
 
         currentThread.createdMessages += todo.size();

--- a/src/tools/concurrency/TracingActors.java
+++ b/src/tools/concurrency/TracingActors.java
@@ -279,7 +279,7 @@ public class TracingActors {
 
       @Override
       protected void processCurrentMessages(final ActorProcessingThread currentThread,
-          final WebDebugger dbg) {
+          final MessageCache cache, final WebDebugger dbg) {
         assert actor instanceof ReplayActor;
         assert size > 0;
 
@@ -289,7 +289,7 @@ public class TracingActors {
         for (EventualMessage msg : todo) {
           currentThread.currentMessage = msg;
           handleBreakpointsAndStepping(firstMessage, dbg, a);
-          msg.execute();
+          msg.execute(cache);
         }
 
         currentThread.createdMessages += todo.size();

--- a/src/tools/debugger/message/StackTraceResponse.java
+++ b/src/tools/debugger/message/StackTraceResponse.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import com.oracle.truffle.api.debug.DebugStackFrame;
 import com.oracle.truffle.api.source.SourceSection;
 
+import som.interpreter.actors.Actor.ExecutorRootNode;
 import som.interpreter.actors.ReceivedRootNode;
 import tools.TraceData;
 import tools.debugger.entities.EntityType;
@@ -88,12 +89,27 @@ public final class StackTraceResponse extends Response {
     }
   }
 
+  private static int getNumRootNodesToSkip(final ArrayList<DebugStackFrame> frames) {
+    int skip = 0;
+    int size = frames.size();
+
+    // Actor-specific infrastructure, to be skipped from stack traces
+    if (frames.get(size - 1).getRootNode() instanceof ExecutorRootNode) {
+      skip += 1;
+    }
+
+    // Actor-specific infrastructure, to be skipped from stack traces
+    if (size >= 2 && frames.get(size - 2).getRootNode() instanceof ReceivedRootNode) {
+      skip += 1;
+    }
+
+    return skip;
+  }
+
   public static StackTraceResponse create(final int startFrame, final int levels,
       final Suspension suspension, final int requestId) {
     ArrayList<DebugStackFrame> frames = suspension.getStackFrames();
     int skipFrames = suspension.getFrameSkipCount();
-    DebugStackFrame lastFrame = frames.get(frames.size() - 1);
-    final boolean ignoreLast = lastFrame.getRootNode() instanceof ReceivedRootNode;
 
     if (startFrame > skipFrames) {
       skipFrames = startFrame;
@@ -104,10 +120,7 @@ public final class StackTraceResponse extends Response {
       numFrames = Integer.MAX_VALUE;
     }
     numFrames = Math.min(frames.size(), numFrames);
-    numFrames -= skipFrames;
-    if (ignoreLast) {
-      numFrames -= 1;
-    }
+    numFrames -= skipFrames + getNumRootNodesToSkip(frames);
 
     StackFrame[] arr = new StackFrame[numFrames];
 


### PR DESCRIPTION
This PR moves the loop that iterates over the messages in a mailbox into Truffle.
This is technically not an optimization in itself, but enables future optimization, because it gives more control over for instance tracing operations.

The PR contains also a number of smaller cleanups.

For reference, I included the code that adds caching for the methods of messages.
However, there are even for simple programs too many messages, so this is not useful, and therefore reverted.