### PR TITLE
Improve readability of Travis CI Logs by using folding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install: |
   if [ "$TRAVIS_OS_NAME" = "linux" ]
   then
     JDK_TAR=${TRAVIS_BUILD_DIR}/../jdk.tar.gz
-    wget https://github.com/graalvm/openjdk8-jvmci-builder/releases/download/${JVMCI_VERSION}/openjdk-8u${JDK8_UPDATE_VERSION}-${JVMCI_VERSION}-linux-amd64.tar.gz -O ${JDK_TAR}
+    wget --progress=bar:force https://github.com/graalvm/openjdk8-jvmci-builder/releases/download/${JVMCI_VERSION}/openjdk-8u${JDK8_UPDATE_VERSION}-${JVMCI_VERSION}-linux-amd64.tar.gz -O ${JDK_TAR}
     tar -C ${TRAVIS_BUILD_DIR}/.. -xzf ${JDK_TAR}
     export JVMCI_HOME=${TRAVIS_BUILD_DIR}/../openjdk1.8.0_${JDK8_UPDATE_VERSION}-${JVMCI_VERSION}
   fi
@@ -70,7 +70,7 @@ install: |
   then
     export ECLIPSE_TAR=eclipse.tar.gz
     export ECLIPSE_URL=http://archive.eclipse.org/eclipse/downloads/drops4/R-4.6.3-201703010400/eclipse-SDK-4.6.3-linux-gtk-x86_64.tar.gz
-    wget ${ECLIPSE_URL} -O ${ECLIPSE_TAR}
+    wget --progress=bar:force ${ECLIPSE_URL} -O ${ECLIPSE_TAR}
     tar -C ${TRAVIS_BUILD_DIR}/.. -xzf ${ECLIPSE_TAR}
     export ECLIPSE_EXE=${TRAVIS_BUILD_DIR}/../eclipse/eclipse
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,19 @@ matrix:
   allow_failures:
     - os: osx
 
+before_install:
+  - |
+   run() {
+     ID=`echo "$@" | sed -e 's/ /_/g'`
+     STR=`echo "$@"`
+     printf "travis_fold:start:$ID\n$STR\n"
+     eval "$@"
+     printf "travis_fold:end:$ID\n"
+   }
+
+
 install: |
+  printf "travis_fold:start:downloads\nLoad JDK and/or Eclipse\n"
   if [ "$TRAVIS_OS_NAME" = "linux" ]
   then
     JDK_TAR=${TRAVIS_BUILD_DIR}/../jdk.tar.gz
@@ -63,13 +75,16 @@ install: |
     export ECLIPSE_EXE=${TRAVIS_BUILD_DIR}/../eclipse/eclipse
   fi
   export SG=-Dskip.graal=true
+  export ANT="ant -e $SG"
+  printf "travis_fold:end:downloads\n"
+
 
 script:
