### PR TITLE
Fix replay test flakiness

### DIFF
--- a/src/som/Launcher.java
+++ b/src/som/Launcher.java
@@ -38,8 +38,8 @@ public final class Launcher {
 
     TracingBackend.waitForTrace();
 
-    if (ReplayActor.printMissingMessages() && exitCode == 0) {
-      exitCode = EXIT_WITH_ERROR;
+    if (exitCode != 0) {
+      ReplayActor.printMissingMessages();
     }
 
     if (VmSettings.MEMORY_TRACING) {

--- a/src/tools/concurrency/TracingActors.java
+++ b/src/tools/concurrency/TracingActors.java
@@ -245,11 +245,12 @@ public class TracingActors {
 
       if (msg instanceof PromiseMessage) {
         Output.println("PromiseMessage " + msg.getSelector()
-            + " from " + msg.getSender().getId() + " PID "
+            + " from " + ((TracingActor) msg.getSender()).getActorId() + " PID "
             + ((STracingPromise) ((PromiseMessage) msg).getPromise()).getResolvingActor());
       } else {
         Output.println(
-            "Message" + msg.getSelector() + " from " + msg.getSender().getId());
+            "Message" + msg.getSelector() + " from "
+                + ((TracingActor) msg.getSender()).getActorId());
       }
     }
 
@@ -282,13 +283,13 @@ public class TracingActors {
 
       MessageRecord other = expectedMessages.peek();
 
-      if (msg instanceof PromiseMessage != other instanceof TraceParser.PromiseMessageRecord) {
+      if ((msg instanceof PromiseMessage) != (other instanceof TraceParser.PromiseMessageRecord)) {
         return false;
       }
 
       // handle promise messages
       if (msg instanceof PromiseMessage
-          && ((STracingPromise) ((PromiseMessage) msg).getPromise()).getResolvingActor() != ((TraceParser.PromiseMessageRecord) other).pId) {
+          && (((STracingPromise) ((PromiseMessage) msg).getPromise()).getResolvingActor() != ((TraceParser.PromiseMessageRecord) other).pId)) {
         return false;
       }
 


### PR DESCRIPTION
Exit code was changed to 1 when there were some unprocessed but expected messages at termination.
Exit code no longer touched by message check, message reports only printed when exiting with codes other than 0.