### PR TITLE
Serialization Improvements

### DIFF
--- a/core-lib/TestSuite/Serialization.ns
+++ b/core-lib/TestSuite/Serialization.ns
@@ -129,15 +129,16 @@ class SerializationTests usingPlatform: platform testFramework: minitest = Value
     )
 
     (*
-    not context free... context also contains a reference to the block itself,
-    such cyclic graphs are currently not surrported
-    public testBlockWithoutContext = (
+    not context free...*)
+    public testBlock = (
       | original clone |
-      original:: blockWC.
+      original:: [ :val :val2 |
+          val * val2.
+      ].
       clone:: actors snapshotClone: original.
-      assert: (original value: 21 with: 2) equals: (clone value: 21 with: 2).
+      assert: (clone value: 21 with: 2) equals: (original value: 21 with: 2).
     )
-    *)
+
 
     public testSimpleArrays = (
       cloneAndEqualsArray: { 1 . 20 . 33 . 404 }.
@@ -178,11 +179,10 @@ class SerializationTests usingPlatform: platform testFramework: minitest = Value
       pp:: actors createPromisePair.
       p:: pp promise.
       pc:: actors snapshotClone: p.
-
     )
 
-    public testCloneNotResolved = (
-      | pp p pc|
+    public testAsyncCloneNotResolved = (
+      | pp p pc rp|
       pp:: actors createPromisePair.
       p:: pp promise.
       pc:: actors snapshotClone: p.
@@ -190,7 +190,7 @@ class SerializationTests usingPlatform: platform testFramework: minitest = Value
         assert: false.
       ].
       pp resolve: 1.
-      assert: pp promise resolvedWith: 1.
+      ^ (assert: pp promise resolvedWith: 1).
     )
 
     public testSimpleResolver = (
@@ -202,38 +202,64 @@ class SerializationTests usingPlatform: platform testFramework: minitest = Value
       r resolve: 2.
     )
 
-    public testSimplePromisePair = (
-      | pp ppc|
+    public testAsyncSimplePromisePair = (
+      | pp ppc |
       pp:: actors createPromisePair.
       ppc:: actors snapshotClone: pp.
       pp resolve: 42.
-      assert: pp promise resolvedWith: 42.
       ppc resolve: 21.
-      assert: ppc promise resolvedWith: 21.
+      ^ (assert: pp promise resolvedWith: 42),
+      (assert: ppc promise resolvedWith: 21).
     )
 
-    public testCloneResolved = (
-      | pp p pc|
+    public testAsyncCloneResolved = (
+      | pp p pc rp rp2|
       pp:: actors createPromisePair.
       pp resolve: 84.
       p:: pp promise.
       pc:: actors snapshotClone: p.
-      assert: p resolvedWith: 84.
-      assert: pc resolvedWith: 84.
+      ^ (assert: p resolvedWith: 84),
+      (assert: pc resolvedWith: 84).
     )
 
-    public testClonePromiseWithMessage = (
+     public testAsyncCloneChain = (
+      | pp pp2 pp3 ppc|
+      pp:: actors createPromisePair.
+      pp2:: actors createPromisePair.
+      pp3:: actors createPromisePair.
+      pp2 resolve: pp.
+      pp3 resolve: pp2.
+      ppc:: actors snapshotClone: pp.
+
+      ppc resolve: 42.
+      ^ assert: ppc promise resolvedWith: 42.
+      (*TODO check that pp2 and three were cloned...*)
+    )
+
+    public testAsyncClonePromiseWithMessage = (
       | pp ppc|
       pp:: actors createPromisePair.
       pp promise <-: value: 42.
       ppc:: actors snapshotClone: pp.
       ppc resolve: [ :v |
-        v println.
       ].
       pp resolve: [ :v |
-        v println.
-      ]
+      ].
+      ^ pp promise, ppc promise.
     )
+
+    public testAsyncCloneCallback = (
+      | pp ppc rp |
+      pp:: actors createPromisePair.
+      pp promise whenResolved: [ :val |
+        assert: val equals: 42.
+      ].
+      ppc:: actors snapshotClone: pp.
+      pp resolve: 42.
+      ppc resolve: 42.
+      ^ (assert: pp promise resolvedWith: 42),
+      (assert: ppc promise resolvedWith: 42).
+  )
 
   ) : ( TEST_CONTEXT = () )
 )

--- a/core-lib/TestSuite/Serialization.ns
+++ b/core-lib/TestSuite/Serialization.ns
@@ -20,6 +20,7 @@ THE SOFTWARE.
 *)
 class SerializationTests usingPlatform: platform testFramework: minitest = Value(
 | private TestContext = minitest TestContext.
+  private AsyncTestContext = minitest AsyncTestContext.
   private actors = platform actors.
   private String = platform kernel String.
   private Array = platform kernel Array.
@@ -33,11 +34,7 @@ class SerializationTests usingPlatform: platform testFramework: minitest = Value
     public f2 = b.|
   )()
 
-  public class SerializationTest = TestContext (
-  | blockWC = [ :a :b |
-      ^ a * b.
-    ].
-  |)(
+  public class SerializationTest = AsyncTestContext ()(
 
     public class EmptyClass = ()(
       public test = (
@@ -175,5 +172,68 @@ class SerializationTests usingPlatform: platform testFramework: minitest = Value
       assert: varr isValue.
       assert: (actors snapshotClone: varr) isValue.
     )
+
+    public testSimplePromise = (
+      | pp p pc|
+      pp:: actors createPromisePair.
+      p:: pp promise.
+      pc:: actors snapshotClone: p.
+
+    )
+
+    public testCloneNotResolved = (
+      | pp p pc|
+      pp:: actors createPromisePair.
+      p:: pp promise.
+      pc:: actors snapshotClone: p.
+      pc whenResolved: [ :v |
+        assert: false.
+      ].
+      pp resolve: 1.
+      assert: pp promise resolvedWith: 1.
+    )
+
+    public testSimpleResolver = (
+      | pp r rc|
+      pp:: actors createPromisePair.
+      r:: pp resolver.
+      rc:: actors snapshotClone: r.
+      rc resolve: 1.
+      r resolve: 2.
+    )
+
+    public testSimplePromisePair = (
+      | pp ppc|
+      pp:: actors createPromisePair.
+      ppc:: actors snapshotClone: pp.
+      pp resolve: 42.
+      assert: pp promise resolvedWith: 42.
+      ppc resolve: 21.
+      assert: ppc promise resolvedWith: 21.
+    )
+
+    public testCloneResolved = (
+      | pp p pc|
+      pp:: actors createPromisePair.
+      pp resolve: 84.
+      p:: pp promise.
+      pc:: actors snapshotClone: p.
+      assert: p resolvedWith: 84.
+      assert: pc resolvedWith: 84.
+    )
+
+    public testClonePromiseWithMessage = (
+      | pp ppc|
+      pp:: actors createPromisePair.
+      pp promise <-: value: 42.
+      ppc:: actors snapshotClone: pp.
+      ppc resolve: [ :v |
+        v println.
+      ].
+      pp resolve: [ :v |
+        v println.
+      ]
+    )
+
   ) : ( TEST_CONTEXT = () )
 )

--- a/core-lib/TestSuite/Serialization.ns
+++ b/core-lib/TestSuite/Serialization.ns
@@ -128,8 +128,6 @@ class SerializationTests usingPlatform: platform testFramework: minitest = Value
       assert: original is: clone.
     )
 
