### PR TITLE
Various fixes before Truffle update

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -58,6 +58,7 @@
     <target name="clean" description="Remove build directories and generated code">
         <delete dir="${build.dir}"/>
         <delete dir="${src_gen.dir}"/>
+        <ant dir="${corelib.dir}/TestSuite/extension" useNativeBasedir="true" target="clean" inheritAll="false" />
     </target>
 
     <target name="clean-truffle" depends="check-truffle-available" if="truffle.present">
@@ -245,8 +246,7 @@
     </target>
 
     <target name="compile-test-extension">
-      <ant dir="${corelib.dir}/TestSuite/extension" useNativeBasedir="true" target="jar" inheritAll="false">
-      </ant>
+      <ant dir="${corelib.dir}/TestSuite/extension" useNativeBasedir="true" target="jar" inheritAll="false" />
     </target>
 
     <target name="kompos" description="Build Kompos">

--- a/core-lib/TestSuite/extension/.checkstyle
+++ b/core-lib/TestSuite/extension/.checkstyle
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
+  <local-check-config name="Checks" location=".checkstyle_checks.xml" type="project" description="">
+    <additional-data name="protect-config-file" value="false"/>
+  </local-check-config>
+  <fileset name="all" enabled="true" check-config-name="Checks" local="true">
+    <file-match-pattern match-pattern="." include-pattern="true"/>
+  </fileset>
+  <filter name="DerivedFiles" enabled="true"/>
+</fileset-config>