-  - if [ "$TASK" = "core-tests"    ]; then ant $SG core-tests    && ant $SG serialization-tests && ant $SG coverage; fi
-  - if [ "$TASK" = "checkstyle"    ]; then ant $SG checkstyle    && ant $SG eclipseformat-check && cd tools/kompos && nvm install 7 && npm install && npm run lint; fi
-  - if [ "$TASK" = "kompos-tests"  ]; then nvm install 8         && ant $SG && cd tools/kompos && npm -s run verify && npm test; fi
-  - if [ "$TASK" = "replay1-tests" ]; then ant $SG compile       && ./tests/replay/test.sh 1; fi
-  - if [ "$TASK" = "replay2-tests" ]; then ant $SG compile       && ./tests/replay/test.sh 2; fi
-  - if [ "$TASK" = "snapshot-tests" ]; then ant $SG compile       && ./tests/snapshot/test.sh; fi
-  - if [ "$TASK" = "unit-tests"    ]; then ant compile           && ./som core-lib/TestSuite/TestRunner.ns; fi
-  - if [ "$TASK" = "native"        ]; then ant native; fi
+  - if [ "$TASK" = "core-tests"    ]; then $ANT core-tests    && $ANT serialization-tests && $ANT coverage; fi
+  - if [ "$TASK" = "checkstyle"    ]; then $ANT checkstyle    && $ANT eclipseformat-check && run cd tools/kompos && nvm install 7 && run npm install && run npm run lint; fi
+  - if [ "$TASK" = "kompos-tests"  ]; then run nvm install 8  && $ANT && cd tools/kompos  && run npm -s run verify && run npm test; fi
+  - if [ "$TASK" = "replay1-tests" ]; then $ANT compile       && run ./tests/replay/test.sh 1; fi
+  - if [ "$TASK" = "replay2-tests" ]; then $ANT compile       && run ./tests/replay/test.sh 2; fi
+  - if [ "$TASK" = "snapshot-tests" ]; then $ANT compile      && run ./tests/snapshot/test.sh; fi
+  - if [ "$TASK" = "unit-tests"    ]; then $ANT compile       && run ./som core-lib/TestSuite/TestRunner.ns; fi
+  - if [ "$TASK" = "native"        ]; then $ANT native; fi

--- a/build.xml
+++ b/build.xml
@@ -80,7 +80,16 @@
         <path refid="common.cp"/>
         <pathelement location="${svm.build}/library-support.jar" />
     </path>
-    
+
+    <macrodef name="travis">
+        <attribute name="target" />
+        <attribute name="start" default="" />
+        <sequential>
+            <echo message="travis_fold:start:@{target}${line.separator}@{start}${line.separator}" unless:blank="@{start}" if:true="${env.TRAVIS}" />
+            <echo message="travis_fold:end:@{target}${line.separator}"             if:blank="@{start}" if:true="${env.TRAVIS}" />
+        </sequential>
+    </macrodef>
+
     <condition property="is.atLeastJava9" value="true" else="false">
       <or>
         <matches string="${java.version}" pattern="^9"/>
@@ -90,32 +99,47 @@
     <condition property="kernel" value="darwin-amd64" else="linux-amd64">
         <os family="mac"/>
     </condition>
+    <travis target="env" start="Environment" />
     <echo>
         ant.java.version: ${ant.java.version}
         java.version:     ${java.version}
         is.atLeastJava9:  ${is.atLeastJava9}
         kernel:           ${kernel}
+        env.TRAVIS:       ${env.TRAVIS}
     </echo>
+    <travis target="env" />
 
     <target name="clean" description="Remove build directories and generated code">
+        <travis target="clean" start="clean" />
+
         <delete dir="${build.dir}"/>
         <delete dir="${src_gen.dir}"/>
         <ant dir="${corelib.dir}/TestSuite/extension" useNativeBasedir="true" target="clean" inheritAll="false" />
+
+        <travis target="clean" />        
     </target>
 
     <target name="clean-truffle" depends="check-truffle-available" if="truffle.present">
+        <travis target="clean-truffle" start="clean-truffle" />
+        
         <exec executable="${mx.cmd}" dir="${truffle.dir}">
             <arg value="clean"/>
         </exec>
         <exec executable="${mx.cmd}" dir="${tools.dir}">
             <arg value="clean"/>
         </exec>
+        
+        <travis target="clean-truffle" />
     </target>
 
     <target name="clobber" description="Do clean, and also clean truffle build" depends="clean,clean-truffle">
+        <travis target="clobber" start="clobber" />
+        
         <delete dir="${kompos.dir}/out"/>
         <delete dir="${kompos.dir}/node_modules"/>
         <ant dir="${bd.dir}" useNativeBasedir="true" target="clean" inheritAll="false"/>
+        
+        <travis target="clobber" />
     </target>
 
     <target name="check-truffle-available">
@@ -128,6 +152,7 @@
     </target>
 
     <target name="truffle-libs" unless="skip.truffle" depends="truffle-submodule">
