### PR TITLE
Fixes potential NullPointerException in ExpressionNode::toString

### DIFF
--- a/src/som/interpreter/nodes/ExpressionNode.java
+++ b/src/som/interpreter/nodes/ExpressionNode.java
@@ -160,6 +160,6 @@ public abstract class ExpressionNode extends SOMNode {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "(" + sourceSection.toString() + ")";
+    return getClass().getSimpleName() + "(" + String.valueOf(sourceSection) + ")";
   }
 }


### PR DESCRIPTION
The NPE is thrown when SourceSection == null