### PR TITLE
Use CompilerDirectives::castExact instead of ValueProfiles

### DIFF
--- a/src/som/interpreter/actors/TransferObject.java
+++ b/src/som/interpreter/actors/TransferObject.java
@@ -14,7 +14,6 @@ import som.interpreter.objectstorage.StorageLocation;
 import som.vm.NotYetImplementedException;
 import som.vm.constants.Nil;
 import som.vmobjects.SAbstractObject;
-import som.vmobjects.SArray;
 import som.vmobjects.SArray.PartiallyEmptyArray;
 import som.vmobjects.SArray.STransferArray;
 import som.vmobjects.SObject;
@@ -100,7 +99,7 @@ public final class TransferObject {
     transferMap.put(arr, newObj);
 
     if (newObj.isObjectType()) {
-      Object[] storage = newObj.getObjectStorage(SArray.ObjectStorageType);
+      Object[] storage = newObj.getObjectStorage();
 
       for (int i = 0; i < storage.length; i++) {
         Object orgObj = storage[i];
@@ -115,7 +114,7 @@ public final class TransferObject {
       }
     } else if (newObj.isPartiallyEmptyType()) {
       PartiallyEmptyArray parr =
-          newObj.getPartiallyEmptyStorage(SArray.PartiallyEmptyStorageType);
+          newObj.getPartiallyEmptyStorage();
       Object[] storage = parr.getStorage();
 
       for (int i = 0; i < storage.length; i++) {

--- a/src/som/primitives/SizeAndLengthPrim.java
+++ b/src/som/primitives/SizeAndLengthPrim.java
@@ -18,7 +18,6 @@ import tools.dym.Tags.OpLength;
 @Primitive(primitive = "stringLength:", selector = "length", receiverType = String.class,
     inParser = false)
 public abstract class SizeAndLengthPrim extends UnaryBasicOperation {
-  private final ValueProfile storageType = ValueProfile.createClassProfile();
 
   @Override
   protected boolean hasTagIgnoringEagerness(final Class<? extends Tag> tag) {
@@ -31,32 +30,32 @@ public abstract class SizeAndLengthPrim extends UnaryBasicOperation {
 
   @Specialization(guards = "receiver.isEmptyType()")
   public final long doEmptySArray(final SArray receiver) {
-    return receiver.getEmptyStorage(storageType);
+    return receiver.getEmptyStorage();
   }
 
   @Specialization(guards = "receiver.isPartiallyEmptyType()")
   public final long doPartialEmptySArray(final SArray receiver) {
-    return receiver.getPartiallyEmptyStorage(storageType).getLength();
+    return receiver.getPartiallyEmptyStorage().getLength();
   }
 
   @Specialization(guards = "receiver.isObjectType()")
   public final long doObjectSArray(final SArray receiver) {
-    return receiver.getObjectStorage(storageType).length;
+    return receiver.getObjectStorage().length;
   }
 
   @Specialization(guards = "receiver.isLongType()")
   public final long doLongSArray(final SArray receiver) {
-    return receiver.getLongStorage(storageType).length;
+    return receiver.getLongStorage().length;
   }
 
   @Specialization(guards = "receiver.isDoubleType()")
   public final long doDoubleSArray(final SArray receiver) {
-    return receiver.getDoubleStorage(storageType).length;
+    return receiver.getDoubleStorage().length;
   }
 
   @Specialization(guards = "receiver.isBooleanType()")
   public final long doBooleanSArray(final SArray receiver) {
-    return receiver.getBooleanStorage(storageType).length;
+    return receiver.getBooleanStorage().length;
   }
 
   public abstract long executeEvaluated(Object receiver);

--- a/src/som/primitives/SizeAndLengthPrim.java
+++ b/src/som/primitives/SizeAndLengthPrim.java
@@ -3,7 +3,6 @@ package som.primitives;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.instrumentation.Tag;
-import com.oracle.truffle.api.profiles.ValueProfile;
 
 import bd.primitives.Primitive;
 import som.interpreter.nodes.nary.UnaryBasicOperation;

--- a/src/som/primitives/StringPrims.java
+++ b/src/som/primitives/StringPrims.java
@@ -185,7 +185,7 @@ public class StringPrims {
     public final String doString(final SArray chars) {
       VM.thisMethodNeedsToBeOptimized(
           "Method not yet optimal for compilation, should speculate or use branch profile in the loop");
-      Object[] storage = chars.getObjectStorage(SArray.ObjectStorageType);
+      Object[] storage = chars.getObjectStorage();
       StringBuilder sb = new StringBuilder(storage.length);
       for (Object o : storage) {
         if (o instanceof String) {

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -23,7 +23,6 @@ import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.nodes.Node;
-import com.oracle.truffle.api.profiles.ValueProfile;
 import com.oracle.truffle.api.source.SourceSection;
 
 import bd.primitives.Primitive;
@@ -380,8 +379,6 @@ public final class SystemPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "systemApply:with:")
   public abstract static class ApplyWithPrim extends BinaryComplexOperation {
-    private final ValueProfile storageType = ValueProfile.createClassProfile();
-
     @Child protected SizeAndLengthPrim size    = SizeAndLengthPrimFactory.create(null);
     @Child protected ToSomConversion   convert = ToSomConversionNodeGen.create(null);
 
@@ -391,13 +388,13 @@ public final class SystemPrims {
 
       Object[] arguments;
       if (args.isLongType()) {
-        long[] arr = args.getLongStorage(storageType);
+        long[] arr = args.getLongStorage();
         arguments = new Object[arr.length];
         for (int i = 0; i < arr.length; i++) {
           arguments[i] = arr[i];
         }
       } else if (args.isObjectType()) {
-        arguments = args.getObjectStorage(storageType);
+        arguments = args.getObjectStorage();
       } else {
         CompilerDirectives.transferToInterpreter();
         throw new NotYetImplementedException();

--- a/src/som/primitives/arrays/AtPrim.java
+++ b/src/som/primitives/arrays/AtPrim.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Tag;
 import com.oracle.truffle.api.nodes.RootNode;
-import com.oracle.truffle.api.profiles.ValueProfile;
 import com.oracle.truffle.api.source.SourceSection;
 
 import bd.primitives.Primitive;
@@ -65,8 +64,6 @@ public abstract class AtPrim extends BinaryBasicOperation {
     }
   }
 
-  private final ValueProfile storageType = ValueProfile.createClassProfile();
-
   @Child protected ExceptionSignalingNode indexOutOfBounds;
 
   public abstract Object execute(VirtualFrame frame, SArray array, long index);
@@ -97,7 +94,7 @@ public abstract class AtPrim extends BinaryBasicOperation {
 
   @Specialization(guards = "receiver.isEmptyType()")
   public final Object doEmptySArray(final SArray receiver, final long idx) {
-    if (idx < 1 || idx > receiver.getEmptyStorage(storageType)) {
+    if (idx < 1 || idx > receiver.getEmptyStorage()) {
       return triggerException(receiver, idx);
     }
     return Nil.nilObject;
@@ -106,7 +103,7 @@ public abstract class AtPrim extends BinaryBasicOperation {
   @Specialization(guards = "receiver.isPartiallyEmptyType()")
   public final Object doPartiallyEmptySArray(final SArray receiver, final long idx) {
     try {
-      return receiver.getPartiallyEmptyStorage(storageType).get(idx - 1);
+      return receiver.getPartiallyEmptyStorage().get(idx - 1);
     } catch (IndexOutOfBoundsException e) {
       return triggerException(receiver, idx);
     }
@@ -115,7 +112,7 @@ public abstract class AtPrim extends BinaryBasicOperation {
   @Specialization(guards = "receiver.isObjectType()")
   public final Object doObjectSArray(final SArray receiver, final long idx) {
     try {
-      return receiver.getObjectStorage(storageType)[(int) idx - 1];
+      return receiver.getObjectStorage()[(int) idx - 1];
     } catch (IndexOutOfBoundsException e) {
       return triggerException(receiver, idx);
     }
@@ -124,7 +121,7 @@ public abstract class AtPrim extends BinaryBasicOperation {
   @Specialization(guards = "receiver.isLongType()")
   public final long doLongSArray(final SArray receiver, final long idx) {
     try {
-      return receiver.getLongStorage(storageType)[(int) idx - 1];
+      return receiver.getLongStorage()[(int) idx - 1];
     } catch (IndexOutOfBoundsException e) {
       return (long) triggerException(receiver, idx);
     }
@@ -133,7 +130,7 @@ public abstract class AtPrim extends BinaryBasicOperation {
   @Specialization(guards = "receiver.isDoubleType()")
   public final double doDoubleSArray(final SArray receiver, final long idx) {
     try {
-      return receiver.getDoubleStorage(storageType)[(int) idx - 1];
+      return receiver.getDoubleStorage()[(int) idx - 1];
     } catch (IndexOutOfBoundsException e) {
       return (double) triggerException(receiver, idx);
     }
@@ -142,7 +139,7 @@ public abstract class AtPrim extends BinaryBasicOperation {
   @Specialization(guards = "receiver.isBooleanType()")
   public final boolean doBooleanSArray(final SArray receiver, final long idx) {
     try {
-      return receiver.getBooleanStorage(storageType)[(int) idx - 1];
+      return receiver.getBooleanStorage()[(int) idx - 1];
     } catch (IndexOutOfBoundsException e) {
       return (boolean) triggerException(receiver, idx);
     }

--- a/src/som/primitives/arrays/AtPutPrim.java
+++ b/src/som/primitives/arrays/AtPutPrim.java
@@ -8,7 +8,6 @@ import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.instrumentation.Tag;
 import com.oracle.truffle.api.nodes.RootNode;
-import com.oracle.truffle.api.profiles.ValueProfile;
 import com.oracle.truffle.api.source.SourceSection;
 
 import bd.primitives.Primitive;
@@ -69,8 +68,6 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
       }
     }
   }
-
-  private final ValueProfile storageType = ValueProfile.createClassProfile();
 
   @Child protected ExceptionSignalingNode indexOutOfBounds;
 
@@ -135,7 +132,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
 
   private void setAndPossiblyTransition(final SMutableArray receiver,
       final long index, final Object value, final PartiallyEmptyArray.Type expectedType) {
-    PartiallyEmptyArray storage = receiver.getPartiallyEmptyStorage(storageType);
+    PartiallyEmptyArray storage = receiver.getPartiallyEmptyStorage();
     setValue(index - 1, value, storage);
     if (storage.getType() != expectedType) {
       storage.setType(PartiallyEmptyArray.Type.OBJECT);
@@ -181,7 +178,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   public final Object doEmptySArray(final SMutableArray receiver, final long index,
       final Object value) {
     final int idx = (int) index - 1;
-    int size = receiver.getEmptyStorage(storageType);
+    int size = receiver.getEmptyStorage();
 
     // if the value is an object, we transition directly to an Object array
     Object[] newStorage = new Object[size];
@@ -199,7 +196,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   public final Object doEmptySArrayWithNil(final SMutableArray receiver, final long index,
       final Object value) {
     long idx = index - 1;
-    if (idx < 0 || idx >= receiver.getEmptyStorage(storageType)) {
+    if (idx < 0 || idx >= receiver.getEmptyStorage()) {
       return triggerException(receiver, index);
     }
     return Nil.nilObject;
@@ -242,7 +239,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   public final Object doPartiallyEmptySArrayWithNil(final SMutableArray receiver,
       final long index, final Object value) {
     long idx = index - 1;
-    PartiallyEmptyArray storage = receiver.getPartiallyEmptyStorage(storageType);
+    PartiallyEmptyArray storage = receiver.getPartiallyEmptyStorage();
 
     try {
       if (storage.get(idx) != Nil.nilObject) {
@@ -270,7 +267,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   public final Object doObjectSArray(final SMutableArray receiver, final long index,
       final Object value) {
     try {
-      receiver.getObjectStorage(storageType)[(int) index - 1] = value;
+      receiver.getObjectStorage()[(int) index - 1] = value;
       return value;
     } catch (IndexOutOfBoundsException e) {
       return triggerException(receiver, index);
@@ -281,7 +278,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   public final long doObjectSArray(final SMutableArray receiver, final long index,
       final long value) {
     try {
-      receiver.getLongStorage(storageType)[(int) index - 1] = value;
+      receiver.getLongStorage()[(int) index - 1] = value;
       return value;
     } catch (IndexOutOfBoundsException e) {
       return (long) triggerException(receiver, index);
@@ -291,7 +288,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   @Specialization(guards = {"receiver.isLongType()", "valueIsNotLong(value)"})
   public final Object doLongSArray(final SMutableArray receiver, final long index,
       final Object value) {
-    long[] storage = receiver.getLongStorage(storageType);
+    long[] storage = receiver.getLongStorage();
     Object[] newStorage = new Object[storage.length];
     for (int i = 0; i < storage.length; i++) {
       newStorage[i] = storage[i];
@@ -308,7 +305,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   public final double doDoubleSArray(final SMutableArray receiver, final long index,
       final double value) {
     try {
-      receiver.getDoubleStorage(storageType)[(int) index - 1] = value;
+      receiver.getDoubleStorage()[(int) index - 1] = value;
       return value;
     } catch (IndexOutOfBoundsException e) {
       return (double) triggerException(receiver, index);
@@ -318,7 +315,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   @Specialization(guards = {"receiver.isDoubleType()", "valueIsNotDouble(value)"})
   public final Object doDoubleSArray(final SMutableArray receiver, final long index,
       final Object value) {
-    double[] storage = receiver.getDoubleStorage(storageType);
+    double[] storage = receiver.getDoubleStorage();
     Object[] newStorage = new Object[storage.length];
     for (int i = 0; i < storage.length; i++) {
       newStorage[i] = storage[i];
@@ -334,7 +331,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   public final boolean doBooleanSArray(final SMutableArray receiver, final long index,
       final boolean value) {
     try {
-      receiver.getBooleanStorage(storageType)[(int) index - 1] = value;
+      receiver.getBooleanStorage()[(int) index - 1] = value;
       return value;
     } catch (IndexOutOfBoundsException e) {
       return (boolean) triggerException(receiver, index);
@@ -344,7 +341,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
   @Specialization(guards = {"receiver.isBooleanType()", "valueIsNotBoolean(value)"})
   public final Object doBooleanSArray(final SMutableArray receiver, final long index,
       final Object value) {
-    boolean[] storage = receiver.getBooleanStorage(storageType);
+    boolean[] storage = receiver.getBooleanStorage();
     Object[] newStorage = new Object[storage.length];
     for (int i = 0; i < storage.length; i++) {
       newStorage[i] = storage[i];

--- a/src/som/primitives/arrays/CopyPrim.java
+++ b/src/som/primitives/arrays/CopyPrim.java
@@ -2,7 +2,6 @@ package som.primitives.arrays;
 
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.profiles.ValueProfile;
 
 import bd.primitives.Primitive;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
@@ -13,20 +12,19 @@ import som.vmobjects.SArray.SMutableArray;
 @GenerateNodeFactory
 @Primitive(selector = "copy", receiverType = SArray.class, disabled = true)
 public abstract class CopyPrim extends UnaryExpressionNode {
-  private final ValueProfile storageType = ValueProfile.createClassProfile();
 
   @Specialization(guards = "receiver.isEmptyType()")
   public final SMutableArray doEmptyArray(final SMutableArray receiver) {
     assert !receiver.getSOMClass()
                     .isTransferObject() : "Not yet supported, need to instantiate another class";
-    return new SMutableArray(receiver.getEmptyStorage(storageType), receiver.getSOMClass());
+    return new SMutableArray(receiver.getEmptyStorage(), receiver.getSOMClass());
   }
 
   @Specialization(guards = "receiver.isPartiallyEmptyType()")
   public final SMutableArray doPartiallyEmptyArray(final SMutableArray receiver) {
     assert !receiver.getSOMClass()
                     .isTransferObject() : "Not yet supported, need to instantiate another class";
-    return new SMutableArray(receiver.getPartiallyEmptyStorage(storageType).copy(),
+    return new SMutableArray(receiver.getPartiallyEmptyStorage().copy(),
         receiver.getSOMClass());
   }
 
@@ -34,7 +32,7 @@ public abstract class CopyPrim extends UnaryExpressionNode {
   public final SMutableArray doObjectArray(final SMutableArray receiver) {
     assert !receiver.getSOMClass()
                     .isTransferObject() : "Not yet supported, need to instantiate another class";
-    return new SMutableArray(receiver.getObjectStorage(storageType).clone(),
+    return new SMutableArray(receiver.getObjectStorage().clone(),
         receiver.getSOMClass());
   }
 
@@ -42,7 +40,7 @@ public abstract class CopyPrim extends UnaryExpressionNode {
   public final SMutableArray doLongArray(final SMutableArray receiver) {
     assert !receiver.getSOMClass()
                     .isTransferObject() : "Not yet supported, need to instantiate another class";
-    return new SMutableArray(receiver.getLongStorage(storageType).clone(),
+    return new SMutableArray(receiver.getLongStorage().clone(),
         receiver.getSOMClass());
   }
 
@@ -50,7 +48,7 @@ public abstract class CopyPrim extends UnaryExpressionNode {
   public final SMutableArray doDoubleArray(final SMutableArray receiver) {
     assert !receiver.getSOMClass()
                     .isTransferObject() : "Not yet supported, need to instantiate another class";
-    return new SMutableArray(receiver.getDoubleStorage(storageType).clone(),
+    return new SMutableArray(receiver.getDoubleStorage().clone(),
         receiver.getSOMClass());
   }
 
@@ -58,7 +56,7 @@ public abstract class CopyPrim extends UnaryExpressionNode {
   public final SMutableArray doBooleanArray(final SMutableArray receiver) {
     assert !receiver.getSOMClass()
                     .isTransferObject() : "Not yet supported, need to instantiate another class";
-    return new SMutableArray(receiver.getBooleanStorage(storageType).clone(),
+    return new SMutableArray(receiver.getBooleanStorage().clone(),
         receiver.getSOMClass());
   }
 }

--- a/src/som/primitives/arrays/DoPrim.java
+++ b/src/som/primitives/arrays/DoPrim.java
@@ -3,7 +3,6 @@ package som.primitives.arrays;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.profiles.ValueProfile;
 
 import bd.primitives.Primitive;
 import som.interpreter.nodes.ExpressionNode;
@@ -20,8 +19,6 @@ import som.vmobjects.SBlock;
 @GenerateNodeFactory
 @Primitive(selector = "do:", receiverType = SArray.class, disabled = true)
 public abstract class DoPrim extends BinaryComplexOperation {
-  private final ValueProfile storageType = ValueProfile.createClassProfile();
-
   @Child private BlockDispatchNode block = BlockDispatchNodeGen.create();
 
   // TODO: tag properly, it is a loop and an access
@@ -32,7 +29,7 @@ public abstract class DoPrim extends BinaryComplexOperation {
 
   @Specialization(guards = "arr.isEmptyType()")
   public final SArray doEmptyArray(final SArray arr, final SBlock block) {
-    int length = arr.getEmptyStorage(storageType);
+    int length = arr.getEmptyStorage();
     try {
       if (SArray.FIRST_IDX < length) {
         execBlock(block, Nil.nilObject);
@@ -50,7 +47,7 @@ public abstract class DoPrim extends BinaryComplexOperation {
 
   @Specialization(guards = "arr.isPartiallyEmptyType()")
   public final SArray doPartiallyEmptyArray(final SArray arr, final SBlock block) {
-    PartiallyEmptyArray storage = arr.getPartiallyEmptyStorage(storageType);
+    PartiallyEmptyArray storage = arr.getPartiallyEmptyStorage();
     int length = storage.getLength();
     try {
       if (SArray.FIRST_IDX < length) {
@@ -69,7 +66,7 @@ public abstract class DoPrim extends BinaryComplexOperation {
 
   @Specialization(guards = "arr.isObjectType()")
   public final SArray doObjectArray(final SArray arr, final SBlock block) {
-    Object[] storage = arr.getObjectStorage(storageType);
+    Object[] storage = arr.getObjectStorage();
     int length = storage.length;
     try {
       if (SArray.FIRST_IDX < length) {
@@ -88,7 +85,7 @@ public abstract class DoPrim extends BinaryComplexOperation {
 
   @Specialization(guards = "arr.isLongType()")
   public final SArray doLongArray(final SArray arr, final SBlock block) {
-    long[] storage = arr.getLongStorage(storageType);
+    long[] storage = arr.getLongStorage();
     int length = storage.length;
     try {
       if (SArray.FIRST_IDX < length) {
@@ -107,7 +104,7 @@ public abstract class DoPrim extends BinaryComplexOperation {
 
   @Specialization(guards = "arr.isDoubleType()")
   public final SArray doDoubleArray(final SArray arr, final SBlock block) {
-    double[] storage = arr.getDoubleStorage(storageType);
+    double[] storage = arr.getDoubleStorage();
     int length = storage.length;
     try {
       if (SArray.FIRST_IDX < length) {
@@ -126,7 +123,7 @@ public abstract class DoPrim extends BinaryComplexOperation {
 
   @Specialization(guards = "arr.isBooleanType()")
   public final SArray doBooleanArray(final SArray arr, final SBlock block) {
-    boolean[] storage = arr.getBooleanStorage(storageType);
+    boolean[] storage = arr.getBooleanStorage();
     int length = storage.length;
     try {
       if (SArray.FIRST_IDX < length) {

--- a/src/som/primitives/arrays/ToArgumentsArrayNode.java
+++ b/src/som/primitives/arrays/ToArgumentsArrayNode.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.profiles.ValueProfile;
 
 import som.interpreter.SArguments;
 import som.interpreter.nodes.nary.ExprWithTagsNode;
@@ -19,7 +18,6 @@ import som.vmobjects.SArray;
     @NodeChild("somArray"),
     @NodeChild("receiver")})
 public abstract class ToArgumentsArrayNode extends ExprWithTagsNode {
-  private final ValueProfile storageType = ValueProfile.createClassProfile();
 
   public static final boolean isNull(final Object somArray) {
     return somArray == null;
@@ -38,7 +36,7 @@ public abstract class ToArgumentsArrayNode extends ExprWithTagsNode {
 
   @Specialization(guards = "somArray.isEmptyType()")
   public final Object[] doEmptyArray(final SArray somArray, final Object rcvr) {
-    Object[] result = new Object[somArray.getEmptyStorage(storageType) + 1];
+    Object[] result = new Object[somArray.getEmptyStorage() + 1];
     Arrays.fill(result, Nil.nilObject);
     result[SArguments.RCVR_IDX] = rcvr;
     return result;
@@ -55,19 +53,19 @@ public abstract class ToArgumentsArrayNode extends ExprWithTagsNode {
   public final Object[] doPartiallyEmptyArray(final SArray somArray,
       final Object rcvr) {
     return addRcvrToObjectArray(
-        rcvr, somArray.getPartiallyEmptyStorage(storageType).getStorage());
+        rcvr, somArray.getPartiallyEmptyStorage().getStorage());
   }
 
   @Specialization(guards = "somArray.isObjectType()")
   public final Object[] doObjectArray(final SArray somArray,
       final Object rcvr) {
-    return addRcvrToObjectArray(rcvr, somArray.getObjectStorage(storageType));
+    return addRcvrToObjectArray(rcvr, somArray.getObjectStorage());
   }
 
   @Specialization(guards = "somArray.isLongType()")
   public final Object[] doLongArray(final SArray somArray,
       final Object rcvr) {
-    long[] arr = somArray.getLongStorage(storageType);
+    long[] arr = somArray.getLongStorage();
     Object[] args = new Object[arr.length + 1];
     args[0] = rcvr;
     for (int i = 0; i < arr.length; i++) {
@@ -79,7 +77,7 @@ public abstract class ToArgumentsArrayNode extends ExprWithTagsNode {
   @Specialization(guards = "somArray.isDoubleType()")
   public final Object[] doDoubleArray(final SArray somArray,
       final Object rcvr) {
-    double[] arr = somArray.getDoubleStorage(storageType);
+    double[] arr = somArray.getDoubleStorage();
     Object[] args = new Object[arr.length + 1];
     args[0] = rcvr;
     for (int i = 0; i < arr.length; i++) {
@@ -91,7 +89,7 @@ public abstract class ToArgumentsArrayNode extends ExprWithTagsNode {
   @Specialization(guards = "somArray.isBooleanType()")
   public final Object[] doBooleanArray(final SArray somArray,
       final Object rcvr) {
-    boolean[] arr = somArray.getBooleanStorage(storageType);
+    boolean[] arr = somArray.getBooleanStorage();
     Object[] args = new Object[arr.length + 1];
     args[0] = rcvr;
     for (int i = 0; i < arr.length; i++) {

--- a/src/som/vmobjects/SArray.java
+++ b/src/som/vmobjects/SArray.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.profiles.ValueProfile;
 
 import som.vm.NotYetImplementedException;
 import som.vm.constants.Nil;
@@ -17,7 +16,6 @@ import som.vm.constants.Nil;
  */
 public abstract class SArray extends SAbstractObject {
   public static final int FIRST_IDX = 0;
-  public static final ValueProfile OBJECT_ARRAY_PROFILE = ValueProfile.createClassProfile();
 
   protected Object       storage;
   protected final SClass clazz;
@@ -56,9 +54,7 @@ public abstract class SArray extends SAbstractObject {
 
   public Object[] getObjectStorage() {
     assert isObjectType();
-    // TODO: `CompilerDirectives.castExact(storage, Object[].class);` can be
-    // used here instead of a ValueProfile (see issue #256).
-    return (Object[]) OBJECT_ARRAY_PROFILE.profile(storage);
+    return CompilerDirectives.castExact(storage, Object[].class);
   }
 
   public long[] getLongStorage() {

--- a/src/som/vmobjects/SArray.java
+++ b/src/som/vmobjects/SArray.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.profiles.ValueProfile;
 
 import som.vm.NotYetImplementedException;
 import som.vm.constants.Nil;
@@ -16,6 +17,7 @@ import som.vm.constants.Nil;
  */
 public abstract class SArray extends SAbstractObject {
   public static final int FIRST_IDX = 0;
+  public static final ValueProfile OBJECT_ARRAY_PROFILE = ValueProfile.createClassProfile();
 
   protected Object       storage;
   protected final SClass clazz;
@@ -44,32 +46,34 @@ public abstract class SArray extends SAbstractObject {
 
   public int getEmptyStorage() {
     assert isEmptyType();
-    return CompilerDirectives.castExact(storage, int.class);
+    return (int) storage;
   }
 
   public PartiallyEmptyArray getPartiallyEmptyStorage() {
     assert isPartiallyEmptyType();
-    return CompilerDirectives.castExact(storage, PartiallyEmptyArray.class);
+    return (PartiallyEmptyArray) storage;
   }
 
   public Object[] getObjectStorage() {
     assert isObjectType();
-    return CompilerDirectives.castExact(storage, Object[].class);
+    // TODO: `CompilerDirectives.castExact(storage, Object[].class);` can be
+    // used here instead of a ValueProfile (see issue #256).
+    return (Object[]) OBJECT_ARRAY_PROFILE.profile(storage);
   }
 
   public long[] getLongStorage() {
     assert isLongType();
-    return CompilerDirectives.castExact(storage, long[].class);
+    return (long[]) storage;
   }
 
   public double[] getDoubleStorage() {
     assert isDoubleType();
-    return CompilerDirectives.castExact(storage, double[].class);
+    return (double[]) storage;
   }
 
   public boolean[] getBooleanStorage() {
     assert isBooleanType();
-    return CompilerDirectives.castExact(storage, boolean[].class);
+    return (boolean[]) storage;
   }
 
   public boolean isEmptyType() {

--- a/src/som/vmobjects/SArray.java
+++ b/src/som/vmobjects/SArray.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.profiles.ValueProfile;
 
 import som.vm.NotYetImplementedException;
 import som.vm.constants.Nil;
@@ -43,34 +42,34 @@ public abstract class SArray extends SAbstractObject {
     return storage;
   }
 
-  public int getEmptyStorage(final ValueProfile storageType) {
+  public int getEmptyStorage() {
     assert isEmptyType();
-    return (int) storageType.profile(storage);
+    return CompilerDirectives.castExact(storage, int.class);
   }
 
-  public PartiallyEmptyArray getPartiallyEmptyStorage(final ValueProfile storageType) {
+  public PartiallyEmptyArray getPartiallyEmptyStorage() {
     assert isPartiallyEmptyType();
-    return (PartiallyEmptyArray) storageType.profile(storage);
+    return CompilerDirectives.castExact(storage, PartiallyEmptyArray.class);
   }
 
-  public Object[] getObjectStorage(final ValueProfile storageType) {
+  public Object[] getObjectStorage() {
     assert isObjectType();
-    return (Object[]) storageType.profile(storage);
+    return CompilerDirectives.castExact(storage, Object[].class);
   }
 
-  public long[] getLongStorage(final ValueProfile storageType) {
+  public long[] getLongStorage() {
     assert isLongType();
-    return (long[]) storageType.profile(storage);
+    return CompilerDirectives.castExact(storage, long[].class);
   }
 
-  public double[] getDoubleStorage(final ValueProfile storageType) {
+  public double[] getDoubleStorage() {
     assert isDoubleType();
-    return (double[]) storageType.profile(storage);
+    return CompilerDirectives.castExact(storage, double[].class);
   }
 
-  public boolean[] getBooleanStorage(final ValueProfile storageType) {
+  public boolean[] getBooleanStorage() {
     assert isBooleanType();
-    return (boolean[]) storageType.profile(storage);
+    return CompilerDirectives.castExact(storage, boolean[].class);
   }
 
   public boolean isEmptyType() {
@@ -124,9 +123,6 @@ public abstract class SArray extends SAbstractObject {
     }
     return storage;
   }
-
-  public static final ValueProfile PartiallyEmptyStorageType =
-      ValueProfile.createClassProfile();
 
   public static final class PartiallyEmptyArray {
     private final Object[] arr;
@@ -194,8 +190,6 @@ public abstract class SArray extends SAbstractObject {
       return new PartiallyEmptyArray(this);
     }
   }
-
-  public static final ValueProfile ObjectStorageType = ValueProfile.createClassProfile();
 
   public static class SMutableArray extends SArray {
 
@@ -275,7 +269,7 @@ public abstract class SArray extends SAbstractObject {
       } else {
         // if this is not true, this method is used in a wrong context
         assert isObjectType();
-        Object[] s = getObjectStorage(ObjectStorageType);
+        Object[] s = getObjectStorage();
         newArr = Arrays.copyOf(s, s.length + 1);
         newArr[s.length] = value;
       }
@@ -321,8 +315,6 @@ public abstract class SArray extends SAbstractObject {
       this.storage = newStorage;
     }
 
-    // private static final ValueProfile emptyStorageType = ValueProfile.createClassProfile();
-
     public final void transitionToObjectWithAll(final long length, final Object val) {
       Object[] arr = new Object[(int) length];
       Arrays.fill(arr, val);
@@ -354,7 +346,7 @@ public abstract class SArray extends SAbstractObject {
     }
 
     public final void ifFullOrObjectTransitionPartiallyEmpty() {
-      PartiallyEmptyArray arr = getPartiallyEmptyStorage(PartiallyEmptyStorageType);
+      PartiallyEmptyArray arr = getPartiallyEmptyStorage();
 
       if (arr.isFull()) {
         if (arr.getType() == PartiallyEmptyArray.Type.LONG) {

--- a/src/som/vmobjects/SFileDescriptor.java
+++ b/src/som/vmobjects/SFileDescriptor.java
@@ -7,7 +7,6 @@ import java.io.RandomAccessFile;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.profiles.BranchProfile;
-import com.oracle.truffle.api.profiles.ValueProfile;
 
 import som.interpreter.nodes.ExceptionSignalingNode;
 import som.interpreter.nodes.dispatch.BlockDispatchNode;
@@ -18,8 +17,6 @@ import som.vmobjects.SArray.SMutableArray;
 
 
 public class SFileDescriptor extends SObjectWithClass {
-  /** Data buffers in this file descriptor are expected to contain only integers. */
-  private static final ValueProfile longStorageType = ValueProfile.createClassProfile();
 
   @CompilationFinal public static SClass fileDescriptorClass;
 
@@ -86,7 +83,7 @@ public class SFileDescriptor extends SObjectWithClass {
       return 0;
     }
 
-    long[] storage = buffer.getLongStorage(longStorageType);
+    long[] storage = buffer.getLongStorage();
     byte[] buff = new byte[bufferSize];
     int bytes = 0;
 
@@ -124,7 +121,7 @@ public class SFileDescriptor extends SObjectWithClass {
       return;
     }
 
-    long[] storage = buffer.getLongStorage(longStorageType);
+    long[] storage = buffer.getLongStorage();
     byte[] buff = new byte[bufferSize];
 
     for (int i = 0; i < bufferSize; i++) {

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -362,14 +362,14 @@ public class TracingBackend {
         throws IOException {
       SImmutableArray sia = aw.immArray;
 
-      Object[] outer = sia.getObjectStorage(SArray.ObjectStorageType);
+      Object[] outer = sia.getObjectStorage();
       byte[][][] bouter = new byte[outer.length][][];
       byte[] endRow = {ENDROW};
       int numBytes = 0;
       for (int i = 0; i < outer.length; i++) {
         Object o = outer[i];
         SImmutableArray ia = (SImmutableArray) o;
-        Object[] inner = ia.getObjectStorage(SArray.ObjectStorageType);
+        Object[] inner = ia.getObjectStorage();
         byte[][] binner = new byte[inner.length + 1][];
         for (int j = 0; j < inner.length; j++) {
           Object oo = inner[j];


### PR DESCRIPTION
The assumption is that performance should remain the same (benchmarks needed for verification). At the same time, this change would simplify code.

Closes #255