--- a/core-lib/TestSuite/extension/.checkstyle_checks.xml
+++ b/core-lib/TestSuite/extension/.checkstyle_checks.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!--
+    This configuration file was written by the eclipse-cs plugin configuration editor
+-->
+<!--
+    Checkstyle-Configuration: Checks
+    Description: none
+-->
+<module name="Checker">
+  <property name="severity" value="error"/>
+  <module name="TreeWalker">
+    <property name="tabWidth" value="4"/>
+    <module name="JavadocStyle">
+      <property name="checkHtml" value="false"/>
+    </module>
+    <module name="LocalFinalVariableName"/>
+    <module name="LocalVariableName">
+      <property name="format" value="^[a-z_][a-zA-Z0-9_]*$"/>
+    </module>
+    <module name="MemberName">
+      <property name="format" value="^(([a-z][a-zA-Z0-9_]*$)|(_[A-Z][a-zA-Z0-9]*_[a-z][a-zA-Z0-9]*$))"/>
+    </module>
+    <module name="MethodName">
+      <property name="format" value="^[a-z][a-z_A-Z0-9]*$"/>
+    </module>
+    <module name="PackageName"/>
+    <module name="ParameterName">
+      <property name="format" value="^[a-z][a-z_A-Z0-9]*$"/>
+    </module>
+    <module name="TypeName">
+      <property name="format" value="^[A-Z][_a-zA-Z0-9]*$"/>
+    </module>
+    <module name="RedundantImport"/>
+    <module name="LineLength">
+      <property name="max" value="550"/>
+    </module>
+    <module name="MethodParamPad"/>
+    <module name="NoWhitespaceAfter">
+      <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
+    </module>
+    <module name="NoWhitespaceBefore"/>
+    <module name="ParenPad"/>
+    <module name="TypecastParenPad">
+      <property name="tokens" value="RPAREN,TYPECAST"/>
+    </module>
+    <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAround">
+      <property name="tokens" value="ASSIGN,BAND,BAND_ASSIGN,BOR,BOR_ASSIGN,BSR,BSR_ASSIGN,BXOR,BXOR_ASSIGN,COLON,DIV,DIV_ASSIGN,EQUAL,GE,GT,LAND,LE,LITERAL_ASSERT,LITERAL_CATCH,LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_RETURN,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,LOR,LT,MINUS,MINUS_ASSIGN,MOD,MOD_ASSIGN,NOT_EQUAL,PLUS,PLUS_ASSIGN,QUESTION,SL,SLIST,SL_ASSIGN,SR,SR_ASSIGN,STAR,STAR_ASSIGN,TYPE_EXTENSION_AND"/>
+      <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyMethods" value="true"/>
+      <property name="allowEmptyCatches" value="true"/>
+    </module>
+    <module name="RedundantModifier"/>
+    <module name="AvoidNestedBlocks">
+      <property name="allowInSwitchCase" value="true"/>
+    </module>
+    <module name="EmptyBlock">
+      <property name="option" value="text"/>
+      <property name="tokens" value="LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_IF,LITERAL_TRY,LITERAL_WHILE,STATIC_INIT"/>
+    </module>
+    <module name="LeftCurly">
+      <property name="severity" value="ignore"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="NeedBraces"/>
+    <module name="RightCurly">
+      <property name="severity" value="ignore"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="EmptyStatement"/>
+    <module name="HiddenField">
+      <property name="severity" value="ignore"/>
+      <property name="ignoreConstructorParameter" value="true"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="FinalClass"/>
+    <module name="HideUtilityClassConstructor">
+      <property name="severity" value="ignore"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="ArrayTypeStyle"/>
+    <module name="UpperEll"/>
+    <module name="FallThrough"/>
+    <module name="FinalLocalVariable">
+      <property name="severity" value="ignore"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="StringLiteralEquality">
+      <property name="severity" value="error"/>
+    </module>
+    <module name="SuperFinalize"/>
+    <module name="UnnecessaryParentheses">
+      <property name="severity" value="ignore"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="Indentation">
+      <property name="severity" value="ignore"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="StaticVariableName">
+      <property name="format" value="^[A-Za-z][a-zA-Z0-9]*$"/>
+    </module>
+    <module name="EmptyForInitializerPad"/>
+    <module name="EmptyForIteratorPad"/>
+    <module name="ModifierOrder"/>
+    <module name="DefaultComesLast"/>
+    <module name="InnerAssignment">
+      <property name="severity" value="ignore"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="JUnitTestCase">
+      <property name="severity" value="ignore"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="ModifiedControlVariable"/>
+    <module name="MutableException">
+      <property name="severity" value="ignore"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="ParameterAssignment">
+      <property name="severity" value="ignore"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <metadata name="net.sf.eclipsecs.core.comment" value="Illegal trailing whitespace(s) at the end of the line."/>
+      <property name="format" value="\s$"/>
+      <property name="message" value="Illegal trailing whitespace(s) at the end of the line."/>
+      <property name="ignoreComments" value="true"/>
+      <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Checks for trailing spaces at the end of a line"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <metadata name="net.sf.eclipsecs.core.comment" value="illegal space before a comma"/>
+      <property name="format" value=" ,"/>
+      <property name="message" value="illegal space before a comma"/>
+      <property name="ignoreComments" value="true"/>
+      <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Checks for whitespace before a comma."/>
+      <metadata name="com.atlassw.tools.eclipse.checkstyle.customMessage" value="Illegal whitespace before a comma."/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <metadata name="net.sf.eclipsecs.core.comment" value="needs a space after comment start"/>
+      <property name="format" value="[^:&quot;]//[^&quot;\s]"/>
+      <property name="message" value="needs a space after comment start"/>
+    </module>
+    <module name="RegexpSinglelineJava">
+      <property name="id" value="sysout"/>
+      <property name="format" value="System\.(out|err)\.print"/>
+      <property name="message" value="System\.(out|err)\.print should be avoided. Use a logging method instead."/>
+    </module>
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="Checkstyle: stop"/>
+      <property name="onCommentFormat" value="Checkstyle: resume"/>
+      <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Disable all checks"/>
+    </module>
+  </module>
+  <module name="SuppressionFilter">
+    <property name="file" value="${basedir}/.checkstyle_suppressions.xml"/>
+  </module>
+  <module name="RegexpHeader">
+    <property name="severity" value="ignore"/>
+    <property name="header" value="(?m)/\*\*\n \* Copyright((.*\n)*) \*/\n"/>
+    <property name="fileExtensions" value="java"/>
+    <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+  </module>
+  <module name="FileTabCharacter">
+    <property name="severity" value="error"/>
+  </module>
+  <module name="NewlineAtEndOfFile">
+    <property name="lineSeparator" value="lf"/>
+  </module>
+  <module name="RegexpMultiline">
+    <metadata name="net.sf.eclipsecs.core.comment" value="illegal Windows line ending"/>
+    <property name="format" value="\r\n"/>
+    <property name="message" value="illegal Windows line ending"/>
+  </module>
+  <module name="Translation"/>
+</module>