+        <travis target="truffle-libs" start="Build Truffle" />
         <exec executable="${mx.cmd}" dir="${truffle.dir}" failonerror="true">
             <arg value="build"/>
             <arg value="--no-native"/>
@@ -139,9 +164,11 @@
             <arg value="build"/>
             <env key="JAVA_HOME" value="${env.JVMCI_HOME}" />
         </exec>
+        <travis target="truffle-libs" />
     </target>
 
     <target name="build-graal" description="Build the embedded Graal" unless="skip.graal">
+      <travis target="build-graal" start="Build Graal" />
       <echo unless:true="${is.atLeastJava9}" level="warning">
           The used JDK needs to have JVMCI support, which is the case for Java 9.
           If Java 8 is needed, see
@@ -153,9 +180,11 @@
         <arg value="build" />
         <arg value="--no-native" />
       </exec>
+      <travis target="build-graal" />
     </target>
 
     <target name="bd-libs"> <!-- implicit dependency on truffle-libs -->
+        <travis target="bd-libs" start="Build Black Diamonds" />
         <ant dir="${bd.dir}" useNativeBasedir="true" target="libs-junit" inheritAll="false">
             <property name="force.java8"   value="${is.atLeastJava9}" />
         </ant>
@@ -165,6 +194,7 @@
             <property name="truffle.build" value="${truffle.build}" />
             <property name="force.java8"   value="${is.atLeastJava9}" />
         </ant>
+        <travis target="bd-libs" />
     </target>
 
     <target name="ideinit" depends="source">
@@ -183,12 +213,14 @@
     </target>
 
     <target name="libs" depends="truffle-libs,bd-libs" unless="skip.libs">
+        <travis target="libs" start="Get Libs" />
         <get src="${lib.url}/somns-deps-${somns-deps.version}.jar"
             usetimestamp="true"
             dest="${lib.dir}/somns-deps.jar" />
         <get src="${lib.url}/somns-deps-dev-${somns-deps.version}.jar"
             usetimestamp="true"
             dest="${lib.dir}/somns-deps-dev.jar" />
+        <travis target="libs" />
     </target>
 
     <target name="source" description="Download Source Jars for development">
@@ -198,6 +230,7 @@
     </target>
 
     <target name="eclipseformat">
+        <travis target="eclipseformat" start="Format code with Eclipse" />
         <pathconvert pathsep=" " property="javafiles">
             <fileset dir="${src.dir}">
                 <include name="**/*.java"/>
@@ -222,9 +255,11 @@
             <arg value="${basedir}/.settings/org.eclipse.jdt.core.prefs"/>
             <arg line="${javafiles}"/>
         </exec>
+        <travis target="eclipseformat" />
     </target>
 
     <target name="eclipseformat-check" depends="eclipseformat">
+        <travis target="eclipseformat-check" start="Check Eclipse Format" />
         <exec executable="git" dir="${basedir}">
             <arg value="status" />
             <arg value="*.java" />
@@ -236,15 +271,19 @@
             <arg value="--ignore-submodules" />
             <arg value="HEAD" />
         </exec>
+        <travis target="eclipseformat-check" />
     </target>
 
     <target name="checkstyle-jar">
+        <travis target="checkstyle-jar" start="Get Checkstyle Jar" />
         <get src="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${checkstyle.version}/checkstyle-${checkstyle.version}-all.jar"
             usetimestamp="true"
             dest="${lib.dir}/checkstyle-${checkstyle.version}-all.jar" />
+        <travis target="checkstyle-jar" />
     </target>
 
     <target name="checkstyle" depends="checkstyle-jar" description="Check Code with Checkstyle">
+        <travis target="checkstyle" start="Run Checkstyle" />
         <taskdef resource="com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties" classpath="${lib.dir}/checkstyle-${checkstyle.version}-all.jar" />
         <checkstyle config=".checkstyle_checks.xml">
           <fileset dir="${src.dir}" includes="**/*.java"/>