-    (*
-    not context free...*)
     public testBlock = (
       | original clone |
       original:: [ :val :val2 |

--- a/core-lib/TestSuite/Serialization.ns
+++ b/core-lib/TestSuite/Serialization.ns
@@ -19,8 +19,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 *)
 class SerializationTests usingPlatform: platform testFramework: minitest = Value(
-| private TestContext = minitest TestContext.
-  private AsyncTestContext = minitest AsyncTestContext.
+| private AsyncTestContext = minitest AsyncTestContext.
   private actors = platform actors.
   private String = platform kernel String.
   private Array = platform kernel Array.

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -1238,7 +1238,7 @@ public class Parser {
         SInvokable blockMethod = bgenc.assemble(blockBody,
             AccessModifier.BLOCK_METHOD, lastMethodsSourceSection);
         builder.addEmbeddedBlockMethod(blockMethod);
-        if (structuralProbe != null && VmSettings.TRACK_SNAPSHOT_ENTITIES) {
+        if (VmSettings.TRACK_SNAPSHOT_ENTITIES && structuralProbe != null) {
           structuralProbe.recordNewMethod(blockMethod);
         }
 

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -1238,6 +1238,9 @@ public class Parser {
         SInvokable blockMethod = bgenc.assemble(blockBody,
             AccessModifier.BLOCK_METHOD, lastMethodsSourceSection);
         builder.addEmbeddedBlockMethod(blockMethod);
+        if (structuralProbe != null) {
+          structuralProbe.recordNewMethod(blockMethod);
+        }
 
         ExpressionNode result;
         if (bgenc.requiresContext() || VmSettings.TRUFFLE_DEBUGGER_ENABLED) {

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -1238,7 +1238,7 @@ public class Parser {
         SInvokable blockMethod = bgenc.assemble(blockBody,
             AccessModifier.BLOCK_METHOD, lastMethodsSourceSection);
         builder.addEmbeddedBlockMethod(blockMethod);
-        if (structuralProbe != null) {
+        if (structuralProbe != null && VmSettings.TRACK_SNAPSHOT_ENTITIES) {
           structuralProbe.recordNewMethod(blockMethod);
         }
 

--- a/src/som/interpreter/actors/EventualMessage.java
+++ b/src/som/interpreter/actors/EventualMessage.java
@@ -2,6 +2,7 @@ package som.interpreter.actors;
 
 import java.util.Arrays;
 
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -215,10 +216,10 @@ public abstract class EventualMessage {
    * after the promise is resolved.
    */
   public abstract static class AbstractPromiseSendMessage extends PromiseMessage {
-    private final SSymbol selector;
-    protected Actor       target;
-    protected Actor       finalSender;
-    protected SPromise    originalTarget;
+    private final SSymbol                selector;
+    protected Actor                      target;
+    protected Actor                      finalSender;
+    @CompilationFinal protected SPromise originalTarget;
 
     protected AbstractPromiseSendMessage(final SSymbol selector,
         final Object[] arguments, final Actor originalSender,
@@ -308,7 +309,7 @@ public abstract class EventualMessage {
     /**
      * The promise on which this callback is registered on.
      */
-    protected SPromise promise;
+    @CompilationFinal protected SPromise promise;
 
     protected AbstractPromiseCallbackMessage(final Actor owner, final SBlock callback,
         final SResolver resolver, final RootCallTarget onReceive,

--- a/src/som/interpreter/actors/EventualMessage.java
+++ b/src/som/interpreter/actors/EventualMessage.java
@@ -13,6 +13,7 @@ import som.vm.VmSettings;
 import som.vmobjects.SBlock;
 import som.vmobjects.SSymbol;
 import tools.concurrency.TracingActivityThread;
+import tools.snapshot.SnapshotBuffer;
 
 
 public abstract class EventualMessage {
@@ -67,6 +68,12 @@ public abstract class EventualMessage {
 
   public SourceSection getTargetSourceSection() {
     return onReceive.getRootNode().getSourceSection();
+  }
+
+  public long serialize(final SnapshotBuffer sb) {
+    ReceivedRootNode rm = (ReceivedRootNode) this.onReceive.getRootNode();
+    // Not sure if this is optimized, worst case need to duplicate this for all messages
+    return rm.getSerializer().execute(this, sb);
   }
 
   /**
@@ -192,6 +199,11 @@ public abstract class EventualMessage {
 
     public abstract SPromise getPromise();
 
+    /**
+     * Used for Fixup in deserialization.
+     */
+    public abstract void setPromise(SPromise promise);
+
     @Override
     public boolean getHaltOnPromiseMessageResolution() {
       return getPromise().getHaltOnResolution();
@@ -203,10 +215,10 @@ public abstract class EventualMessage {
    * after the promise is resolved.
    */
   public abstract static class AbstractPromiseSendMessage extends PromiseMessage {
-    private final SSymbol    selector;
-    protected Actor          target;
-    protected Actor          finalSender;
-    protected final SPromise originalTarget;
+    private final SSymbol selector;
+    protected Actor       target;
+    protected Actor       finalSender;
+    protected SPromise    originalTarget;
 
     protected AbstractPromiseSendMessage(final SSymbol selector,
         final Object[] arguments, final Actor originalSender,
@@ -248,6 +260,10 @@ public abstract class EventualMessage {
       return target;
     }
 
+    public boolean isDelivered() {
+      return target != null;
+    }
+
     @Override
     public String toString() {
       String t;
@@ -264,10 +280,21 @@ public abstract class EventualMessage {
     public SPromise getPromise() {
       return originalTarget;
     }
+
+    @Override
+    public final void setPromise(final SPromise promise) {
+      assert VmSettings.SNAPSHOTS_ENABLED;
+      assert promise != null && originalTarget == null;
+      this.originalTarget = promise;
+    }
+
+    public Actor getFinalSender() {
+      return finalSender;
+    }
   }
 
   public static final class PromiseSendMessage extends AbstractPromiseSendMessage {
-    protected PromiseSendMessage(final SSymbol selector, final Object[] arguments,
+    public PromiseSendMessage(final SSymbol selector, final Object[] arguments,
         final Actor originalSender, final SResolver resolver, final RootCallTarget onReceive,
         final boolean triggerMessageReceiverBreakpoint,
         final boolean triggerPromiseResolverBreakpoint) {
@@ -281,7 +308,7 @@ public abstract class EventualMessage {
     /**
      * The promise on which this callback is registered on.
      */
-    protected final SPromise promise;
+    protected SPromise promise;
 
     protected AbstractPromiseCallbackMessage(final Actor owner, final SBlock callback,
         final SResolver resolver, final RootCallTarget onReceive,
@@ -326,6 +353,16 @@ public abstract class EventualMessage {
     @Override
     public SPromise getPromise() {
       return promise;
+    }
+
+    /**
+     * Used for Fixup in deserialization.
+     */
+    @Override
+    public final void setPromise(final SPromise promise) {
+      assert VmSettings.SNAPSHOTS_ENABLED;
+      assert promise != null && this.promise == null;
+      this.promise = promise;
     }
   }
 

--- a/src/som/interpreter/actors/ReceivedRootNode.java
+++ b/src/som/interpreter/actors/ReceivedRootNode.java
@@ -16,6 +16,8 @@ import tools.debugger.WebDebugger;
 import tools.debugger.entities.DynamicScopeType;
 import tools.replay.nodes.TraceMessageNode;
 import tools.replay.nodes.TraceMessageNodeGen;
+import tools.snapshot.nodes.MessageSerializationNode;
+import tools.snapshot.nodes.MessageSerializationNodeFactory;
 
 
 public abstract class ReceivedRootNode extends RootNode {
@@ -23,7 +25,8 @@ public abstract class ReceivedRootNode extends RootNode {
   @Child protected AbstractPromiseResolutionNode resolve;
   @Child protected AbstractPromiseResolutionNode error;
 
-  @Child protected TraceMessageNode msgTracer = TraceMessageNodeGen.create();
+  @Child protected TraceMessageNode         msgTracer = TraceMessageNodeGen.create();
+  @Child protected MessageSerializationNode serializer;
 
   private final VM            vm;
   protected final WebDebugger dbg;
@@ -40,6 +43,11 @@ public abstract class ReceivedRootNode extends RootNode {
       this.dbg = null;
     }
     this.sourceSection = sourceSection;
+    if (VmSettings.SNAPSHOTS_ENABLED) {
+      serializer = MessageSerializationNodeFactory.create();
+    } else {
+      serializer = null;
+    }
   }
 
   protected abstract Object executeBody(VirtualFrame frame, EventualMessage msg,
@@ -121,6 +129,10 @@ public abstract class ReceivedRootNode extends RootNode {
 
     // error promise
     error.executeEvaluated(frame, resolver, exception, haltOnResolver, haltOnResolution);
+  }
+
+  public MessageSerializationNode getSerializer() {
+    return serializer;
   }
 
   /**

--- a/src/som/interpreter/actors/SPromise.java
+++ b/src/som/interpreter/actors/SPromise.java
@@ -111,7 +111,7 @@ public class SPromise extends SObjectWithClass {
    *
    * @return the value this promise was resolved to
    */
-  public final Object getValue() {
+  public final Object getValueForSnapshot() {
     assert VmSettings.SNAPSHOTS_ENABLED;
     assert resolutionState == Resolution.SUCCESSFUL || resolutionState == Resolution.ERRONEOUS;
     assert value != null;
@@ -122,7 +122,7 @@ public class SPromise extends SObjectWithClass {
    * Do not use for things other than deserializing Promises.
    * This is necessary for circular object graphs.
    */
-  public final void setValue(final Object value) {
+  public final void setValueForSnapshot(final Object value) {
     assert VmSettings.SNAPSHOTS_ENABLED;
     assert resolutionState == Resolution.SUCCESSFUL || resolutionState == Resolution.ERRONEOUS;
     assert value != null;

--- a/src/som/interpreter/actors/SPromise.java
+++ b/src/som/interpreter/actors/SPromise.java
@@ -40,10 +40,11 @@ public class SPromise extends SObjectWithClass {
     }
   }
 
-  public static SPromise createResolved(final Actor owner, final Object value) {
+  public static SPromise createResolved(final Actor owner, final Object value,
+      final Resolution state) {
     assert VmSettings.SNAPSHOTS_ENABLED;
     SPromise prom = createPromise(owner, false, false, null);
-    prom.resolutionState = Resolution.SUCCESSFUL;
+    prom.resolutionState = state;
     prom.value = value;
     return prom;
   }
@@ -112,7 +113,7 @@ public class SPromise extends SObjectWithClass {
    */
   public final Object getValue() {
     assert VmSettings.SNAPSHOTS_ENABLED;
-    assert resolutionState == Resolution.SUCCESSFUL;
+    assert resolutionState == Resolution.SUCCESSFUL || resolutionState == Resolution.ERRONEOUS;
     assert value != null;
     return value;
   }
@@ -123,7 +124,7 @@ public class SPromise extends SObjectWithClass {
    */
   public final void setValue(final Object value) {
     assert VmSettings.SNAPSHOTS_ENABLED;
-    assert resolutionState == Resolution.SUCCESSFUL;
+    assert resolutionState == Resolution.SUCCESSFUL || resolutionState == Resolution.ERRONEOUS;
     assert value != null;
     this.value = value;
   }

--- a/src/som/interpreter/actors/SPromise.java
+++ b/src/som/interpreter/actors/SPromise.java
@@ -304,37 +304,37 @@ public class SPromise extends SObjectWithClass {
     }
   }
 
-  /** Do not use for things other than serializing Promises */
+  /** Do not use for things other than serializing Promises. */
   public PromiseMessage getWhenResolved() {
     assert VmSettings.SNAPSHOTS_ENABLED;
     return whenResolved;
   }
 
-  /** Do not use for things other than serializing Promises */
+  /** Do not use for things other than serializing Promises. */
   public ArrayList<PromiseMessage> getWhenResolvedExt() {
     assert VmSettings.SNAPSHOTS_ENABLED;
     return whenResolvedExt;
   }
 
-  /** Do not use for things other than serializing Promises */
+  /** Do not use for things other than serializing Promises. */
   public PromiseMessage getOnError() {
     assert VmSettings.SNAPSHOTS_ENABLED;
     return onError;
   }
 
-  /** Do not use for things other than serializing Promises */
+  /** Do not use for things other than serializing Promises. */
   public ArrayList<PromiseMessage> getOnErrorExt() {
     assert VmSettings.SNAPSHOTS_ENABLED;
     return onErrorExt;
   }
 
-  /** Do not use for things other than serializing Promises */
+  /** Do not use for things other than serializing Promises. */
   public SPromise getChainedPromise() {
     assert VmSettings.SNAPSHOTS_ENABLED;
     return chainedPromise;
   }
 
-  /** Do not use for things other than serializing Promises */
+  /** Do not use for things other than serializing Promises. */
   public ArrayList<SPromise> getChainedPromiseExt() {
     assert VmSettings.SNAPSHOTS_ENABLED;
     return chainedPromiseExt;

--- a/src/som/interpreter/actors/SPromise.java
+++ b/src/som/interpreter/actors/SPromise.java
@@ -40,6 +40,7 @@ public class SPromise extends SObjectWithClass {
     }
   }
 
+  /** Used by snapshot deserialization. */
   public static SPromise createResolved(final Actor owner, final Object value,
       final Resolution state) {
     assert VmSettings.SNAPSHOTS_ENABLED;

--- a/src/som/interpreter/actors/SPromise.java
+++ b/src/som/interpreter/actors/SPromise.java
@@ -122,7 +122,7 @@ public class SPromise extends SObjectWithClass {
    * Do not use for things other than deserializing Promises.
    * This is necessary for circular object graphs.
    */
-  public final void setValueForSnapshot(final Object value) {
+  public final void setValueFromSnapshot(final Object value) {
     assert VmSettings.SNAPSHOTS_ENABLED;
     assert resolutionState == Resolution.SUCCESSFUL || resolutionState == Resolution.ERRONEOUS;
     assert value != null;
@@ -274,68 +274,38 @@ public class SPromise extends SObjectWithClass {
     return value;
   }
 
-  public int getNumChainedPromises() {
-    if (chainedPromise == null) {
-      return 0;
-    } else if (chainedPromiseExt == null) {
-      return 1;
-    } else {
-      return chainedPromiseExt.size() + 1;
-    }
-  }
-
-  public int getNumWhenResolved() {
-    if (whenResolved == null) {
-      return 0;
-    } else if (whenResolvedExt == null) {
-      return 1;
-    } else {
-      return whenResolvedExt.size() + 1;
-    }
-  }
-
-  public int getNumOnError() {
-    if (onError == null) {
-      return 0;
-    } else if (onErrorExt == null) {
-      return 1;
-    } else {
-      return onErrorExt.size() + 1;
-    }
-  }
-
-  /** Do not use for things other than serializing Promises. */
-  public PromiseMessage getWhenResolved() {
+  /** Do not use for things other than serializing Promises, requires synchronization. */
+  public PromiseMessage getWhenResolvedUnsync() {
     assert VmSettings.SNAPSHOTS_ENABLED;
     return whenResolved;
   }
 
-  /** Do not use for things other than serializing Promises. */
-  public ArrayList<PromiseMessage> getWhenResolvedExt() {
+  /** Do not use for things other than serializing Promises, requires synchronization. */
+  public ArrayList<PromiseMessage> getWhenResolvedExtUnsync() {
     assert VmSettings.SNAPSHOTS_ENABLED;
     return whenResolvedExt;
   }
 
-  /** Do not use for things other than serializing Promises. */
+  /** Do not use for things other than serializing Promises, requires synchronization. */
   public PromiseMessage getOnError() {
     assert VmSettings.SNAPSHOTS_ENABLED;
     return onError;
   }
 
-  /** Do not use for things other than serializing Promises. */
-  public ArrayList<PromiseMessage> getOnErrorExt() {
+  /** Do not use for things other than serializing Promises, requires synchronization. */
+  public ArrayList<PromiseMessage> getOnErrorExtUnsync() {
     assert VmSettings.SNAPSHOTS_ENABLED;
     return onErrorExt;
   }
 
-  /** Do not use for things other than serializing Promises. */
-  public SPromise getChainedPromise() {
+  /** Do not use for things other than serializing Promises, requires synchronization. */
+  public SPromise getChainedPromiseUnsync() {
     assert VmSettings.SNAPSHOTS_ENABLED;
     return chainedPromise;
   }
 
-  /** Do not use for things other than serializing Promises. */
-  public ArrayList<SPromise> getChainedPromiseExt() {
+  /** Do not use for things other than serializing Promises, requires synchronization. */
+  public ArrayList<SPromise> getChainedPromiseExtUnsync() {
     assert VmSettings.SNAPSHOTS_ENABLED;
     return chainedPromiseExt;
   }

--- a/src/som/interpreter/objectstorage/ClassFactory.java
+++ b/src/som/interpreter/objectstorage/ClassFactory.java
@@ -88,8 +88,9 @@ public final class ClassFactory {
     this.superclassAndMixins = superclassAndMixins;
 
     if (VmSettings.SNAPSHOTS_ENABLED) {
+
       this.serializationRoot =
-          new SerializerRootNode(null, serializerFactory.createNode(this));
+          new SerializerRootNode(serializerFactory.createNode(this));
     } else {
       this.serializationRoot = null;
     }

--- a/src/som/interpreter/objectstorage/ClassFactory.java
+++ b/src/som/interpreter/objectstorage/ClassFactory.java
@@ -88,7 +88,6 @@ public final class ClassFactory {
     this.superclassAndMixins = superclassAndMixins;
 
     if (VmSettings.SNAPSHOTS_ENABLED) {
-
       this.serializationRoot =
           new SerializerRootNode(serializerFactory.createNode(this));
     } else {

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 
 import com.oracle.truffle.api.CompilerDirectives;
@@ -60,8 +59,8 @@ import tools.concurrency.TraceParser;
 import tools.concurrency.TracingBackend;
 import tools.replay.actors.ActorExecutionTrace;
 import tools.replay.nodes.TraceActorContextNode;
-import tools.snapshot.SnapshotBackend;
 import tools.snapshot.SnapshotBuffer;
+import tools.snapshot.deserialization.DeserializationBuffer;
 
 
 public final class SystemPrims {
@@ -354,15 +353,13 @@ public final class SystemPrims {
         if (!sb.containsObject(receiver)) {
           SClass clazz = Types.getClassOf(receiver);
           clazz.serialize(receiver, sb);
-          ByteBuffer bb = sb.getBuffer();
-
-          short cId = bb.getShort();
-          Object o = SnapshotBackend.lookupClass(cId).getSerializer().deserialize(bb);
+          DeserializationBuffer bb = sb.getBuffer();
+          Object o = bb.deserialize();
           assert Types.getClassOf(o) == clazz;
           return o;
         }
       }
-      return null;
+      return Nil.nilObject;
     }
   }
 

--- a/src/som/vm/ObjectSystem.java
+++ b/src/som/vm/ObjectSystem.java
@@ -410,6 +410,8 @@ public final class ObjectSystem {
     Classes.blockClass.getSOMClass()
                       .setClassGroup(Classes.metaclassClass.getInstanceFactory());
 
+    // these classes are not exposed in Newspeak directly, and thus, do not yet have a class
+    // factory
     setDummyClassFactory(Classes.messageClass, MessageSerializationNodeFactory.getInstance());
     setDummyClassFactory(Classes.methodClass,
         SInvokableSerializationNodeFactory.getInstance());

--- a/src/som/vm/constants/Classes.java
+++ b/src/som/vm/constants/Classes.java
@@ -30,6 +30,9 @@ public final class Classes {
 
   public static final SClass blockClass;
 
+  // dummy class for message deserialization
+  public static final SClass messageClass;
+
   // These classes can be statically preinitialized.
   static {
     // Allocate the Metaclass classes
@@ -60,5 +63,8 @@ public final class Classes {
     falseClass = ObjectSystem.newEmptyClassWithItsClass("False");
 
     blockClass = ObjectSystem.newEmptyClassWithItsClass("Block");
+
+    messageClass = ObjectSystem.newEmptyClassWithItsClass("Message");
+
   }
 }

--- a/src/som/vm/constants/Classes.java
+++ b/src/som/vm/constants/Classes.java
@@ -65,6 +65,5 @@ public final class Classes {
     blockClass = ObjectSystem.newEmptyClassWithItsClass("Block");
 
     messageClass = ObjectSystem.newEmptyClassWithItsClass("Message");
-
   }
 }

--- a/src/som/vmobjects/SClass.java
+++ b/src/som/vmobjects/SClass.java
@@ -194,7 +194,11 @@ public final class SClass extends SObjectWithClass {
     // assert instanceClassGroup != null || !ObjectSystem.isInitialized();
 
     if (VmSettings.TRACK_SNAPSHOT_ENTITIES) {
-      SnapshotBackend.registerClass(mixinDef.getIdentifier(), this);
+      if (mixinDef != null) {
+        SnapshotBackend.registerClass(mixinDef.getIdentifier(), this);
+      } else {
+        SnapshotBackend.registerClass(classFactory.getClassName(), this);
+      }
     }
   }
 
@@ -352,7 +356,9 @@ public final class SClass extends SObjectWithClass {
 
   public void serialize(final Object o, final SnapshotBuffer sb) {
     assert instanceClassGroup != null;
-    getSerializer().execute(o, sb);
+    if (!sb.containsObject(o)) {
+      getSerializer().execute(o, sb);
+    }
   }
 
   public AbstractSerializationNode getSerializer() {

--- a/src/tools/concurrency/TracingActors.java
+++ b/src/tools/concurrency/TracingActors.java
@@ -130,6 +130,10 @@ public class TracingActors {
       return 0;
     }
 
+    public static ReplayActor getActorWithId(final int id) {
+      return actorList.get(id);
+    }
+
     @Override
     public long getId() {
       return activityId;

--- a/src/tools/snapshot/SnapshotBackend.java
+++ b/src/tools/snapshot/SnapshotBackend.java
@@ -2,6 +2,8 @@ package tools.snapshot;
 
 import org.graalvm.collections.EconomicMap;
 
+import som.interpreter.actors.Actor;
+import som.interpreter.actors.EventualMessage;
 import som.vm.VmSettings;
 import som.vmobjects.SClass;
 import som.vmobjects.SInvokable;
@@ -72,6 +74,11 @@ public class SnapshotBackend {
     // intentionally unsynchronized, as a result the line between snapshots will be a bit
     // fuzzy.
     return snapshotVersion;
+  }
+
+  public static Actor lookupActor(final int actorId) {
+    // TODO implement
+    return EventualMessage.getActorCurrentMessageIsExecutionOn();
   }
 
   public static StructuralProbe getProbe() {

--- a/src/tools/snapshot/SnapshotBackend.java
+++ b/src/tools/snapshot/SnapshotBackend.java
@@ -8,6 +8,7 @@ import som.vm.VmSettings;
 import som.vmobjects.SClass;
 import som.vmobjects.SInvokable;
 import som.vmobjects.SSymbol;
+import tools.concurrency.TracingActors.ReplayActor;
 import tools.language.StructuralProbe;
 
 
@@ -77,8 +78,12 @@ public class SnapshotBackend {
   }
 
   public static Actor lookupActor(final int actorId) {
-    // TODO implement
-    return EventualMessage.getActorCurrentMessageIsExecutionOn();
+    if (VmSettings.REPLAY) {
+      return ReplayActor.getActorWithId(actorId);
+    } else {
+      // For testing with snaphsotClone:
+      return EventualMessage.getActorCurrentMessageIsExecutionOn();
+    }
   }
 
   public static StructuralProbe getProbe() {

--- a/src/tools/snapshot/SnapshotBuffer.java
+++ b/src/tools/snapshot/SnapshotBuffer.java
@@ -67,7 +67,6 @@ public class SnapshotBuffer extends TraceBuffer {
     // (either from a promise or a mailbox)
     int oldPos = this.position;
 
-    // TODO use Message Class
     this.putShortAt(this.position,
         Classes.messageClass.getFactory().getClassName().getSymbolId());
     this.position += CLASS_ID_SIZE + payload;

--- a/src/tools/snapshot/deserialization/DeserializationBuffer.java
+++ b/src/tools/snapshot/deserialization/DeserializationBuffer.java
@@ -100,7 +100,7 @@ public class DeserializationBuffer {
 
   private void fixUpIfNecessary(final long reference, final Object result) {
     Object ref = deserialized.get(reference);
-    if (ref != null && ref instanceof FixupList) {
+    if (ref instanceof FixupList) {
       // we have fixup information, this means that this object is part of a circular
       // relationship
       for (FixupInformation fi : (FixupList) ref) {

--- a/src/tools/snapshot/deserialization/DeserializationBuffer.java
+++ b/src/tools/snapshot/deserialization/DeserializationBuffer.java
@@ -116,5 +116,4 @@ public class DeserializationBuffer {
   public void position(final int newPosition) {
     wrapped.position(newPosition);
   }
-
 }

--- a/src/tools/snapshot/deserialization/DeserializationBuffer.java
+++ b/src/tools/snapshot/deserialization/DeserializationBuffer.java
@@ -1,0 +1,121 @@
+package tools.snapshot.deserialization;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.graalvm.collections.EconomicMap;
+
+import som.vmobjects.SClass;
+import tools.snapshot.SnapshotBackend;
+import tools.snapshot.deserialization.FixupInformation.FixupList;
+
+
+public class DeserializationBuffer {
+
+  private final ByteBuffer                wrapped;
+  private final EconomicMap<Long, Object> deserialized;
+  private long                            lastRef;
+
+  public DeserializationBuffer(final byte[] backing) {
+    wrapped = ByteBuffer.wrap(backing).asReadOnlyBuffer().order(ByteOrder.LITTLE_ENDIAN);
+    wrapped.rewind();
+    deserialized = EconomicMap.create();
+  }
+
+  public byte get() {
+    return wrapped.get();
+  }
+
+  public void get(final byte[] b) {
+    wrapped.get(b);
+  }
+
+  public short getShort() {
+    return wrapped.getShort();
+  }
+
+  public int getInt() {
+    return wrapped.getInt();
+  }
+
+  public long getLong() {
+    return wrapped.getLong();
+  }
+
+  public double getDouble() {
+    return wrapped.getDouble();
+  }
+
+  public Object deserialize() {
+    int current = position();
+    assert !deserialized.containsKey((long) current);
+
+    // to avoid endless loop, when null is read we replace it with a linked list containing
+    // fixup information
+    deserialized.put((long) current, null);
+    short cId = getShort();
+    Object o = SnapshotBackend.lookupClass(cId).getSerializer().deserialize(this);
+
+    fixUpIfNecessary(current, o);
+    deserialized.put((long) current, o);
+    return o;
+  }
+
+  public Object getReference() {
+    long reference = getLong();
+    lastRef = reference;
+    if (!deserialized.containsKey(reference)) {
+      int current = position();
+
+      deserialized.put(reference, null);
+
+      // prepare deserialize referenced object
+      position((int) reference);
+      short classId = getShort();
+      SClass clazz = SnapshotBackend.lookupClass(classId);
+      Object o = clazz.getSerializer().deserialize(this);
+
+      // continue with current object
+      position(current);
+      fixUpIfNecessary(reference, o);
+      deserialized.put(reference, o);
+      return o;
+    } else {
+      return deserialized.get(reference);
+    }
+  }
+
+  public static boolean needsFixup(final Object o) {
+    return o == null || o instanceof FixupList;
+  }
+
+  public void installFixup(final FixupInformation fi) {
+    FixupList fl = (FixupList) deserialized.get(lastRef);
+    if (fl == null) {
+      deserialized.put(lastRef, new FixupList(fi));
+    } else {
+      fl.add(fi);
+    }
+  }
+
+  private void fixUpIfNecessary(final long reference, final Object result) {
+    if (deserialized.get(reference) != null) {
+      // we have fixup information, this means that this object is part of a circular
+      // relationship
+      FixupList fl = (FixupList) deserialized.get(reference);
+
+      for (FixupInformation fi : fl) {
+        fi.fixUp(result);
+      }
+    }
+  }
+
+  public int position() {
+    return wrapped.position();
+  }
+
+  public void position(final int newPosition) {
+    wrapped.position(newPosition);
+  }
+
+}

--- a/src/tools/snapshot/deserialization/DeserializationBuffer.java
+++ b/src/tools/snapshot/deserialization/DeserializationBuffer.java
@@ -99,12 +99,11 @@ public class DeserializationBuffer {
   }
 
   private void fixUpIfNecessary(final long reference, final Object result) {
-    if (deserialized.get(reference) != null) {
+    Object ref = deserialized.get(reference);
+    if (ref != null && ref instanceof FixupList) {
       // we have fixup information, this means that this object is part of a circular
       // relationship
-      FixupList fl = (FixupList) deserialized.get(reference);
-
-      for (FixupInformation fi : fl) {
+      for (FixupInformation fi : (FixupList) ref) {
         fi.fixUp(result);
       }
     }

--- a/src/tools/snapshot/deserialization/FixupInformation.java
+++ b/src/tools/snapshot/deserialization/FixupInformation.java
@@ -43,10 +43,4 @@ public abstract class FixupInformation {
       };
     }
   }
-
-  public static abstract class FixupFactory {
-    public static FixupFactory instance;
-
-    public abstract FixupInformation create(final Object target, Object... args);
-  }
 }

--- a/src/tools/snapshot/deserialization/FixupInformation.java
+++ b/src/tools/snapshot/deserialization/FixupInformation.java
@@ -1,0 +1,52 @@
+package tools.snapshot.deserialization;
+
+import java.util.Iterator;
+
+
+public abstract class FixupInformation {
+
+  public abstract void fixUp(Object o);
+
+  protected FixupInformation next;
+
+  public static class FixupList implements Iterable<FixupInformation> {
+    FixupInformation head;
+    FixupInformation tail;
+
+    public FixupList(final FixupInformation initial) {
+      head = initial;
+      tail = initial;
+    }
+
+    public void add(final FixupInformation fi) {
+      tail.next = fi;
+      tail = fi;
+    }
+
+    @Override
+    public Iterator<FixupInformation> iterator() {
+      return new Iterator<FixupInformation>() {
+        FixupInformation next = head;
+
+        @Override
+        public FixupInformation next() {
+          assert next != null;
+          FixupInformation res = next;
+          next = next.next;
+          return res;
+        }
+
+        @Override
+        public boolean hasNext() {
+          return next != null;
+        }
+      };
+    }
+  }
+
+  public static abstract class FixupFactory {
+    public static FixupFactory instance;
+
+    public abstract FixupInformation create(final Object target, Object... args);
+  }
+}

--- a/src/tools/snapshot/nodes/AbstractSerializationNode.java
+++ b/src/tools/snapshot/nodes/AbstractSerializationNode.java
@@ -1,14 +1,11 @@
 package tools.snapshot.nodes;
 
-import java.nio.ByteBuffer;
-
 import com.oracle.truffle.api.nodes.Node;
 
 import som.interpreter.objectstorage.ClassFactory;
 import som.vm.VmSettings;
-import som.vmobjects.SClass;
-import tools.snapshot.SnapshotBackend;
 import tools.snapshot.SnapshotBuffer;
+import tools.snapshot.deserialization.DeserializationBuffer;
 
 
 public abstract class AbstractSerializationNode extends Node {
@@ -21,20 +18,5 @@ public abstract class AbstractSerializationNode extends Node {
 
   public abstract void execute(Object o, SnapshotBuffer sb);
 
-  public abstract Object deserialize(ByteBuffer sb);
-
-  public static Object deserializeReference(final ByteBuffer bb) {
-    long reference = bb.getLong();
-    int current = bb.position();
-
-    // prepare deserialize referenced object
-    bb.position((int) reference);
-    short classId = bb.getShort();
-    SClass clazz = SnapshotBackend.lookupClass(classId);
-    Object o = clazz.getSerializer().deserialize(bb);
-
-    // continue with current object
-    bb.position(current);
-    return o;
-  }
+  public abstract Object deserialize(DeserializationBuffer bb);
 }

--- a/src/tools/snapshot/nodes/BlockSerializationNode.java
+++ b/src/tools/snapshot/nodes/BlockSerializationNode.java
@@ -122,8 +122,6 @@ public abstract class BlockSerializationNode extends AbstractSerializationNode {
     FrameDescriptor fd = ((Method) invokable.getInvokable()).getLexicalScope().getOuterMethod()
                                                             .getMethod().getFrameDescriptor();
 
-    // FrameDescriptor fd = invokable.getInvokable().getFrameDescriptor();
-
     // read num args
     int numArgs = bb.get();
     Object[] args = new Object[numArgs];
@@ -141,7 +139,7 @@ public abstract class BlockSerializationNode extends AbstractSerializationNode {
     MaterializedFrame frame = Truffle.getRuntime().createMaterializedFrame(args, fd);
 
     int numSlots = bb.get();
-    // assert numSlots == fd.getSlots().size();
+    assert numSlots == fd.getSlots().size();
 
     for (int i = 0; i < numSlots; i++) {
       FrameSlot slot = fd.getSlots().get(i);

--- a/src/tools/snapshot/nodes/CachedSerializationNode.java
+++ b/src/tools/snapshot/nodes/CachedSerializationNode.java
@@ -1,7 +1,5 @@
 package tools.snapshot.nodes;
 
-import java.nio.ByteBuffer;
-
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -10,6 +8,7 @@ import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 import som.interpreter.Types;
 import som.interpreter.nodes.dispatch.DispatchGuard;
 import tools.snapshot.SnapshotBuffer;
+import tools.snapshot.deserialization.DeserializationBuffer;
 
 
 @GenerateNodeFactory
@@ -39,7 +38,7 @@ public abstract class CachedSerializationNode extends AbstractSerializationNode 
   }
 
   @Override
-  public Object deserialize(final ByteBuffer sb) {
+  public Object deserialize(final DeserializationBuffer sb) {
     throw new UnsupportedOperationException("Use this node only for serialization");
   }
 }

--- a/src/tools/snapshot/nodes/MessageSerializationNode.java
+++ b/src/tools/snapshot/nodes/MessageSerializationNode.java
@@ -291,7 +291,6 @@ public abstract class MessageSerializationNode extends AbstractSerializationNode
 
   @Override
   public EventualMessage deserialize(final DeserializationBuffer bb) {
-
     // commonalities
     MessageType type = MessageType.getMessageType(bb.get());
     SSymbol selector = SnapshotBackend.getSymbolForId(bb.getShort());
@@ -299,9 +298,9 @@ public abstract class MessageSerializationNode extends AbstractSerializationNode
 
     switch (type) {
       case CallbackMessage:
-        return deserializeCallback(selector, sender, bb, (SResolver) bb.getReference());
+        return deserializeCallback(sender, bb, (SResolver) bb.getReference());
       case CallbackMessageNR:
-        return deserializeCallback(selector, sender, bb, null);
+        return deserializeCallback(sender, bb, null);
       case DirectMessage:
         return deserializeDirect(selector, sender, bb, (SResolver) bb.getReference());
       case DirectMessageNR:
@@ -319,8 +318,8 @@ public abstract class MessageSerializationNode extends AbstractSerializationNode
     }
   }
 
-  private PromiseCallbackMessage deserializeCallback(final SSymbol selector,
-      final Actor sender, final DeserializationBuffer bb, final SResolver resolver) {
+  private PromiseCallbackMessage deserializeCallback(final Actor sender,
+      final DeserializationBuffer bb, final SResolver resolver) {
 
     PromiseMessageFixup pmf = null;
     SPromise prom = null;

--- a/src/tools/snapshot/nodes/MessageSerializationNode.java
+++ b/src/tools/snapshot/nodes/MessageSerializationNode.java
@@ -364,7 +364,7 @@ public abstract class MessageSerializationNode extends AbstractSerializationNode
         onReceive = EventualSendNode.createOnReceiveCallTarget(selector, null,
             SomLanguage.getLanguage(getRootNode()));
 
-        // bakup value for resolution.
+        // backup value for resolution.
         Object value = args[0];
 
         if (!(args[0] instanceof SPromise)) {
@@ -403,9 +403,12 @@ public abstract class MessageSerializationNode extends AbstractSerializationNode
     }
   }
 
-  // first reads number of arguments (byte) and then deserializes the referenced objects if
-  // necessary
-  // returns an array containg the references to the deserialized objects
+  /**
+   * First reads number of arguments (byte) and then deserializes the referenced objects if
+   * necessary.
+   *
+   * @return An array containing the references to the deserialized objects.
+   */
   private Object[] parseArguments(final DeserializationBuffer bb) {
     int argCnt = bb.get();
     Object[] args = new Object[argCnt];

--- a/src/tools/snapshot/nodes/MessageSerializationNode.java
+++ b/src/tools/snapshot/nodes/MessageSerializationNode.java
@@ -1,0 +1,451 @@
+package tools.snapshot.nodes;
+
+import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
+import com.oracle.truffle.api.dsl.Specialization;
+
+import som.interpreter.SomLanguage;
+import som.interpreter.Types;
+import som.interpreter.actors.Actor;
+import som.interpreter.actors.EventualMessage;
+import som.interpreter.actors.EventualMessage.DirectMessage;
+import som.interpreter.actors.EventualMessage.PromiseCallbackMessage;
+import som.interpreter.actors.EventualMessage.PromiseMessage;
+import som.interpreter.actors.EventualMessage.PromiseSendMessage;
+import som.interpreter.actors.EventualSendNode;
+import som.interpreter.actors.SPromise;
+import som.interpreter.actors.SPromise.SResolver;
+import som.interpreter.objectstorage.ClassFactory;
+import som.primitives.actors.PromisePrims;
+import som.vm.constants.Classes;
+import som.vm.constants.Nil;
+import som.vmobjects.SBlock;
+import som.vmobjects.SSymbol;
+import tools.concurrency.TracingActors.TracingActor;
+import tools.snapshot.SnapshotBackend;
+import tools.snapshot.SnapshotBuffer;
+import tools.snapshot.deserialization.DeserializationBuffer;
+import tools.snapshot.deserialization.FixupInformation;
+
+
+@GenerateNodeFactory
+public abstract class MessageSerializationNode extends AbstractSerializationNode {
+
+  public MessageSerializationNode(final ClassFactory factory) {
+    super(factory);
+  }
+
+  public MessageSerializationNode() {
+    super(Classes.messageClass.getInstanceFactory());
+  }
+
+  protected static final int COMMONALITY_BYTES = 7;
+
+  public enum MessageType {
+    DirectMessage, CallbackMessage, PromiseMessage, UndeliveredPromiseMessage, DirectMessageNR,
+    CallbackMessageNR, PromiseMessageNR, UndeliveredPromiseMessageNR;
+    public byte getValue() {
+      return (byte) this.ordinal();
+    }
+
+    public static MessageType getMessageType(final byte ordinal) {
+      return MessageType.values()[ordinal];
+    }
+  }
+
+  /**
+   * Serializes a message and returns a long that can be used to reference to the message
+   * within the snapshot.
+   */
+  public abstract long execute(EventualMessage em, SnapshotBuffer sb);
+
+  // Possible Optimizations:
+  // actors receive a limited set of messages
+  // => specialize on different messages
+  // => can specialize on number of arguments! (explode loop)
+  // arguments probably have similar types for each of those message types
+  // => cached serializers
+
+  // Do we want to serialize messages with other object and just keep their addresses ready,
+  // or do we want to put them into a separate buffer performance wise there shoudn't be much
+  // of a difference
+
+  // TODO possibly explode as optimization, use cached serialization nodes for the args...
+  protected final void doArguments(final Object[] args, final int base,
+      final SnapshotBuffer sb) {
+
+    // assume number of args is reasonable
+    assert args.length < 2 * Byte.MAX_VALUE;
+    if (args.length > 0) {
+      // special case for callback message
+      sb.putByteAt(base, (byte) args.length);
+      for (int i = 0; i < args.length; i++) {
+        if (args[i] == null) {
+          if (!sb.containsObject(Nil.nilObject)) {
+            Classes.nilClass.serialize(Nil.nilObject, sb);
+          }
+          sb.putLongAt((base + 1) + i * Long.BYTES, sb.getObjectPointer(Nil.nilObject));
+        } else {
+          if (!sb.containsObject(args[i])) {
+            Types.getClassOf(args[i]).serialize(args[i], sb);
+          }
+          sb.putLongAt((base + 1) + i * Long.BYTES, sb.getObjectPointer(args[i]));
+        }
+      }
+    }
+  }
+
+  /**
+   *
+   * Takes 7 bytes in the buffer
+   */
+  protected final void doCommonalities(final MessageType type, final SSymbol selector,
+      final TracingActor sender, final int base,
+      final SnapshotBuffer sb) {
+    sb.putByteAt(base, type.getValue());
+    sb.putShortAt(base + 1, selector.getSymbolId());
+    sb.putIntAt(base + 3, sender.getActorId());
+  }
+
+  @Specialization(guards = "dm.getResolver() != null")
+  protected long doDirectMessage(final DirectMessage dm, final SnapshotBuffer sb) {
+    SResolver resolver = dm.getResolver();
+    Object[] args = dm.getArgs();
+
+    int payload = COMMONALITY_BYTES + Long.BYTES + 1 + (args.length * Long.BYTES);
+    int base = sb.addMessage(payload);
+    long start = base - SnapshotBuffer.CLASS_ID_SIZE;
+
+    doCommonalities(MessageType.DirectMessage, dm.getSelector(), (TracingActor) dm.getSender(),
+        base, sb);
+
+    SResolver.getResolverClass().serialize(resolver, sb);
+    sb.putLongAt(base + COMMONALITY_BYTES, sb.getObjectPointer(resolver));
+    base += COMMONALITY_BYTES + Long.BYTES;
+
+    doArguments(args, base, sb);
+
+    return start;
+  }
+
+  @Specialization
+  protected long doDirectMessageNoResolver(final DirectMessage dm, final SnapshotBuffer sb) {
+    Object[] args = dm.getArgs();
+
+    int payload = COMMONALITY_BYTES + Long.BYTES + 1 + (args.length * Long.BYTES);
+    int base = sb.addMessage(payload);
+    long start = base - SnapshotBuffer.CLASS_ID_SIZE;
+
+    doCommonalities(MessageType.DirectMessageNR, dm.getSelector(),
+        (TracingActor) dm.getSender(),
+        base, sb);
+    base += COMMONALITY_BYTES;
+
+    doArguments(args, base, sb);
+
+    return start;
+  }
+
+  @Specialization(guards = "dm.getResolver() != null")
+  protected long doCallbackMessage(final PromiseCallbackMessage dm, final SnapshotBuffer sb) {
+    SResolver resolver = dm.getResolver();
+    SPromise prom = dm.getPromise();
+    Object[] args = dm.getArgs();
+
+    int payload = COMMONALITY_BYTES + Long.BYTES + Long.BYTES + 1 + (args.length * Long.BYTES);
+    int base = sb.addMessage(payload);
+    long start = base - SnapshotBuffer.CLASS_ID_SIZE;
+
+    doCommonalities(MessageType.CallbackMessage, dm.getSelector(),
+        (TracingActor) dm.getSender(), base, sb);
+
+    SPromise.getPromiseClass().serialize(prom, sb);
+    SResolver.getResolverClass().serialize(resolver, sb);
+    sb.putLongAt(base + COMMONALITY_BYTES, sb.getObjectPointer(resolver));
+    sb.putLongAt(base + COMMONALITY_BYTES + Long.BYTES, sb.getObjectPointer(prom));
+    base += COMMONALITY_BYTES + Long.BYTES + Long.BYTES;
+
+    doArguments(args, base, sb);
+
+    return start;
+  }
+
+  @Specialization
+  protected long doCallbackMessageNoResolver(final PromiseCallbackMessage dm,
+      final SnapshotBuffer sb) {
+    SPromise prom = dm.getPromise();
+    Object[] args = dm.getArgs();
+
+    int payload = COMMONALITY_BYTES + Long.BYTES + 1 + (args.length * Long.BYTES);
+    int base = sb.addMessage(payload);
+    long start = base - SnapshotBuffer.CLASS_ID_SIZE;
+
+    doCommonalities(MessageType.CallbackMessageNR, dm.getSelector(),
+        (TracingActor) dm.getSender(), base, sb);
+
+    SPromise.getPromiseClass().serialize(prom, sb);
+    sb.putLongAt(base + COMMONALITY_BYTES, sb.getObjectPointer(prom));
+    base += COMMONALITY_BYTES + Long.BYTES;
+
+    doArguments(args, base, sb);
+
+    return start;
+  }
+
+  @Specialization(guards = {"dm.isDelivered()", "dm.getResolver() != null"})
+  protected long doPromiseMessage(final PromiseSendMessage dm, final SnapshotBuffer sb) {
+
+    SResolver resolver = dm.getResolver();
+    SPromise prom = dm.getPromise();
+    TracingActor fsender = (TracingActor) dm.getFinalSender();
+    Object[] args = dm.getArgs();
+    args[0] = dm.getPromise();
+
+    int payload = COMMONALITY_BYTES + Long.BYTES + Long.BYTES + Integer.BYTES + 1
+        + (args.length * Long.BYTES);
+    int base = sb.addMessage(payload);
+    long start = base - SnapshotBuffer.CLASS_ID_SIZE;
+
+    doCommonalities(MessageType.PromiseMessage, dm.getSelector(),
+        (TracingActor) dm.getSender(), base, sb);
+
+    SPromise.getPromiseClass().serialize(prom, sb);
+    SResolver.getResolverClass().serialize(resolver, sb);
+
+    sb.putLongAt(base + COMMONALITY_BYTES, sb.getObjectPointer(resolver));
+    sb.putLongAt(base + COMMONALITY_BYTES + Long.BYTES, sb.getObjectPointer(prom));
+    sb.putIntAt(base + COMMONALITY_BYTES + Long.BYTES + Long.BYTES, fsender.getActorId());
+    base += COMMONALITY_BYTES + Long.BYTES + Long.BYTES + Integer.BYTES;
+
+    doArguments(args, base, sb);
+
+    return start;
+  }
+
+  @Specialization(guards = "dm.isDelivered()")
+  protected long doPromiseMessageNoResolver(final PromiseSendMessage dm,
+      final SnapshotBuffer sb) {
+
+    SPromise prom = dm.getPromise();
+    TracingActor fsender = (TracingActor) dm.getFinalSender();
+    Object[] args = dm.getArgs();
+
+    int payload = COMMONALITY_BYTES + Long.BYTES + Integer.BYTES + 1
+        + (args.length * Long.BYTES);
+    int base = sb.addMessage(payload);
+    long start = base - SnapshotBuffer.CLASS_ID_SIZE;
+
+    doCommonalities(MessageType.PromiseMessageNR, dm.getSelector(),
+        (TracingActor) dm.getSender(), base, sb);
+
+    SPromise.getPromiseClass().serialize(prom, sb);
+
+    sb.putLongAt(base + COMMONALITY_BYTES, sb.getObjectPointer(prom));
+    sb.putIntAt(base + COMMONALITY_BYTES + Long.BYTES, fsender.getActorId());
+    base += COMMONALITY_BYTES + Long.BYTES + Integer.BYTES;
+
+    doArguments(args, base, sb);
+
+    return start;
+  }
+
+  @Specialization(guards = {"!dm.isDelivered()", "dm.getResolver() != null"})
+  protected long doUndeliveredPromiseMessage(final PromiseSendMessage dm,
+      final SnapshotBuffer sb) {
+
+    SResolver resolver = dm.getResolver();
+    Object[] args = dm.getArgs();
+
+    int payload = COMMONALITY_BYTES + Long.BYTES + 1 + (args.length * Long.BYTES);
+    int base = sb.addMessage(payload);
+    long start = base - SnapshotBuffer.CLASS_ID_SIZE;
+
+    SResolver.getResolverClass().serialize(resolver, sb);
+
+    doCommonalities(MessageType.UndeliveredPromiseMessage, dm.getSelector(),
+        (TracingActor) dm.getSender(), base, sb);
+    sb.putLongAt(base + COMMONALITY_BYTES, sb.getObjectPointer(resolver));
+    base += COMMONALITY_BYTES + Long.BYTES;
+
+    doArguments(args, base, sb);
+
+    return start;
+  }
+
+  @Specialization(guards = "!dm.isDelivered()")
+  protected long doUndeliveredPromiseMessageNoResolver(final PromiseSendMessage dm,
+      final SnapshotBuffer sb) {
+    Object[] args = dm.getArgs();
+
+    int payload = COMMONALITY_BYTES + 1 + (args.length * Long.BYTES);
+    int base = sb.addMessage(payload);
+    long start = base - SnapshotBuffer.CLASS_ID_SIZE;
+
+    doCommonalities(MessageType.UndeliveredPromiseMessageNR, dm.getSelector(),
+        (TracingActor) dm.getSender(), base, sb);
+    base += COMMONALITY_BYTES;
+
+    doArguments(args, base, sb);
+
+    return start;
+  }
+
+  @Override
+  public EventualMessage deserialize(final DeserializationBuffer bb) {
+
+    // commonalities
+    MessageType type = MessageType.getMessageType(bb.get());
+    SSymbol selector = SnapshotBackend.getSymbolForId(bb.getShort());
+    Actor sender = SnapshotBackend.lookupActor(bb.getInt());
+    SResolver resolver = null;
+
+    if (type == MessageType.DirectMessage || type == MessageType.CallbackMessage
+        || type == MessageType.PromiseMessage
+        || type == MessageType.UndeliveredPromiseMessage) {
+      resolver = (SResolver) bb.getReference();
+    }
+
+    Object[] args;
+    SPromise prom;
+    Object promObj;
+    PromiseMessageFixup pmf = null;
+    switch (type) {
+      case CallbackMessage:
+      case CallbackMessageNR:
+        promObj = bb.getReference();
+
+        if (DeserializationBuffer.needsFixup(promObj)) {
+          pmf = new PromiseMessageFixup();
+          bb.installFixup(pmf);
+          prom = null;
+        } else {
+          prom = (SPromise) promObj;
+        }
+        args = parseArguments(bb);
+
+        RootCallTarget onReceive = PromisePrims.createReceived((SBlock) args[0]);
+        PromiseCallbackMessage pcm =
+            new PromiseCallbackMessage(sender, (SBlock) args[0], resolver,
+                onReceive, false, false, prom);
+
+        if (pmf != null) {
+          pmf.setMessage(pcm);
+        }
+
+        // set the remaining arg, i.e. the value passed to the callback block
+        pcm.getArgs()[1] = args[1];
+        return pcm;
+      case DirectMessage:
+      case DirectMessageNR:
+        args = parseArguments(bb);
+        onReceive = EventualSendNode.createOnReceiveCallTarget(selector, null,
+            SomLanguage.getLanguage(getRootNode()));
+
+        DirectMessage dm =
+            new DirectMessage(EventualMessage.getActorCurrentMessageIsExecutionOn(), selector,
+                args, sender, resolver,
+                onReceive, false, false);
+
+        return dm;
+      case PromiseMessage:
+      case PromiseMessageNR:
+        promObj = bb.getReference();
+
+        if (DeserializationBuffer.needsFixup(promObj)) {
+          pmf = new PromiseMessageFixup();
+          bb.installFixup(pmf);
+          prom = null;
+        } else {
+          prom = (SPromise) promObj;
+        }
+
+        Actor finalSender = SnapshotBackend.lookupActor(bb.getInt());
+        args = parseArguments(bb);
+        onReceive = EventualSendNode.createOnReceiveCallTarget(selector, null,
+            SomLanguage.getLanguage(getRootNode()));
+
+        // bakup value for resolution.
+        Object value = args[0];
+
+        if (!(args[0] instanceof SPromise)) {
+          // expects args[0] to be a promise, which may not be the case with a circular
+          // dependency. We therefore use this placeholder as a workaround...
+          args[0] = SPromise.createPromise(sender, false, false, null);
+        }
+
+        PromiseSendMessage psm =
+            new PromiseSendMessage(selector, args, sender, resolver, onReceive, false, false);
+
+        if (pmf != null) {
+          pmf.setMessage(psm);
+        }
+        psm.resolve(value, EventualMessage.getActorCurrentMessageIsExecutionOn(),
+            finalSender);
+
+        return psm;
+      case UndeliveredPromiseMessage:
+      case UndeliveredPromiseMessageNR:
+        args = parseArguments(bb);
+        onReceive = EventualSendNode.createOnReceiveCallTarget(selector,
+            SomLanguage.getSyntheticSource("Deserialized Message", "Trace").createSection(1),
+            SomLanguage.getLanguage(this.getRootNode()));
+
+        if (!(args[0] instanceof SPromise)) {
+          // expects args[0] to be a promise
+          args[0] = SPromise.createPromise(sender, false, false, null);
+        }
+
+        psm =
+            new PromiseSendMessage(selector, args, sender, resolver, onReceive, false, false);
+        return psm;
+      default:
+        throw new UnsupportedOperationException();
+    }
+  }
+
+  // first reads number of arguments (byte) and then deserializes the referenced objects if
+  // necessary
+  // returns an array containg the references to the deserialized objects
+  private Object[] parseArguments(final DeserializationBuffer bb) {
+    int argCnt = bb.get();
+    Object[] args = new Object[argCnt];
+    for (int i = 0; i < argCnt; i++) {
+      Object arg = bb.getReference();
+      if (DeserializationBuffer.needsFixup(arg)) {
+        bb.installFixup(new MessageArgumentFixup(args, i));
+      } else {
+        args[i] = arg;
+      }
+    }
+    return args;
+  }
+
+  public static class MessageArgumentFixup extends FixupInformation {
+    Object[] args;
+    int      idx;
+
+    public MessageArgumentFixup(final Object[] args, final int idx) {
+      this.args = args;
+      this.idx = idx;
+    }
+
+    @Override
+    public void fixUp(final Object o) {
+      args[idx] = o;
+    }
+  }
+
+  public static class PromiseMessageFixup extends FixupInformation {
+    PromiseMessage pm;
+
+    public void setMessage(final PromiseMessage pm) {
+      this.pm = pm;
+    }
+
+    @Override
+    public void fixUp(final Object o) {
+      assert pm != null;
+      this.pm.setPromise((SPromise) o);
+    }
+  }
+}

--- a/src/tools/snapshot/nodes/ObjectSerializationNodes.java
+++ b/src/tools/snapshot/nodes/ObjectSerializationNodes.java
@@ -235,7 +235,6 @@ public abstract class ObjectSerializationNodes {
       }
 
       for (int i = 0; i < fieldWrites.length; i++) {
-        // reference, writeNode
         Object ref = sb.getReference();
         if (DeserializationBuffer.needsFixup(ref)) {
           sb.installFixup(new SlotFixup(o, fieldWrites[i]));
@@ -258,7 +257,6 @@ public abstract class ObjectSerializationNodes {
 
       @Override
       public void fixUp(final Object res) {
-        // TODO Auto-generated method stub
         csw.doWrite(obj, res);
       }
 

--- a/src/tools/snapshot/nodes/ObjectSerializationNodes.java
+++ b/src/tools/snapshot/nodes/ObjectSerializationNodes.java
@@ -250,7 +250,7 @@ public abstract class ObjectSerializationNodes {
       final CachedSlotWrite csw;
       final SObject         obj;
 
-      public SlotFixup(final SObject obj, final CachedSlotWrite csw) {
+      SlotFixup(final SObject obj, final CachedSlotWrite csw) {
         this.csw = csw;
         this.obj = obj;
       }

--- a/src/tools/snapshot/nodes/ObjectSerializationNodes.java
+++ b/src/tools/snapshot/nodes/ObjectSerializationNodes.java
@@ -259,7 +259,6 @@ public abstract class ObjectSerializationNodes {
       public void fixUp(final Object res) {
         csw.doWrite(obj, res);
       }
-
     }
   }
 

--- a/src/tools/snapshot/nodes/ObjectSerializationNodes.java
+++ b/src/tools/snapshot/nodes/ObjectSerializationNodes.java
@@ -1,6 +1,5 @@
 package tools.snapshot.nodes;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -28,6 +27,8 @@ import som.vmobjects.SObjectWithClass;
 import som.vmobjects.SObjectWithClass.SObjectWithoutFields;
 import tools.snapshot.SnapshotBackend;
 import tools.snapshot.SnapshotBuffer;
+import tools.snapshot.deserialization.DeserializationBuffer;
+import tools.snapshot.deserialization.FixupInformation;
 import tools.snapshot.nodes.ObjectSerializationNodesFactory.SObjectSerializationNodeFactory;
 import tools.snapshot.nodes.ObjectSerializationNodesFactory.SObjectWithoutFieldsSerializationNodeFactory;
 import tools.snapshot.nodes.ObjectSerializationNodesFactory.UninitializedObjectSerializationNodeFactory;
@@ -135,7 +136,7 @@ public abstract class ObjectSerializationNodes {
     }
 
     @Override
-    public Object deserialize(final ByteBuffer sb) {
+    public Object deserialize(final DeserializationBuffer sb) {
       if (classFact.hasSlots()) {
         return replace(SObjectSerializationNodeFactory.create(classFact, null)).deserialize(
             sb);
@@ -215,7 +216,7 @@ public abstract class ObjectSerializationNodes {
     }
 
     @Override
-    public Object deserialize(final ByteBuffer sb) {
+    public Object deserialize(final DeserializationBuffer sb) {
       SObject o;
 
       if (classFact.hasOnlyImmutableFields()) {
@@ -234,11 +235,33 @@ public abstract class ObjectSerializationNodes {
       }
 
       for (int i = 0; i < fieldWrites.length; i++) {
-        Object ref = deserializeReference(sb);
-        fieldWrites[i].doWrite(o, ref);
+        // reference, writeNode
+        Object ref = sb.getReference();
+        if (DeserializationBuffer.needsFixup(ref)) {
+          sb.installFixup(new SlotFixup(o, fieldWrites[i]));
+        } else {
+          fieldWrites[i].doWrite(o, ref);
+        }
       }
 
       return o;
+    }
+
+    private static class SlotFixup extends FixupInformation {
+      final CachedSlotWrite csw;
+      final SObject         obj;
+
+      public SlotFixup(final SObject obj, final CachedSlotWrite csw) {
+        this.csw = csw;
+        this.obj = obj;
+      }
+
+      @Override
+      public void fixUp(final Object res) {
+        // TODO Auto-generated method stub
+        csw.doWrite(obj, res);
+      }
+
     }
   }
 
@@ -257,7 +280,7 @@ public abstract class ObjectSerializationNodes {
     }
 
     @Override
-    public Object deserialize(final ByteBuffer sb) {
+    public Object deserialize(final DeserializationBuffer sb) {
       return new SObjectWithoutFields(SnapshotBackend.lookupClass(classFact.getIdentifier()),
           classFact);
     }

--- a/src/tools/snapshot/nodes/PrimitiveSerializationNodes.java
+++ b/src/tools/snapshot/nodes/PrimitiveSerializationNodes.java
@@ -1,6 +1,5 @@
 package tools.snapshot.nodes;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 import com.oracle.truffle.api.CompilerAsserts;
@@ -16,6 +15,7 @@ import som.vmobjects.SInvokable;
 import som.vmobjects.SSymbol;
 import tools.snapshot.SnapshotBackend;
 import tools.snapshot.SnapshotBuffer;
+import tools.snapshot.deserialization.DeserializationBuffer;
 
 
 public abstract class PrimitiveSerializationNodes {
@@ -38,7 +38,7 @@ public abstract class PrimitiveSerializationNodes {
     }
 
     @Override
-    public Object deserialize(final ByteBuffer sb) {
+    public Object deserialize(final DeserializationBuffer sb) {
       int len = sb.getInt();
       byte[] b = new byte[len];
       sb.get(b);
@@ -63,7 +63,7 @@ public abstract class PrimitiveSerializationNodes {
     }
 
     @Override
-    public Object deserialize(final ByteBuffer sb) {
+    public Object deserialize(final DeserializationBuffer sb) {
       return sb.getLong();
     }
   }
@@ -84,7 +84,7 @@ public abstract class PrimitiveSerializationNodes {
     }
 
     @Override
-    public Object deserialize(final ByteBuffer sb) {
+    public Object deserialize(final DeserializationBuffer sb) {
       return sb.getDouble();
     }
   }
@@ -105,7 +105,7 @@ public abstract class PrimitiveSerializationNodes {
     }
 
     @Override
-    public Object deserialize(final ByteBuffer sb) {
+    public Object deserialize(final DeserializationBuffer sb) {
       return sb.get() == 1;
     }
   }
@@ -125,7 +125,7 @@ public abstract class PrimitiveSerializationNodes {
     }
 
     @Override
-    public Object deserialize(final ByteBuffer sb) {
+    public Object deserialize(final DeserializationBuffer sb) {
       return true;
     }
   }
@@ -145,7 +145,7 @@ public abstract class PrimitiveSerializationNodes {
     }
 
     @Override
-    public Object deserialize(final ByteBuffer sb) {
+    public Object deserialize(final DeserializationBuffer sb) {
       return false;
     }
   }
@@ -166,7 +166,7 @@ public abstract class PrimitiveSerializationNodes {
     }
 
     @Override
-    public Object deserialize(final ByteBuffer sb) {
+    public Object deserialize(final DeserializationBuffer sb) {
       short symid = sb.getShort();
       return SnapshotBackend.getSymbolForId(symid);
     }
@@ -192,7 +192,7 @@ public abstract class PrimitiveSerializationNodes {
     }
 
     @Override
-    public Object deserialize(final ByteBuffer sb) {
+    public Object deserialize(final DeserializationBuffer sb) {
       short id = sb.getShort();
       return SnapshotBackend.lookupClass(id);
     }
@@ -214,7 +214,7 @@ public abstract class PrimitiveSerializationNodes {
     }
 
     @Override
-    public Object deserialize(final ByteBuffer sb) {
+    public Object deserialize(final DeserializationBuffer sb) {
       short id = sb.getShort();
       SSymbol s = SnapshotBackend.getSymbolForId(id);
       return SnapshotBackend.lookupInvokable(s);
@@ -234,7 +234,7 @@ public abstract class PrimitiveSerializationNodes {
     }
 
     @Override
-    public Object deserialize(final ByteBuffer sb) {
+    public Object deserialize(final DeserializationBuffer sb) {
       return Nil.nilObject;
     }
   }

--- a/src/tools/snapshot/nodes/PromiseSerializationNodes.java
+++ b/src/tools/snapshot/nodes/PromiseSerializationNodes.java
@@ -51,9 +51,13 @@ public abstract class PromiseSerializationNodes {
 
     @Specialization(guards = "!prom.isCompleted()")
     public void doUnresolved(final SPromise prom, final SnapshotBuffer sb) {
-      int ncp, nwr, noe;
-      PromiseMessage whenRes, onError;
-      ArrayList<PromiseMessage> whenResExt, onErrorExt;
+      int ncp;
+      int nwr;
+      int noe;
+      PromiseMessage whenRes;
+      PromiseMessage onError;
+      ArrayList<PromiseMessage> whenResExt;
+      ArrayList<PromiseMessage> onErrorExt;
       SPromise chainedProm;
       ArrayList<SPromise> chainedPromExt;
       synchronized (prom) {

--- a/src/tools/snapshot/nodes/PromiseSerializationNodes.java
+++ b/src/tools/snapshot/nodes/PromiseSerializationNodes.java
@@ -42,7 +42,7 @@ public abstract class PromiseSerializationNodes {
           throw new IllegalArgumentException("This shoud be unreachable");
       }
 
-      Object value = prom.getValue();
+      Object value = prom.getValueForSnapshot();
       if (!sb.containsObject(value)) {
         Types.getClassOf(value).serialize(value, sb);
       }
@@ -188,7 +188,7 @@ public abstract class PromiseSerializationNodes {
 
       @Override
       public void fixUp(final Object o) {
-        promise.setValue(o);
+        promise.setValueFromSnapshot(o);
       }
     }
   }

--- a/src/tools/snapshot/nodes/PromiseSerializationNodes.java
+++ b/src/tools/snapshot/nodes/PromiseSerializationNodes.java
@@ -1,0 +1,188 @@
+package tools.snapshot.nodes;
+
+import java.util.List;
+
+import com.oracle.truffle.api.dsl.GenerateNodeFactory;
+import com.oracle.truffle.api.dsl.Specialization;
+
+import som.interpreter.Types;
+import som.interpreter.actors.EventualMessage;
+import som.interpreter.actors.EventualMessage.PromiseMessage;
+import som.interpreter.actors.SPromise;
+import som.interpreter.actors.SPromise.SResolver;
+import som.interpreter.objectstorage.ClassFactory;
+import tools.snapshot.SnapshotBuffer;
+import tools.snapshot.deserialization.DeserializationBuffer;
+import tools.snapshot.deserialization.FixupInformation;
+
+
+public abstract class PromiseSerializationNodes {
+
+  @GenerateNodeFactory
+  public abstract static class PromiseSerializationNode extends AbstractSerializationNode {
+
+    public PromiseSerializationNode(final ClassFactory classFact) {
+      super(classFact);
+    }
+
+    @Specialization(guards = "prom.isCompleted()")
+    public void doResolved(final SPromise prom, final SnapshotBuffer sb) {
+      int base = sb.addObject(prom, classFact, 1 + Long.BYTES);
+      // resolutionstate
+      sb.putByteAt(base, (byte) 1);
+
+      Object value = prom.getValue();
+      if (!sb.containsObject(value)) {
+        Types.getClassOf(value).serialize(value, sb);
+      }
+      sb.putLongAt(base + 1, sb.getObjectPointer(value));
+    }
+
+    @Specialization(guards = "!prom.isCompleted()")
+    public void doUnresolved(final SPromise prom, final SnapshotBuffer sb) {
+      int ncp = prom.getNumChainedPromises();
+      int nwr = prom.getNumWhenResolved();
+      int noe = prom.getNumOnError();
+
+      int base = sb.addObject(prom, classFact, 1 + 6 + Long.BYTES * (noe + nwr + ncp));
+
+      // resolutionstate
+      // TODO errored Promises
+      sb.putByteAt(base, (byte) 0);
+
+      // whenResolvedMsgs
+      sb.putShortAt(base + 1, (short) nwr);
+      base += 3;
+      if (nwr > 0) {
+        sb.putLongAt(base, prom.getWhenResolved().serialize(sb));
+        base += Long.BYTES;
+
+        if (nwr > 1) {
+          List<PromiseMessage> wre = prom.getWhenResolvedExt();
+          for (int i = 0; i < wre.size(); i++) {
+            sb.putLongAt(base + i * Long.BYTES, wre.get(i).serialize(sb));
+          }
+          base += wre.size() * Long.BYTES;
+        }
+      }
+
+      // onErrorMsgs
+      sb.putShortAt(base, (short) noe);
+      base += 2;
+      if (noe > 0) {
+        sb.putLongAt(base, prom.getOnError().serialize(sb));
+        base += Long.BYTES;
+
+        if (noe > 1) {
+          List<PromiseMessage> oee = prom.getOnErrorExt();
+          for (int i = 0; i < oee.size(); i++) {
+            sb.putLongAt(base + i * Long.BYTES, oee.get(i).serialize(sb));
+          }
+          base += oee.size() * Long.BYTES;
+        }
+      }
+
+      // chainedPromises deal with as with far references(fixup)
+      sb.putShortAt(base, (short) ncp);
+      base += 2;
+      if (ncp > 0) {
+        SPromise p = prom.getChainedPromise();
+        SPromise.getPromiseClass().serialize(p, sb);
+        sb.putLongAt(base, sb.getObjectPointer(p));
+        base += Long.BYTES;
+
+        if (ncp > 1) {
+          List<SPromise> cpe = prom.getChainedPromiseExt();
+          for (int i = 0; i < cpe.size(); i++) {
+            p = cpe.get(i);
+            SPromise.getPromiseClass().serialize(p, sb);
+            sb.putLongAt(base + i * Long.BYTES, sb.getObjectPointer(p));
+          }
+        }
+      }
+    }
+
+    @Override
+    public SPromise deserialize(final DeserializationBuffer sb) {
+      boolean completed = sb.get() == 1;
+
+      if (completed) {
+        Object value = sb.getReference();
+        SPromise p = SPromise.createResolved(
+            EventualMessage.getActorCurrentMessageIsExecutionOn(), value);
+
+        if (DeserializationBuffer.needsFixup(value)) {
+          sb.installFixup(new PromiseValueFixup(p));
+        }
+
+        return p;
+      } else {
+        SPromise promise = SPromise.createPromise(
+            EventualMessage.getActorCurrentMessageIsExecutionOn(), false, false, null);
+
+        // These messages aren't referenced by anything else, no need to deal with fixup
+        int whenResolvedCnt = sb.getShort();
+        for (int i = 0; i < whenResolvedCnt; i++) {
+          PromiseMessage pm = (PromiseMessage) sb.getReference();
+          promise.registerWhenResolvedUnsynced(pm);
+        }
+
+        int onErrorCnt = sb.getShort();
+        for (int i = 0; i < onErrorCnt; i++) {
+          PromiseMessage pm = (PromiseMessage) sb.getReference();
+          promise.registerOnErrorUnsynced(pm);
+        }
+
+        int chainedPromCnt = sb.getShort();
+        for (int i = 0; i < chainedPromCnt; i++) {
+          SPromise remote = (SPromise) sb.getReference();
+          promise.addChainedPromise(remote);
+        }
+
+        return promise;
+      }
+    }
+
+    public static class PromiseValueFixup extends FixupInformation {
+      private final SPromise promise;
+
+      public PromiseValueFixup(final SPromise promise) {
+        this.promise = promise;
+      }
+
+      @Override
+      public void fixUp(final Object o) {
+        promise.setValue(o);
+      }
+    }
+  }
+
+  // Resolvers are values and can be passed directly without being wrapped
+  // Problem how do i deal with identity of Resolvers
+  // from what i have seen there is only one resolver created for any promise.
+  // resolver only contains a reference to the promise
+  // a problem is that i'm missing ownership of the promise
+
+  @GenerateNodeFactory
+  public abstract static class ResolverSerializationNode extends AbstractSerializationNode {
+    public ResolverSerializationNode(final ClassFactory classFact) {
+      super(classFact);
+    }
+
+    @Specialization
+    public void doResolver(final SResolver resolver, final SnapshotBuffer sb) {
+      int base = sb.addObject(resolver, classFact, Long.BYTES);
+      SPromise prom = resolver.getPromise();
+      if (!sb.containsObject(prom)) {
+        SPromise.getPromiseClass().serialize(prom, sb);
+      }
+      sb.putLongAt(base, sb.getObjectPointer(prom));
+    }
+
+    @Override
+    public SResolver deserialize(final DeserializationBuffer bb) {
+      SPromise prom = (SPromise) bb.getReference();
+      return SPromise.createResolver(prom);
+    }
+  }
+}

--- a/src/tools/snapshot/nodes/SerializerRootNode.java
+++ b/src/tools/snapshot/nodes/SerializerRootNode.java
@@ -1,5 +1,6 @@
 package tools.snapshot.nodes;
 
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.RootNode;
 
@@ -7,11 +8,19 @@ import som.interpreter.SomLanguage;
 
 
 public final class SerializerRootNode extends RootNode {
+  @CompilationFinal private static SomLanguage lang;
+
   @Child protected AbstractSerializationNode serializer;
 
-  public SerializerRootNode(final SomLanguage language,
-      final AbstractSerializationNode serializer) {
-    super(language);
+  public static void initializeSerialization(final SomLanguage lang) {
+    if (lang != null && SerializerRootNode.lang == null) {
+      SerializerRootNode.lang = lang;
+    }
+  }
+
+  public SerializerRootNode(final AbstractSerializationNode serializer) {
+    super(lang);
+    assert lang != null;
     this.serializer = insert(serializer);
   }
 


### PR DESCRIPTION
This PR is another step towards actor snapshots, it introduces:

- **Support for deserializing circular object graphs** by introducing a fixup system:
When a not yet available object is referenced, we temporarily assign a placeholder (e.g. `null`), and create a `FixupInformation` object that allows us to insert the correct reference once the object is available (deserialized).

- **Serialization of blocks:**
Blocks can be (de)serialized, including their context (`MaterializedFrame`).
We do not serialize `FrameDescriptors` and instead recover that information in replay from the blocks invokable.
Non-local returns from deserialized blocks are currently not supported (this means we cover sufficient semantics of for instance JS).

- **Serialization of Promises and Messages:**
Promises including any scheduled callbacks, messages, or chained promises can be (de)serialized.
Message serialization will be essential for snapshotting, as it will be our starting point for snapshots (i.e. serializing all objects that are reachable from serialized messages).