--- a/core-lib/TestSuite/extension/.checkstyle_suppressions.xml
+++ b/core-lib/TestSuite/extension/.checkstyle_suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+"-//Puppy Crawl//DTD Suppressions 1.1//EN"
+"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<suppressions>
+  <suppress files="[\\]tests/dym[\\]" checks=".*"/>
+  <suppress files=".*\.csv" checks=".*"/>
+  <suppress files=".*\.bz2" checks=".*"/>
+</suppressions>

--- a/core-lib/TestSuite/extension/.gitignore
+++ b/core-lib/TestSuite/extension/.gitignore
@@ -1,0 +1,2 @@
+/src_gen/
+/bin/

--- a/core-lib/TestSuite/extension/README.md
+++ b/core-lib/TestSuite/extension/README.md
@@ -1,0 +1,10 @@
+# SOMns Extension for Testing
+
+This is a SOMns extension module, which is used to test the SOMns functionality.
+
+Similar to SOMns, the extension uses `ant` as build systems.
+
+The `build.xml` file defines the various build tasks. It contains examples of
+how to create the `somns.properties` file (see the `compile` task) as well as
+an example for adding a JAR dependency to the module's own `Class-Path`
+property in its manifest file (see the `jar` task).

--- a/core-lib/TestSuite/extension/src/ext/ExtensionPrims.java
+++ b/core-lib/TestSuite/extension/src/ext/ExtensionPrims.java
@@ -8,7 +8,7 @@ import dep.SomeDependency;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
 
 
-public class ExtensionPrims {
+public abstract class ExtensionPrims {
 
   private static long cnt = 0;
 

--- a/src/som/UncaughtExceptions.java
+++ b/src/som/UncaughtExceptions.java
@@ -30,6 +30,9 @@ public final class UncaughtExceptions implements UncaughtExceptionHandler {
       Output.errorPrintln("Processing failed for: "
           + thread.getActivity().toString());
     }
+
+    Output.errorPrintln(
+        "Stack Trace: (printing may fail in some situation with a null pointer exception");
     e.printStackTrace();
 
     vm.requestExit(2);

--- a/src/som/interpreter/LexicalScope.java
+++ b/src/som/interpreter/LexicalScope.java
@@ -245,7 +245,12 @@ public abstract class LexicalScope {
 
     @Override
     public MethodScope getOuterScopeOrNull() {
-      return outerScope.getMethodScope();
+      if (outerScope == null) {
+        // this can only happen for superclass resolution methods
+        return null;
+      } else {
+        return outerScope.getMethodScope();
+      }
     }
 
     @Override
@@ -395,13 +400,13 @@ public abstract class LexicalScope {
     @Override
     public boolean lookupSlotOrClass(final SSymbol selector,
         final List<MixinDefinitionId> results) {
-      assert outerScope != null : "Should not be possible, because we do not support top-level methods";
+      assert outerScope != null : "Should not be possible, because we do not support top-level methods, except for superclass resolution";
       // this traversal concerns only the enclosing objects, not the activations
       return outerScope.lookupSlotOrClass(selector, results);
     }
 
     public MethodScope getEmbeddedScope(final SourceSection source) {
-      assert embeddedScopes != null : "Something is wrong, trying to get embedded scope for leaf method";
+      assert embeddedScopes != null : "Something is wrong, trying to get embedded scope for leaf method, except for superclass resolution";
       for (MethodScope s : embeddedScopes) {
         if (s.method.getSourceSection().equals(source)) {
           return s;

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -265,9 +265,8 @@ public class Actor implements Activity {
         ObjectTransitionSafepoint.INSTANCE.unregister();
       }
 
-      if (VmSettings.ACTOR_TRACING && t.swapTracingBuffer) {
-        t.getBuffer().swapStorage();
-        t.swapTracingBuffer = false;
+      if (VmSettings.ACTOR_TRACING || VmSettings.KOMPOS_TRACING) {
+        t.swapTracingBufferIfRequestedUnsync();
       }
       t.currentlyExecutingActor = null;
     }

--- a/src/som/interpreter/nodes/ExpressionNode.java
+++ b/src/som/interpreter/nodes/ExpressionNode.java
@@ -49,10 +49,6 @@ public abstract class ExpressionNode extends SOMNode {
 
   protected ExpressionNode(final ExpressionNode wrapped) {}
 
-  public boolean assertIsStatement() {
-    return isTaggedWith(StatementTag.class);
-  }
-
   public void markAsRootExpression() {
     throw new UnsupportedOperationException();
   }

--- a/src/som/interpreter/nodes/dispatch/ClassSlotAccessNode.java
+++ b/src/som/interpreter/nodes/dispatch/ClassSlotAccessNode.java
@@ -64,7 +64,7 @@ public final class ClassSlotAccessNode extends CachedSlotRead {
       try {
         // recheck guard under synchronized, don't want to access object if
         // layout might have changed, we are going to slow path in that case
-        read.guard.entryMatches(rcvr);
+        guard.entryMatches(rcvr);
         cachedValue = read.read(rcvr);
       } catch (InvalidAssumptionException e) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
@@ -93,7 +93,7 @@ public final class ClassSlotAccessNode extends CachedSlotRead {
       //
       // at this point the guard will fail, if it failed for the read guard,
       // but we simply recheck here to avoid impact on fast path
-      write.guard.entryMatches(rcvr);
+      guard.entryMatches(rcvr);
       write.doWrite(rcvr, classObject);
     } catch (InvalidAssumptionException e) {
       CompilerDirectives.transferToInterpreterAndInvalidate();

--- a/src/som/primitives/ActivityJoin.java
+++ b/src/som/primitives/ActivityJoin.java
@@ -13,6 +13,7 @@ import som.interpreter.nodes.nary.UnaryExpressionNode;
 import som.primitives.threading.TaskThreads.SomTaskOrThread;
 import som.vm.VmSettings;
 import tools.concurrency.KomposTrace;
+import tools.concurrency.Tags;
 import tools.concurrency.Tags.ExpressionBreakpoint;
 import tools.debugger.entities.ReceiveOp;
 
@@ -58,7 +59,7 @@ public class ActivityJoin {
 
     @Override
     protected boolean isTaggedWithIgnoringEagerness(final Class<?> tag) {
-      if (tag == ActivityJoin.class || tag == ExpressionBreakpoint.class) {
+      if (tag == Tags.ActivityJoin.class || tag == ExpressionBreakpoint.class) {
         return true;
       }
       return super.isTaggedWith(tag);

--- a/src/som/primitives/arrays/AtPutPrim.java
+++ b/src/som/primitives/arrays/AtPutPrim.java
@@ -62,7 +62,7 @@ public abstract class AtPutPrim extends TernaryExpressionNode {
 
       if (forAtomic) {
         return TxTernaryArrayOpNodeGen.create((TernaryExpressionNode) node, null, null, null)
-                                      .initialize(section);
+                                      .initialize(section, eagerWrapper);
       } else {
         return node;
       }

--- a/src/tools/Tagging.java
+++ b/src/tools/Tagging.java
@@ -28,6 +28,10 @@ public abstract class Tagging {
         @SuppressWarnings("unchecked")
         Set<Class<? extends Tags>> tags = t;
 
+        if (node.getSourceSection() == null) {
+          return true;
+        }
+
         if (tags.size() > 0) {
           if (sourceSectionsAndTags.containsKey(node.getSourceSection())) {
             sourceSectionsAndTags.get(node.getSourceSection()).addAll(tags);

--- a/src/tools/concurrency/TracingActors.java
+++ b/src/tools/concurrency/TracingActors.java
@@ -72,10 +72,6 @@ public class TracingActors {
 
     public static void handleBreakpointsAndStepping(final EventualMessage msg,
         final WebDebugger dbg, final Actor actor) {
-      if (!VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
-        return;
-      }
-
       if (msg.getHaltOnReceive() || ((TracingActor) actor).isStepToNextTurn()) {
         dbg.prepareSteppingUntilNextRootNode();
         if (((TracingActor) actor).isStepToNextTurn()) { // reset flag
@@ -101,7 +97,7 @@ public class TracingActors {
 
     static {
       if (VmSettings.REPLAY) {
-        actorList = new WeakHashMap();
+        actorList = new WeakHashMap<>();
       }
     }
 

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -245,6 +245,9 @@ public class TracingBackend {
           runningThreads -= 1;
           result[i] = null;
           t.getBuffer().swapStorage();
+        } else if (t.swapTracingBufferIfThreadSuspendedInDebugger()) {
+          runningThreads -= 1;
+          result[i] = null;
         }
       }
     }

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -74,7 +74,8 @@ public enum SteppingType {
   },
 
   @SerializedName("stepIntoActivity")
-  STEP_INTO_ACTIVITY("stepIntoActivity", "Step into Activity", Group.ACTIVITY_STEPPING, "arrow-down", new Class[] {ActivityCreation.class}) {
+  STEP_INTO_ACTIVITY("stepIntoActivity", "Step into Activity", Group.ACTIVITY_STEPPING,
+      "arrow-down", new Class[] {ActivityCreation.class}) {
     @Override
     public void process(final Suspension susp) {
       susp.getEvent().prepareStepOver(1);
@@ -83,8 +84,8 @@ public enum SteppingType {
   },
 
   @SerializedName("returnFromActivity")
-  RETURN_FROM_ACTIVITY("returnFromActivity", "Return from Activity", Group.ACTIVITY_STEPPING, "arrow-left",
-      null,
+  RETURN_FROM_ACTIVITY("returnFromActivity", "Return from Activity", Group.ACTIVITY_STEPPING,
+      "arrow-left", null,
       new ActivityType[] {ActivityType.PROCESS, ActivityType.TASK, ActivityType.THREAD}) {
     @Override
     public void process(final Suspension susp) {
@@ -94,7 +95,8 @@ public enum SteppingType {
   },
 
   @SerializedName("stepToChannelRcvr")
-  STEP_TO_CHANNEL_RCVR("stepToChannelRcvr", "Step to Receiver", Group.PROCESS_STEPPING, "arrow-right", new Class[] {ChannelWrite.class}) {
+  STEP_TO_CHANNEL_RCVR("stepToChannelRcvr", "Step to Receiver", Group.PROCESS_STEPPING,
+      "arrow-right", new Class[] {ChannelWrite.class}) {
     @Override
     public void process(final Suspension susp) {
       susp.getEvent().prepareStepOver(1);
@@ -103,7 +105,8 @@ public enum SteppingType {
   },
 
   @SerializedName("stepToChannelSender")
-  STEP_TO_CHANNEL_SENDER("stepToChannelSender", "Step to Sender", Group.PROCESS_STEPPING, "arrow-left", new Class[] {ChannelRead.class}) {
+  STEP_TO_CHANNEL_SENDER("stepToChannelSender", "Step to Sender", Group.PROCESS_STEPPING,
+      "arrow-left", new Class[] {ChannelRead.class}) {
     @Override
     public void process(final Suspension susp) {
       susp.getEvent().prepareStepInto(1);
@@ -112,7 +115,8 @@ public enum SteppingType {
   },
 
   @SerializedName("stepToNextTx")
-  STEP_TO_NEXT_TX("stepToNextTx", "Step to next Transaction", Group.ACTIVITY_STEPPING, "arrow-right", null, null) {
+  STEP_TO_NEXT_TX("stepToNextTx", "Step to next Transaction", Group.ACTIVITY_STEPPING,
+      "arrow-right", null, null) {
     @Override
     public void process(final Suspension susp) {
       susp.getEvent().prepareContinue();

--- a/src/tools/debugger/entities/SteppingType.java
+++ b/src/tools/debugger/entities/SteppingType.java
@@ -1,7 +1,6 @@
 package tools.debugger.entities;
 
 import com.google.gson.annotations.SerializedName;
-import com.oracle.truffle.api.debug.SuspendedEvent;
 
 import som.vm.NotYetImplementedException;
 import tools.concurrency.Tags;
@@ -215,11 +214,9 @@ public enum SteppingType {
   }
 
   private static void handleFrameSkip(final Suspension susp) {
-    if (susp.getFrameSkipCount() > 0) {
-      SuspendedEvent event = susp.getEvent();
-      for (int i = 0; i < susp.getFrameSkipCount(); i += 1) {
-        event.prepareStepOut(1);
-      }
+    int skipCnt = susp.getFrameSkipCount();
+    if (skipCnt > 1) {
+      susp.getEvent().prepareStepOut(skipCnt - 1); // -1 for correct step-out semantics
     }
   }
 

--- a/src/tools/debugger/frontend/Suspension.java
+++ b/src/tools/debugger/frontend/Suspension.java
@@ -146,6 +146,7 @@ public class Suspension {
   public void suspend() {
     // don't participate in safepoints while being suspended
     ObjectTransitionSafepoint.INSTANCE.unregister();
+    activityThread.markThreadAsSuspendedInDebugger();
 
     boolean continueWaiting = true;
     while (continueWaiting) {
@@ -174,6 +175,7 @@ public class Suspension {
       stack = null;
     }
 
+    activityThread.markThreadAsResumedFromDebugger();
     ObjectTransitionSafepoint.INSTANCE.register();
   }
 

--- a/tools/kompos/tests/basic-protocol.ts
+++ b/tools/kompos/tests/basic-protocol.ts
@@ -1,20 +1,13 @@
 "use strict";
 
 import { expect } from "chai";
-import * as fs from "fs";
 import { X_OK } from "constants";
-
-import {
-  SOM, PING_PONG_URI, ControllerWithInitialBreakpoints,
-  TestConnection, HandleStoppedAndGetStackTrace,
-  expectStack, expectSourceCoordinate
-} from "./test-setup";
-
-import {
-  SourceMessage, createLineBreakpointData,
-  createSectionBreakpointData
-} from "../src/messages";
+import * as fs from "fs";
+import { createLineBreakpointData, createSectionBreakpointData, SourceMessage } from "../src/messages";
 import { BreakpointType as BT, SteppingType as ST } from "./somns-support";
+import { ControllerWithInitialBreakpoints, expectSourceCoordinate, expectStack, HandleStoppedAndGetStackTrace, PING_PONG_URI, SOM, TestConnection, getCmd } from "./test-setup";
+
+
 
 let connectionPossible = false;
 function onlyWithConnection(fn) {
@@ -282,6 +275,15 @@ describe("Basic Protocol", function() {
           });
 
           after(closeConnectionAfterSuite);
+
+          afterEach(function() {
+            if (this.currentTest.state === "failed") {
+              console.log("Failed test: " + suiteName);
+              console.log("To reproduce the issue:")
+              console.log("\tcmd: " + getCmd());
+              console.log("\tbp: " + JSON.stringify(testDesc.breakpoint));
+            }
+          });
 
           it(testDesc.test, onlyWithConnection(() => {
             return ctrl.stackPs[0].then(msg => {

--- a/tools/kompos/tests/stm.ns
+++ b/tools/kompos/tests/stm.ns
@@ -7,22 +7,14 @@ class STM usingPlatform: platform = Value (
   |  public field ::= 0. |
   )()
 
-  private doCount: o = (
+  private doCount: o id: id = (
     tx atomic: [
       | cnt |
       cnt:: o field.
       o field: cnt + 1.
     ].
 
-    o field println.
-
-    tx atomic: [
-      | cnt |
-      cnt:: o field.
-      o field: cnt + 1.
-    ].
-
-    o field println.
+    ('id: ' + id asString + ' val: ' + o field asString) println.
 
     tx atomic: [
       | cnt |
@@ -30,7 +22,15 @@ class STM usingPlatform: platform = Value (
       o field: cnt + 1.
     ].
 
-    o field println.
+    ('id: ' + id asString + ' val: ' + o field asString) println.
+
+    tx atomic: [
+      | cnt |
+      cnt:: o field.
+      o field: cnt + 1.
+    ].
+
+    ('id: ' + id asString + ' val: ' + o field asString) println.
   )
 
   public main: args = (
@@ -38,9 +38,9 @@ class STM usingPlatform: platform = Value (
     'STM example\n' println.
     o:: MyObj new.
 
-    Thread spawn: [ doCount: o ].
+    Thread spawn: [ doCount: o id: 2 ].
 
-    doCount: o.
+    doCount: o id: 1.
 
     ^ 0
   )

--- a/tools/kompos/tests/stm.ts
+++ b/tools/kompos/tests/stm.ts
@@ -27,13 +27,13 @@ const steppingTests: Test[] = [
         activity: "main",
         stops: [{
           line: 11,
-          methodName: "STM>>#doCount:",
+          methodName: "STM>>#doCount:id:",
           stackHeight: 6,
           activity: "main"
         },
         {
           line: 11,
-          methodName: "STM>>#doCount:",
+          methodName: "STM>>#doCount:id:",
           stackHeight: 2,
           activity: "thread2"
         }]
@@ -43,7 +43,7 @@ const steppingTests: Test[] = [
         activity: "main",
         stops: [{
           line: 13,
-          methodName: "STM>>#λdoCount@11@16",
+          methodName: "STM>>#λdoCountid@11@16",
           stackHeight: 7,
           activity: "main"
         }]
@@ -53,7 +53,7 @@ const steppingTests: Test[] = [
         activity: "thread2",
         stops: [{
           line: 13,
-          methodName: "STM>>#λdoCount@11@16",
+          methodName: "STM>>#λdoCountid@11@16",
           stackHeight: 3,
           activity: "thread2"
         }]
@@ -63,7 +63,7 @@ const steppingTests: Test[] = [
         activity: "main",
         stops: [{
           line: 17,
-          methodName: "STM>>#doCount:",
+          methodName: "STM>>#doCount:id:",
           stackHeight: 6,
           activity: "main"
         }]
@@ -73,7 +73,7 @@ const steppingTests: Test[] = [
         activity: "thread2",
         stops: [{
           line: 13,
-          methodName: "STM>>#λdoCount@11@16",
+          methodName: "STM>>#λdoCountid@11@16",
           stackHeight: 3,
           activity: "thread2"
         }]

--- a/tools/kompos/tests/test-setup.ts
+++ b/tools/kompos/tests/test-setup.ts
@@ -150,7 +150,7 @@ export class TestConnection extends VmConnection {
               reject(new Error("SOMns failed to starting WebSocket and/or HTTP Server. StdOut: " + dataStr + " StdErr: " + stdErr));
             });
           });
-          this.somProc.kill();
+          this.somProc.kill("SIGKILL");
         }
       });
     });
@@ -161,7 +161,7 @@ export class TestConnection extends VmConnection {
     if (!this.closed) {
       this.closed = true;
       this.disconnect();
-      this.somProc.kill();
+      this.somProc.kill("SIGKILL");
     }
 
     done();


### PR DESCRIPTION
This PR prepares updating Truffle by fix various issues that were found in the update process.

Most notably:

 - use parameter of step-out operation https://github.com/smarr/SOMns/commit/93ad33e2bf87460bcf138b352dddf5dc7ad6a15c
 - fix wrong ActivityJoin tag https://github.com/smarr/SOMns/commit/c945606a6ead3d05f00c7e441d01e6930637ec4d
 - fix initialization of transactional `#at:put:` https://github.com/smarr/SOMns/commit/532415337833d476362fc1561bc3d4d49bbbaf61
 - add some maintainability bits for extension tests https://github.com/smarr/SOMns/commit/dd2c09ec136c6a49cf616669fa0753aa3061c378
 - `ClassSlotAccessNode`: use guard in node https://github.com/smarr/SOMns/commit/da4d5cb8be408daa2bf75a7f2f3c5fb2f5a832a9
 - fix swapping of tracing buffers for Kompos https://github.com/smarr/SOMns/commit/70e0c3657555f047458e0c2dfdf1cc79b59eb197  
   @daumayr could you please review this change? (also after merging)
 