@@ -252,9 +291,11 @@
           <fileset dir="${corelib.dir}" includes="**/*.java"/>
           <formatter type="plain"/>
         </checkstyle>
+        <travis target="checkstyle" />
     </target>
 
     <target name="jacoco-lib" description="Get JaCoCo dependency">
+        <travis target="jacoco-lib" start="Get JaCoCo" />
         <get src="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/${jacoco.version}/jacoco-${jacoco.version}.zip"
             usetimestamp="true"
             dest="${lib.dir}/jacoco-${jacoco.version}.zip" />
@@ -262,22 +303,28 @@
         <taskdef uri="antlib:org.jacoco.ant"
             resource="org/jacoco/ant/antlib.xml"
             classpath="${lib.dir}/jacoco/lib/jacocoant.jar" />
+        <travis target="jacoco-lib" />
     </target>
 
     <target name="codacy-coverage-lib" description="Report Coverage to Codacy">
+        <travis target="codacy-lib" start="Get Codacy Lib" />
         <get src="https://oss.sonatype.org/service/local/repositories/releases/content/com/codacy/codacy-coverage-reporter/2.0.2/codacy-coverage-reporter-2.0.2-assembly.jar"
             usetimestamp="true"
             dest="${lib.dir}/codacy-coverage-reporter.jar" />
+        <travis target="codacy-lib" />
     </target>
 
     <target name="java8-on-java9" description="Support Java 9 or later" if="${is.atLeastJava9}">
+      <travis target="java89" start="Support Java 9" />
       <mkdir dir="${classes.dir}" />
       <javac includeantruntime="false" srcdir="${lib.dir}/java8" destdir="${classes.dir}" debug="true">
         <compilerarg line="--release 8" />
       </javac>
+      <travis target="java89" />
     </target>
 
     <target name="compile-som" description="Compile SOMns" depends="java8-on-java9">
+        <travis target="compile-som" start="Compilse SOMns" />
         <mkdir dir="${build.dir}"/>
         <mkdir dir="${classes.dir}" />
         <mkdir dir="${src_gen.dir}" />
@@ -299,20 +346,25 @@
           <classpath refid="som.cp" />
           <compilerarg line="--release 8" if:true="${is.atLeastJava9}" />
         </javac>
+        <travis target="compile-som" />
     </target>
 
     <target name="compile" depends="libs,compile-som,compile-test-extension,build-graal" description="Compile SOMns and dependencies">
     </target>
 
     <target name="compile-test-extension">
+      <travis target="compile-test-extension" start="Compile an Extension for Testing" />
       <ant dir="${corelib.dir}/TestSuite/extension" useNativeBasedir="true" target="jar" inheritAll="false" />
+      <travis target="compile-test-extension" />
     </target>
 
     <target name="kompos" description="Build Kompos">
+        <travis target="kompos" start="Build Kompos" />
         <exec executable="npm" dir="${kompos.dir}" failonerror="true">
             <arg value="--quiet"/>
             <arg value="install"/>
         </exec>
+        <travis target="kompos" />
     </target>
 
     <target name="compile-all" depends="compile,kompos" description="Build SOMns and Kompos">
@@ -323,6 +375,7 @@
     </target>
 
     <target name="unit-tests" depends="compile,jacoco-lib" description="Execute tests">
+      <travis target="unit-tests" start="Execute Tests" />
       <jacoco:coverage>
         <junit haltonerror="false" haltonfailure="false" failureproperty="test.failed"
             outputtoformatters="true" fork="true" forkmode="once">
@@ -349,9 +402,11 @@
      </jacoco:coverage>
 
      <fail message="Basic tests failed." if="test.failed" />
+     <travis target="unit-tests" />
     </target>
 
     <target name="som-tests" depends="compile">
+      <travis target="som-tests" start="Run SOMns Tests" />
       <!-- delete old coverage data, this should be the first task generating coverage data -->
       <delete file="all.gcov" />
 
