### PR TITLE
VMM'18 Demo and Kompos improvements

### DIFF
--- a/core-lib/demos/ReplayDemo.ns
+++ b/core-lib/demos/ReplayDemo.ns
@@ -1,0 +1,95 @@
+(* Written by Dominik Aumayr *)
+class ReplayDemo usingPlatform: platform = Value (
+| private actors    = platform actors.
+  private Array     = platform kernel Array.
+  private TransferArray= platform kernel TransferArray.
+  private harness   = (platform system loadModule: '../Benchmarks/Harness.ns' nextTo: self) usingPlatform: platform.
+  private Random    = harness Random.
+
+  private numCustomers = 11.
+  private numFlights = 10.
+  private numBookings = 1.
+|)(
+  public class Website new: completionRes = (
+  | private completionRes = completionRes.
+    private finishedCustomers ::= 0.
+    private flightPrices = TransferArray new: numFlights withAll: 50.
+    private resolved ::= false.
+  |)(
+    public requestFlights = (
+      ^ flightPrices.
+    )
+
+    public book: customer flight: flightId = (
+      ('Book flights for customer: ' + customer asString) println.
+      ^ flightPrices at: flightId.
+    )
+
+    public pay: customer flight: flightId amount: amount = (
+      amount = (flightPrices at: flightId)
+        ifTrue:[
+          (* customer paid correct price, ok *)
+          ('Payment succeeded. Booking confirmed for customer ' + customer) println.
+          (* flight is in demand, let's increase the price *)
+          flightPrices at: flightId put: (amount + 10) ]
+        ifFalse:[
+          (* didn't match price, fail *)
+          'Payment FAILED' println.
+          resolved ifFalse: [
+            completionRes resolve: false.
+            resolved:: true ] ]
+    )
+
+    public done = (
+      finishedCustomers:: finishedCustomers + 1.
+      finishedCustomers = numCustomers ifTrue: [
+        resolved ifFalse:[
+          completionRes resolve: true.
+          resolved:: true ] ]
+    )
+  )
+
+  public class Customer new: customerId website: web = (
+  | private id = customerId.
+    private web = web.
+    private rand = Random new: customerId + 73425.
+  |)(
+    public bookFlight = (
+      | flightId |
+      ('Customer starts booking flights. Customer id: ' + id) println.
+      numBookings timesRepeat: [
+        (web <-: requestFlights) whenResolved: [:flights |
+          flightId:: 1 + (rand next % numFlights).
+          web <-: book: id flight: flightId.
+          web <-: pay: id flight: flightId amount: (flights at: flightId).
+          web <-: done ] ]
+    )
+  )
+
+  public main: args = (
+    | customers website payment completionPP |
+
+    printBanner.
+
+    completionPP:: actors createPromisePair.
+    website:: (actors createActorFromValue: Website) <-: new: completionPP resolver.
+
+    customers:: Array new: numCustomers.
+    customers doIndexes: [:i |
+      | c |
+      c:: (actors createActorFromValue: Customer) <-: new: i website: website.
+      customers at: i put: c ].
+
+    customers do: [:c | c <-: bookFlight ].
+
+    ^ completionPP promise
+  )
+
+  private printBanner = (
+    '
+   /_\\  __ _ __  ___  /_\\ (_)_ _  |  \\/  (_)_ _ (_)
+  / _ \\/ _| \'  \\/ -_)/ _ \\| | \'_| | |\\/| | | \' \\| |
+ /_/ \\_\\__|_|_|_\\___/_/ \\_\\_|_|   |_|  |_|_|_||_|_|
+' println.
+  )
+)

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -427,8 +427,12 @@ public class TracingBackend {
 
     private void writeSymbols(final BufferedWriter bw) throws IOException {
       synchronized (symbolsToWrite) {
+        if (symbolsToWrite.isEmpty()) {
+          return;
+        }
+
         if (front != null) {
-          front.sendSymbols(TracingBackend.symbolsToWrite);
+          front.sendSymbols(symbolsToWrite);
         }
 
         if (bw != null) {

--- a/src/tools/debugger/FrontendConnector.java
+++ b/src/tools/debugger/FrontendConnector.java
@@ -93,7 +93,7 @@ public class FrontendConnector {
   private final Gson       gson;
   private static final int MESSAGE_PORT   = 7977;
   private static final int TRACE_PORT     = 7978;
-  private static final int HTTP_PORT      = 8888;
+  private static final int HTTP_PORT      = 8880;
   private static final int EPHEMERAL_PORT = 0;
 
   private final ArrayList<Source> sourceToBeSent = new ArrayList<>();

--- a/tools/kompos/index.html
+++ b/tools/kompos/index.html
@@ -304,6 +304,10 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
     width: 100%;
     clear: both;
   }
+  .trace-entry-no-source {
+    color: #999;
+    background-color: #dddddd;
+  }
   .trace-location {
     float:right;
     font-size:5px;

--- a/tools/kompos/index.html
+++ b/tools/kompos/index.html
@@ -15,6 +15,9 @@
   <title>Kompos Debugger</title>
 
   <style id="style-main">
+    .demo #debugger-log {display: none;}
+    .demo #debugger table {display: none;}
+
   #templates { display: none; }
 
   .filename  { font-family: sans-serif; }
@@ -193,9 +196,10 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
     max-height: 700px;
     overflow: auto;
   }
-  #code-views {
-    column-count: 2;
-  }
+
+  #code-views { column-count: 2; }
+  .demo #code-views { column-count: 1; }
+
   #debugger button {
     font-size: 75%;
     padding: 2px 6px 3px;
@@ -229,10 +233,14 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
   .activity-sources {
     padding: 0;
   }
+  .demo .activity-sources { font-size: 150%; }
+
   .activity-stack {
     font-size: 50%;
     width: 100%;
   }
+  .demo .activity-stack { font-size: 100%; }
+
   .activity-stack label {
     padding: 0.1rem .2rem;
     overflow: hidden;
@@ -296,6 +304,8 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
     top: 4ex;
     right: 1ex;
   }
+  .demo .system-status { top: 1ex; }
+
   .activity-state {
     margin:  0;
     padding: 0;
@@ -310,7 +320,7 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
   }
   .trace-location {
     float:right;
-    font-size:5px;
+    font-size:60%;
   }
   .trace-method {
     float:left;
@@ -349,6 +359,9 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
 <div class="btn-toolbar card-pane" role="toolbar" aria-label="Debugger Controls">
   <div class="btn-group btn-group-xs" role="group" aria-label="Basic Controls">
     <button id="dbg-connect-btn" type="button" class="btn btn-secondary btn-sm" onclick="ctrl.toggleConnection();">Connecting</button>
+  </div>
+  <div class="btn-group btn-group-xs" role="group" aria-label="Demo Mode" style="float: right;margin-left: 40%;font-size:45%">
+    <input type="checkbox" id="demo-checkbox" class="btn btn-secondary btn-sm" onclick="$('body').toggleClass('demo', this.checked);" /> demo
   </div>
 </div>
 

--- a/tools/kompos/index.html
+++ b/tools/kompos/index.html
@@ -230,7 +230,7 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
     padding: 0;
   }
   .activity-stack {
-    font-size: 75%;
+    font-size: 50%;
     width: 100%;
   }
   .activity-stack label {
@@ -397,7 +397,7 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
             </button>
           </div>
         </div>
-        <div class="activity-stack btn-group-vertical stack" data-toggle="buttons"></div>
+        <div class="activity-stack list-group stack" data-toggle="buttons"></div>
 
         <table class="activity-scopes"><tbody></tbody></table>
       </div>
@@ -406,9 +406,8 @@ https://github.com/ivyl/gedit-mate/blob/master/styles/Tango.xml
   <!-- This allows the cards to wrap earlier to the next column. Makes UI nicer. -->
   <div id="card-wrapper" class="card container-fluid force-wrap-card"></div>
 
-  <label id="stack-trace-elem-tpl" class="trace-entry btn btn-sm btn-secondary">
+  <label id="stack-trace-elem-tpl" class="trace-entry list-group-item">
     <span class="trace-method">
-      <input type="radio" name="options" autocomplete="off">
       <span class="trace-method-name"></span>
     </span>
     <span class="trace-location"></span>

--- a/tools/kompos/package.json
+++ b/tools/kompos/package.json
@@ -25,7 +25,7 @@
     "@types/mocha": "^5.2.4",
     "@types/node": "^10.5.2",
     "@types/ws": "^3.2.1",
-    "bootstrap": "^4.1.2",
+    "bootstrap": "^4.1.3",
     "popper.js": "^1.14.3",
     "d3": "^3.5.17",
     "font-awesome": "^4.7.0",

--- a/tools/kompos/src/debugger.ts
+++ b/tools/kompos/src/debugger.ts
@@ -1,6 +1,5 @@
 import {
-  IdMap, Source, StackFrame, SourceMessage, TaggedSourceCoordinate,
-  getSectionId
+  IdMap, Source, SourceMessage, TaggedSourceCoordinate, getSectionId
 } from "./messages";
 import { Breakpoint } from "./breakpoints";
 
@@ -41,15 +40,6 @@ export class Debugger {
 
   public getSource(id: string): Source {
     return this.sources[id];
-  }
-
-  public getSectionIdFromFrame(sourceId: string, frame: StackFrame) {
-    const line = frame.line,
-      column = frame.column,
-      length = frame.length;
-
-    return getSectionId(sourceId,
-      { startLine: line, startColumn: column, charLength: length });
   }
 
   public addSource(msg: SourceMessage): Source {

--- a/tools/kompos/src/execution-data.ts
+++ b/tools/kompos/src/execution-data.ts
@@ -1,9 +1,6 @@
-import {
-  SymbolMessage, FullSourceCoordinate, ActivityType, PassiveEntityType,
-  DynamicScopeType, SendOpType, ReceiveOpType
-} from "./messages";
+import { ActivityType, DynamicScopeType, FullSourceCoordinate, PassiveEntityType, ReceiveOpType, SendOpType, SymbolMessage } from "./messages";
+import { EntityRefType, KomposMetaModel } from "./meta-model";
 import { TraceParser } from "./trace-parser";
-import { KomposMetaModel, EntityRefType } from "./meta-model";
 
 
 export interface EntityProperties {

--- a/tools/kompos/src/messages.ts
+++ b/tools/kompos/src/messages.ts
@@ -12,6 +12,15 @@ export interface Source {
   methods: Method[];
 }
 
+export function getSectionIdFromFrame(sourceId: string, frame: StackFrame) {
+  const line = frame.line,
+    column = frame.column,
+    length = frame.length;
+
+  return getSectionId(sourceId,
+    { startLine: line, startColumn: column, charLength: length });
+}
+
 export function getSectionId(sourceId: string, section: SourceCoordinate) {
   return sourceId + ":" + section.startLine + ":" + section.startColumn + ":" +
     section.charLength;

--- a/tools/kompos/src/system-view-data.ts
+++ b/tools/kompos/src/system-view-data.ts
@@ -4,6 +4,7 @@ import { getEntityId, getEntityGroupId, getEntityGroupVizId, getEntityVizId } fr
 import { KomposMetaModel, EntityRefType } from "./meta-model";
 
 const NUM_ACTIVITIES_STARTING_GROUP = 4;
+const NUM_ENTITIES_STARTING_GROUP = 3;
 
 const HORIZONTAL_DISTANCE = 100;
 const VERTICAL_DISTANCE = 100;
@@ -98,7 +99,7 @@ class ActivityNodeImpl extends ActivityNode {
   public getActivityId() { return this.activity.id; }
 }
 
-class GroupNode extends ActivityNode {
+class ActivityGroupNode extends ActivityNode {
   private group: ActivityGroup;
 
   constructor(group: ActivityGroup, reflexive: boolean, x: number, y: number) {
@@ -108,7 +109,7 @@ class GroupNode extends ActivityNode {
 
   public getGroupSize() { return this.group.activities.length; }
   public isRunning() {
-    console.warn("GroupNode.isRunning() not yet implemented");
+    // TODO: GroupNode.isRunning() not yet implemented
     return true;
   }
   public getName() { return this.group.activities[0].name; }
@@ -130,7 +131,7 @@ class GroupNode extends ActivityNode {
   public getActivityId() { return this.group.activities[0].id; }
 }
 
-export abstract class AbstractPassiveEntityNode extends EntityNode {
+export abstract class PassiveEntityNode extends EntityNode {
   public readonly reflexive: boolean;
 
   constructor(x: number, y: number) {
@@ -138,13 +139,18 @@ export abstract class AbstractPassiveEntityNode extends EntityNode {
   }
 
   public abstract getGroupSize(): number;
-  public abstract getName(): string;
+  public abstract getLocationId(): string;
   public abstract getDataId(): string;
   public abstract getSystemViewId(): string;
   public abstract getEntityType(): EntityRefType;
 }
 
-export class PassiveEntityNode extends AbstractPassiveEntityNode {
+function getPassiveEntityLocationId(pe: PassiveEntity): string {
+  const ss = pe.origin;
+  return ss.uri + ":" + ss.startLine + ":" + ss.startColumn + ":" + ss.charLength
+}
+
+export class PassiveEntityNodeImpl extends PassiveEntityNode {
   public readonly entity: PassiveEntity;
   public messages?: number[][];
 
@@ -153,16 +159,14 @@ export class PassiveEntityNode extends AbstractPassiveEntityNode {
     this.entity = entity;
   }
 
-  public getGroupSize() { return 1 }
+  public getGroupSize() { return 1; }
   public getDataId() { return getEntityId(this.entity.id); }
   public getSystemViewId() { return getEntityVizId(this.entity.id); }
-  public getName() {
-    return getPEName(this.entity)
-  }
+  public getLocationId() { return getPassiveEntityLocationId(this.entity); }
   public getEntityType() { return EntityRefType.PassiveEntity; }
 }
 
-class PassiveGroupNode extends AbstractPassiveEntityNode {
+class PassiveGroupNode extends PassiveEntityNode {
   private group: PassiveEntityGroup;
 
   constructor(group: PassiveEntityGroup, x: number, y: number) {
@@ -170,26 +174,22 @@ class PassiveGroupNode extends AbstractPassiveEntityNode {
     this.group = group;
   }
 
-  public getGroupSize() { return this.group.promises.length; }
+  public getGroupSize() { return this.group.entities.length; }
 
   public getDataId() { return getEntityGroupId(this.group.id); }
   public getSystemViewId() { return getEntityGroupVizId(this.group.id); }
-  public getName() { return getPEName(this.group.promises[0]) }
+  public getLocationId() { return getPassiveEntityLocationId(this.group.entities[0]); }
+
   public getQueryForCodePane() {
     let result = "";
-    for (const p of this.group.promises) {
+    for (const e of this.group.entities) {
       if (result !== "") { result += ","; }
-      result += "#" + getEntityId(p.id);
+      result += "#" + getEntityId(e.id);
     }
     return result;
   }
 
   public getEntityType() { return EntityRefType.PassiveEntity; }
-}
-
-function getPEName(pe: PassiveEntity): string {
-  const ss = pe.origin;
-  return ss.uri + ":" + ss.startLine + ":" + ss.startColumn + ":" + ss.charLength
 }
 
 export interface EntityLink extends d3.layout.force.Link<EntityNode> {
@@ -202,12 +202,12 @@ export interface EntityLink extends d3.layout.force.Link<EntityNode> {
 interface ActivityGroup {
   id: number;
   activities: Activity[];
-  groupNode?: GroupNode;
+  groupNode?: ActivityGroupNode;
 }
 
 interface PassiveEntityGroup {
   id: number;
-  promises: PassiveEntity[];
+  entities: PassiveEntity[];
   groupNode?: PassiveGroupNode;
 }
 
@@ -234,9 +234,9 @@ export class SystemViewData {
 
   private activities: IdMap<ActivityNodeImpl>;
   private activitiesPerType: IdMap<ActivityGroup>;
-  private promisesPerLocation: IdMap<PassiveEntityGroup>;
 
-  private passiveEntities: IdMap<PassiveEntityNode>;
+  private passiveEntities: IdMap<PassiveEntityNodeImpl>;
+  private passiveEntitiesPerLocation: IdMap<PassiveEntityGroup>;
 
   private messages: SourceTargetMap;
 
@@ -254,7 +254,7 @@ export class SystemViewData {
     this.activities = {};
     this.activitiesPerType = {};
     this.passiveEntities = {};
-    this.promisesPerLocation = {};
+    this.passiveEntitiesPerLocation = {};
 
     this.maxMessageCount = 0;
 
@@ -294,7 +294,22 @@ export class SystemViewData {
     this.activities[act.id.toString()] = node;
   }
 
-  private getGroupOrActivity(id: number): ActivityNode {
+  private addPassiveEntity(pe: PassiveEntity) {
+    const numGroups = Object.keys(this.passiveEntitiesPerLocation).length;
+    const locationId = getPassiveEntityLocationId(pe);
+
+    if (!this.passiveEntitiesPerLocation[locationId]) {
+      this.passiveEntitiesPerLocation[locationId] = { id: numGroups, entities: [] };
+    }
+    this.passiveEntitiesPerLocation[locationId].entities.push(pe);
+
+    const node = new PassiveEntityNodeImpl(pe,
+      HORIZONTAL_DISTANCE + HORIZONTAL_DISTANCE * this.passiveEntitiesPerLocation[locationId].entities.length,
+      VERTICAL_DISTANCE * numGroups);
+    this.passiveEntities[pe.id.toString()] = node;
+  }
+
+  private getActivityGroupOrActivity(id: number): ActivityNode {
     const node = this.activities[id];
     console.assert(node !== undefined);
 
@@ -305,11 +320,11 @@ export class SystemViewData {
     return node;
   }
 
-  private getPassiveGroupOrActivity(id: number): AbstractPassiveEntityNode {
+  private getPassiveGroupOrEntity(id: number): PassiveEntityNode {
     const node = this.passiveEntities[id];
     console.assert(node !== undefined);
 
-    const group = this.promisesPerLocation[node.getName()];
+    const group = this.passiveEntitiesPerLocation[node.getLocationId()];
     if (group.groupNode) {
       return group.groupNode;
     }
@@ -338,37 +353,14 @@ export class SystemViewData {
     sourceTargetInc(this.messages, source, target);
   }
 
-
-
-  private addPassiveEntity(pe: PassiveEntity) {
-    if (pe.type === 5) {
-      // group Promises
-      const numGroups = Object.keys(this.promisesPerLocation).length;
-      if (!this.promisesPerLocation[getPEName(pe)]) {
-        this.promisesPerLocation[getPEName(pe)] = { id: numGroups, promises: [] };
-      }
-
-      this.promisesPerLocation[getPEName(pe)].promises.push(pe);
-
-      const node = new PassiveEntityNode(pe,
-        HORIZONTAL_DISTANCE + HORIZONTAL_DISTANCE * this.promisesPerLocation[getPEName(pe)].promises.length,
-        VERTICAL_DISTANCE * numGroups);
-      this.passiveEntities[pe.id.toString()] = node;
-    } else {
-      // other passive entities
-      this.passiveEntities[pe.id] = new PassiveEntityNode(
-        pe, HORIZONTAL_DISTANCE * Object.keys(this.passiveEntities).length, 0);
-    }
-  }
-
   public getMaxMessageSends() {
     return this.maxMessageCount;
   }
 
   public getActivityNodes(): ActivityNode[] {
     const groupStarted = {};
-
     const arr: ActivityNode[] = [];
+
     for (const i in this.activities) {
       const a = this.activities[i];
       const name = a.getName();
@@ -376,7 +368,7 @@ export class SystemViewData {
       if (group.activities.length > NUM_ACTIVITIES_STARTING_GROUP) {
         if (!groupStarted[name]) {
           groupStarted[name] = true;
-          const groupNode = new GroupNode(group,
+          const groupNode = new ActivityGroupNode(group,
             false, // todo reflexive
             HORIZONTAL_DISTANCE + HORIZONTAL_DISTANCE * group.activities.length,
             VERTICAL_DISTANCE * Object.keys(this.activitiesPerType).length);
@@ -392,19 +384,18 @@ export class SystemViewData {
 
   public getEntityNodes(): PassiveEntityNode[] {
     const groupStarted = {};
-
-    const result = [];
+    const result: PassiveEntityNode[] = [];
 
     for (const i in this.passiveEntities) {
       const p = this.passiveEntities[i];
-      const name = p.getName();
-      const group = this.promisesPerLocation[name];
-      if (group.promises.length > 1) {
+      const name = p.getLocationId();
+      const group = this.passiveEntitiesPerLocation[name];
+      if (group.entities.length > NUM_ENTITIES_STARTING_GROUP) {
         if (!groupStarted[name]) {
           groupStarted[name] = true;
           const groupNode = new PassiveGroupNode(group,
-            HORIZONTAL_DISTANCE + HORIZONTAL_DISTANCE * group.promises.length,
-            VERTICAL_DISTANCE * Object.keys(this.activitiesPerType).length);
+            HORIZONTAL_DISTANCE + HORIZONTAL_DISTANCE * group.entities.length,
+            VERTICAL_DISTANCE * Object.keys(this.passiveEntitiesPerLocation).length);
           group.groupNode = groupNode;
           result.push(groupNode);
         }
@@ -426,21 +417,20 @@ export class SystemViewData {
         let sender;
         switch (source.getEntityType()) {
           case EntityRefType.Activity:
-            sender = this.getGroupOrActivity((<ActivityNodeImpl> source).activity.id);
+            sender = this.getActivityGroupOrActivity((<ActivityNodeImpl> source).activity.id);
             break;
           case EntityRefType.PassiveEntity:
-            sender = this.getPassiveGroupOrActivity((<PassiveEntityNode> source).entity.id);
+            sender = this.getPassiveGroupOrEntity((<PassiveEntityNodeImpl> source).entity.id);
             break;
         }
-
 
         let receiver;
         switch (target.getEntityType()) {
           case EntityRefType.Activity:
-            receiver = this.getGroupOrActivity((<ActivityNodeImpl> target).activity.id);
+            receiver = this.getActivityGroupOrActivity((<ActivityNodeImpl> target).activity.id);
             break;
           case EntityRefType.PassiveEntity:
-            receiver = this.getPassiveGroupOrActivity((<PassiveEntityNode> target).entity.id);
+            receiver = this.getPassiveGroupOrEntity((<PassiveEntityNodeImpl> target).entity.id);
             break;
         }
 
@@ -471,16 +461,16 @@ export class SystemViewData {
         continue;
       }
 
-      const target = this.getGroupOrActivity(act.activity.id);
-      const source = this.getGroupOrActivity(act.activity.creationActivity.id);
+      const target = this.getActivityGroupOrActivity(act.activity.id);
+      const source = this.getActivityGroupOrActivity(act.activity.creationActivity.id);
 
       sourceTargetInc(connections, source, target);
     }
 
     for (const i in this.passiveEntities) {
       const e = this.passiveEntities[i];
-      const source = this.getGroupOrActivity(e.entity.creationActivity.id);
-      const target = this.getPassiveGroupOrActivity(e.entity.id);
+      const source = this.getActivityGroupOrActivity(e.entity.creationActivity.id);
+      const target = this.getPassiveGroupOrEntity(e.entity.id);
       sourceTargetInc(connections, source, target);
     }
 

--- a/tools/kompos/src/system-view-data.ts
+++ b/tools/kompos/src/system-view-data.ts
@@ -130,7 +130,21 @@ class GroupNode extends ActivityNode {
   public getActivityId() { return this.group.activities[0].id; }
 }
 
-export class PassiveEntityNode extends EntityNode {
+export abstract class AbstractPassiveEntityNode extends EntityNode {
+  public readonly reflexive: boolean;
+
+  constructor(x: number, y: number) {
+    super(x, y);
+  }
+
+  public abstract getGroupSize(): number;
+  public abstract getName(): string;
+  public abstract getDataId(): string;
+  public abstract getSystemViewId(): string;
+  public abstract getEntityType(): EntityRefType;
+}
+
+export class PassiveEntityNode extends AbstractPassiveEntityNode {
   public readonly entity: PassiveEntity;
   public messages?: number[][];
 
@@ -139,10 +153,43 @@ export class PassiveEntityNode extends EntityNode {
     this.entity = entity;
   }
 
+  public getGroupSize() { return 1 }
   public getDataId() { return getEntityId(this.entity.id); }
   public getSystemViewId() { return getEntityVizId(this.entity.id); }
+  public getName() {
+    return getPEName(this.entity)
+  }
+  public getEntityType() { return EntityRefType.PassiveEntity; }
+}
+
+class PassiveGroupNode extends AbstractPassiveEntityNode {
+  private group: PassiveEntityGroup;
+
+  constructor(group: PassiveEntityGroup, x: number, y: number) {
+    super(x, y);
+    this.group = group;
+  }
+
+  public getGroupSize() { return this.group.promises.length; }
+
+  public getDataId() { return getEntityGroupId(this.group.id); }
+  public getSystemViewId() { return getEntityGroupVizId(this.group.id); }
+  public getName() { return getPEName(this.group.promises[0]) }
+  public getQueryForCodePane() {
+    let result = "";
+    for (const p of this.group.promises) {
+      if (result !== "") { result += ","; }
+      result += "#" + getEntityId(p.id);
+    }
+    return result;
+  }
 
   public getEntityType() { return EntityRefType.PassiveEntity; }
+}
+
+function getPEName(pe: PassiveEntity): string {
+  const ss = pe.origin;
+  return ss.uri + ":" + ss.startLine + ":" + ss.startColumn + ":" + ss.charLength
 }
 
 export interface EntityLink extends d3.layout.force.Link<EntityNode> {
@@ -156,6 +203,12 @@ interface ActivityGroup {
   id: number;
   activities: Activity[];
   groupNode?: GroupNode;
+}
+
+interface PassiveEntityGroup {
+  id: number;
+  promises: PassiveEntity[];
+  groupNode?: PassiveGroupNode;
 }
 
 type SourceTargetMap = Map<EntityNode, Map<EntityNode, number>>;
@@ -181,6 +234,7 @@ export class SystemViewData {
 
   private activities: IdMap<ActivityNodeImpl>;
   private activitiesPerType: IdMap<ActivityGroup>;
+  private promisesPerLocation: IdMap<PassiveEntityGroup>;
 
   private passiveEntities: IdMap<PassiveEntityNode>;
 
@@ -200,6 +254,7 @@ export class SystemViewData {
     this.activities = {};
     this.activitiesPerType = {};
     this.passiveEntities = {};
+    this.promisesPerLocation = {};
 
     this.maxMessageCount = 0;
 
@@ -250,6 +305,17 @@ export class SystemViewData {
     return node;
   }
 
+  private getPassiveGroupOrActivity(id: number): AbstractPassiveEntityNode {
+    const node = this.passiveEntities[id];
+    console.assert(node !== undefined);
+
+    const group = this.promisesPerLocation[node.getName()];
+    if (group.groupNode) {
+      return group.groupNode;
+    }
+    return node;
+  }
+
   private getNode(type: EntityRefType, entity: number | Activity | DynamicScope | PassiveEntity) {
     switch (type) {
       case EntityRefType.Activity:
@@ -272,9 +338,27 @@ export class SystemViewData {
     sourceTargetInc(this.messages, source, target);
   }
 
-  private addPassiveEntity(passiveEntity: PassiveEntity) {
-    this.passiveEntities[passiveEntity.id] = new PassiveEntityNode(
-      passiveEntity, HORIZONTAL_DISTANCE * Object.keys(this.passiveEntities).length, 0);
+
+
+  private addPassiveEntity(pe: PassiveEntity) {
+    if (pe.type === 5) {
+      // group Promises
+      const numGroups = Object.keys(this.promisesPerLocation).length;
+      if (!this.promisesPerLocation[getPEName(pe)]) {
+        this.promisesPerLocation[getPEName(pe)] = { id: numGroups, promises: [] };
+      }
+
+      this.promisesPerLocation[getPEName(pe)].promises.push(pe);
+
+      const node = new PassiveEntityNode(pe,
+        HORIZONTAL_DISTANCE + HORIZONTAL_DISTANCE * this.promisesPerLocation[getPEName(pe)].promises.length,
+        VERTICAL_DISTANCE * numGroups);
+      this.passiveEntities[pe.id.toString()] = node;
+    } else {
+      // other passive entities
+      this.passiveEntities[pe.id] = new PassiveEntityNode(
+        pe, HORIZONTAL_DISTANCE * Object.keys(this.passiveEntities).length, 0);
+    }
   }
 
   public getMaxMessageSends() {
@@ -307,9 +391,26 @@ export class SystemViewData {
   }
 
   public getEntityNodes(): PassiveEntityNode[] {
+    const groupStarted = {};
+
     const result = [];
+
     for (const i in this.passiveEntities) {
-      result.push(this.passiveEntities[i]);
+      const p = this.passiveEntities[i];
+      const name = p.getName();
+      const group = this.promisesPerLocation[name];
+      if (group.promises.length > 1) {
+        if (!groupStarted[name]) {
+          groupStarted[name] = true;
+          const groupNode = new PassiveGroupNode(group,
+            HORIZONTAL_DISTANCE + HORIZONTAL_DISTANCE * group.promises.length,
+            VERTICAL_DISTANCE * Object.keys(this.activitiesPerType).length);
+          group.groupNode = groupNode;
+          result.push(groupNode);
+        }
+      } else {
+        result.push(p);
+      }
     }
     return result;
   }
@@ -328,7 +429,7 @@ export class SystemViewData {
             sender = this.getGroupOrActivity((<ActivityNodeImpl> source).activity.id);
             break;
           case EntityRefType.PassiveEntity:
-            sender = source;
+            sender = this.getPassiveGroupOrActivity((<PassiveEntityNode> source).entity.id);
             break;
         }
 
@@ -339,7 +440,7 @@ export class SystemViewData {
             receiver = this.getGroupOrActivity((<ActivityNodeImpl> target).activity.id);
             break;
           case EntityRefType.PassiveEntity:
-            receiver = target;
+            receiver = this.getPassiveGroupOrActivity((<PassiveEntityNode> target).entity.id);
             break;
         }
 
@@ -379,8 +480,8 @@ export class SystemViewData {
     for (const i in this.passiveEntities) {
       const e = this.passiveEntities[i];
       const source = this.getGroupOrActivity(e.entity.creationActivity.id);
-
-      sourceTargetInc(connections, source, e);
+      const target = this.getPassiveGroupOrActivity(e.entity.id);
+      sourceTargetInc(connections, source, target);
     }
 
     for (const [source, m] of connections) {

--- a/tools/kompos/src/system-view.ts
+++ b/tools/kompos/src/system-view.ts
@@ -26,6 +26,23 @@ export function getLightTangoColor(actType: ActivityType, actId: number) {
   return getTangoColors(actType)[3 + (actId % 4)];
 }
 
+function drawEdgesWithPaddingFromCenter(d: EntityLink) {
+  const target = <EntityNode> d.target;
+  const source = <EntityNode> d.source;
+  const deltaX = target.x - source.x,
+    deltaY = target.y - source.y,
+    dist = Math.sqrt(deltaX * deltaX + deltaY * deltaY),
+    normX = dist === 0 ? 0 : deltaX / dist,
+    normY = dist === 0 ? 0 : deltaY / dist,
+    sourcePadding = d.left ? 17 : 12,
+    targetPadding = d.right ? 17 : 12,
+    sourceX = source.x + (sourcePadding * normX),
+    sourceY = source.y + (sourcePadding * normY),
+    targetX = target.x - (targetPadding * normX),
+    targetY = target.y - (targetPadding * normY);
+  return `M${sourceX},${sourceY}L${targetX},${targetY}`;
+}
+
 export class SystemView {
   private readonly data: SystemViewData;
 
@@ -39,6 +56,8 @@ export class SystemView {
 
   private zoomScale = 1;
   private zoomTransl = [0, 0];
+
+  private forceLayout;
 
   private metaModel: KomposMetaModel;
 
@@ -89,7 +108,7 @@ export class SystemView {
     const allEntities = this.activities.concat(<any[]> this.passiveEntities);
 
     // init D3 force layout
-    const forceLayout = d3.layout.force()
+    this.forceLayout = d3.layout.force()
       .nodes(allEntities)
       .links(this.links)
       .size([canvas.width(), canvas.height()])
@@ -97,7 +116,7 @@ export class SystemView {
       .charge(-500)
       .on("tick", () => this.forceLayoutUpdateIteration());
 
-    forceLayout.linkStrength((link: EntityLink) => {
+    this.forceLayout.linkStrength((link: EntityLink) => {
       return link.messageCount / this.data.getMaxMessageSends();
     });
 
@@ -108,7 +127,8 @@ export class SystemView {
     createArrowMarker(svg, "end-arrow-creator", 6, "M0,-5L10,0L0,5", "#aaa");
     createArrowMarker(svg, "start-arrow-creator", 4, "M10,-5L0,0L10,5", "#aaa");
 
-    this.renderSystemView(forceLayout, svg);
+    const layout = this.forceLayout;
+    setTimeout(() => this.renderSystemView(layout, svg), 100);
   }
 
   private zoomed() {
@@ -131,22 +151,7 @@ export class SystemView {
 
   private forceLayoutUpdateIteration() {
     // draw directed edges with proper padding from node centers
-    this.entityLinks.attr("d", (d: EntityLink) => {
-      const target = <EntityNode> d.target;
-      const source = <EntityNode> d.source;
-      const deltaX = target.x - source.x,
-        deltaY = target.y - source.y,
-        dist = Math.sqrt(deltaX * deltaX + deltaY * deltaY),
-        normX = dist === 0 ? 0 : deltaX / dist,
-        normY = dist === 0 ? 0 : deltaY / dist,
-        sourcePadding = d.left ? 17 : 12,
-        targetPadding = d.right ? 17 : 12,
-        sourceX = source.x + (sourcePadding * normX),
-        sourceY = source.y + (sourcePadding * normY),
-        targetX = target.x - (targetPadding * normX),
-        targetY = target.y - (targetPadding * normY);
-      return `M${sourceX},${sourceY}L${targetX},${targetY}`;
-    });
+    this.entityLinks.attr("d", drawEdgesWithPaddingFromCenter);
 
     this.activityNodes.attr("transform", (d: ActivityNode) => {
       const x = this.zoomTransl[0] + d.x * this.zoomScale;
@@ -164,6 +169,11 @@ export class SystemView {
   private renderSystemView(forceLayout:
     d3.layout.Force<d3.layout.force.Link<d3.layout.force.Node>, d3.layout.force.Node>,
     svg: d3.Selection<any>) {
+    if (forceLayout !== this.forceLayout) {
+      // ok, looks like we got new data, let's not do this anymore
+      return;
+    }
+
     // handles to link and node element groups
     this.entityLinks = svg.append("svg:g")
       .selectAll("path")
@@ -212,6 +222,17 @@ export class SystemView {
     // remove old nodes
     this.activityNodes.exit().remove();
     this.entityNodes.exit().remove();
+
+    // delay the execution of the layouting, it may be invalidated soon
+    setTimeout(() => this.layoutView(forceLayout), 100);
+  }
+
+  private layoutView(forceLayout:
+    d3.layout.Force<d3.layout.force.Link<d3.layout.force.Node>, d3.layout.force.Node>) {
+    if (forceLayout !== this.forceLayout) {
+      // ok, looks like we got new data, let's not do this anymore
+      return;
+    }
 
     // set the graph in motion
     forceLayout.start();

--- a/tools/kompos/src/ui-controller.ts
+++ b/tools/kompos/src/ui-controller.ts
@@ -6,7 +6,7 @@ import { Debugger } from "./debugger";
 import {
   SourceMessage, SymbolMessage, StoppedMessage, StackTraceResponse,
   ScopesResponse, VariablesResponse, ProgramInfoResponse, InitializationResponse,
-  Source, Method
+  Source, Method, getSectionIdFromFrame
 } from "./messages";
 import {
   LineBreakpoint, SectionBreakpoint, getBreakpointId,
@@ -176,7 +176,7 @@ export class UiController extends Controller {
 
       const newSource = this.view.displaySource(act, source, sourceId);
 
-      const ssId = this.dbg.getSectionIdFromFrame(sourceId, msg.stackFrames[0]);
+      const ssId = getSectionIdFromFrame(sourceId, msg.stackFrames[0]);
       const section = this.dbg.getSection(ssId);
 
       this.view.displayStackTrace(sourceId, msg, topFrameId, act, ssId, section);


### PR DESCRIPTION
Changes for the VMM'18 demo.

This PR includes a port of @daumayr's `ReplayDemo.ns` airline booking system.

It fixes various other details, and adds a checkbox to enable a demo-mode layout in Kompos.

It also improves the performance of the rendering in Kompos.
This is done by avoiding sending unnecessary symbol messages, and by delaying rendering to avoid unnecessary repainting.