### PR TITLE
Update to mx with support for compilation from tar ball

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,9 @@ matrix:
         export JAVA_HOME=`/usr/libexec/java_home`
 
   allow_failures:
-    - env: TASK=replay1-tests
-    - env: TASK=replay2-tests
+    - env: TASK=unit-tests JDK=10
+    - jdk: oraclejdk9
+    - os: osx
 
 install: |
   if [ "$TASK" = "checkstyle" ]

--- a/build.xml
+++ b/build.xml
@@ -73,15 +73,15 @@
     </target>
 
     <target name="check-truffle-available">
-        <available file="${lib.dir}/truffle/.git" property="truffle.present"/>
+        <available file="${truffle.dir}" property="truffle.present"/>
     </target>
-    <target name="truffle" depends="check-truffle-available"
+    <target name="truffle-submodule" depends="check-truffle-available"
             unless="truffle.present">
       <exec executable="./.gitloadmodules" failonerror="true">
       </exec>
     </target>
 
-    <target name="truffle-libs" unless="skip.truffle" depends="truffle,build-graal">
+    <target name="truffle-libs" unless="skip.truffle" depends="truffle-submodule,build-graal">
         <exec executable="${mx.cmd}" dir="${truffle.dir}" failonerror="true">
             <arg value="build"/>
             <arg value="--no-native"/>


### PR DESCRIPTION
This change updates MX so that we are able to compile SOMns from its sources without requiring a git repo around.