@@ -368,9 +423,11 @@
         <arg value="-X" />
         <arg value="${corelib.dir}/TestSuite/TestRunner.ns" />
       </exec>
+      <travis target="som-tests" />
     </target>
 
     <target name="serialization-tests" depends="compile">
+      <travis target="serialization-tests" start="Test Snapshot Serialization" />
       <exec executable="./som" failonerror="true">
         <arg value="-G" />
         <arg value="-at" />
@@ -379,16 +436,21 @@
         <arg value="${corelib.dir}/TestSuite/Serialization.ns" /> 
         <arg value="SerializationTest" />
       </exec>
+      <travis target="serialization-tests" />
     </target>
 
     <target name="dynamic-metrics-tests" depends="compile-som">
+      <travis target="dym-tests" start="Test Dynamic Metric Tool" />
       <exec executable="tests/dym/test.sh" failonerror="true">
           <arg value="--coverage" />
       </exec>
+      <travis target="dym-tests" />
     </target>
 
     <target name="superinstructions-tests" depends="compile-som">
+      <travis target="si-tests" start="Test Superinstruction Tool" />
       <exec executable="tests/superinstructions/test.sh" failonerror="true"></exec>
+      <travis target="si-tests" />
     </target>
     
     <target name="update-test-data" depends="compile-som" description="Updates the test data for DynamicMetrics and SuperInstructions">
@@ -401,23 +463,28 @@
     </target>
 
     <target name="replay-tests" depends="compile">
+      <travis target="replay-tests" start="Test Trace Replay" />
       <exec executable="tests/replay/test.sh" failonerror="true">
           <arg value="1" />
       </exec>
       <exec executable="tests/replay/test.sh" failonerror="true">
           <arg value="2" />
       </exec>
+      <travis target="replay-tests" />
     </target>
 
     <target name="snapshot-tests" depends="compile">
+      <travis target="snapshot-tests" start="Tests Snapshotting" />
       <exec executable="tests/snapshot/test.sh" failonerror="true">
       </exec>
+      <travis target="snapshot-tests" />
     </target>
 
     <target name="core-tests" depends="unit-tests,som-tests,dynamic-metrics-tests,superinstructions-tests">
     </target>
 
     <target name="send-java-coverage" depends="jacoco-lib,codacy-coverage-lib">
+      <travis target="send-java-coverage" start="Send Java Coverage" />
       <jacoco:report>
         <executiondata>
           <file file="jacoco.exec"/>
@@ -447,15 +514,18 @@
         <arg value="-r" />
         <arg value="jacoco.xml" />
       </java>
+      <travis target="send-java-coverage" />
     </target>
 
     <target name="send-somns-coverage">
+        <travis target="send-somns-coverage" start="Send SOMns Coverage" />
         <!-- submit coverage data -->
         <java classname="coveralls.Report" fork="true" failonerror="true">
             <classpath refid="som.cp" />
             <arg value="${env.COVERALLS_REPO_TOKEN}" />
             <arg value="all.gcov" />
         </java>
+        <travis target="send-somns-coverage" />
     </target>
 
     <target name="coverage" depends="send-java-coverage,send-somns-coverage" />
@@ -464,6 +534,7 @@
     </target>
     
     <target name="native" depends="libs,compile-som">
+      <travis target="native" start="Build Native Image" />
       <java classname="com.oracle.svm.hosted.NativeImageGeneratorRunner" fork="true" failonerror="true"
           jvm="${env.JVMCI_HOME}/bin/java">
         <classpath refid="svm.cp" />
@@ -496,5 +567,6 @@
         <arg line="-H:Class=som.Launcher -H:Name=som-native" />
 
       </java>
+      <travis target="native" />
     </target>
 </project>


### PR DESCRIPTION
This adds folding info to `build.xml` and `.travis.yml`.

It also force the use of the wget progress bar to avoid flooding the logs with text.