### PR TITLE
Update basic-setup documentation

### DIFF
--- a/docs/basic-setup.md
+++ b/docs/basic-setup.md
@@ -4,15 +4,18 @@ A brief overview for a basic development setup for SOMns.
 
 ## Minimal Software Requirements
 
-SOMns works on Java 9 or 10, uses Ant as a build system, git as
-source control system, and Python for a launcher script.
+SOMns works on Java 8+JVMCI, Java 9, 10 and 11, uses Ant as a build system, git as source control system, and Python for a launcher script.
 
-We test SOMns on Linux and macOS. Windows is not currently supported.
+SOMns relies on JVMCI, which is present by default in Java starting from Java 9. Hence, to use Java8, one needs to download a [lab JDK 8](https://www.oracle.com/technetwork/oracle-labs/program-languages/downloads/index.html) instead of the default JDK 8.
 
-On Ubuntu, the following instructions will install the necessary dependencies:
+Although most of SOMns can be compiled under Java 9, 10 and 11, the Substrate VM dependency can be compiled so far only using Java 8+JVMCI.  To work around this problem, the build process includes two environment variables, JAVA\_HOME and JVMCI\_HOME. JVMCI_HOME must hold a Java 8+JVMCI home, while JAVA\_HOME can hold a more recent JDK home (JDK 11 for example).
+
+We test SOMns on Linux and macOS (fully under Java 8+JVMCI, and in Java 11 mixed with Java 8+JVMCI). Windows is not currently supported.
+
+On Ubuntu, the following instructions will install the necessary dependencies (in this case jdk 11):
 
 ```bash
-sudo apt install openjdk-9-jdk git ant
+sudo apt install openjdk-11-jdk git ant
 ```
 
 On macOS, the relevant dependencies can be installed, for instance with
@@ -22,12 +25,17 @@ On macOS, the relevant dependencies can be installed, for instance with
 brew tap caskroom/versions
 brew cask install java
 brew install ant
-export JAVA_HOME=`/usr/libexec/java_home`
 ```
 
 MacPorts or other Linux package manager should allow the installation of
 dependencies with similar instructions.
 
+In addition to the dependencies installed, a [lab JDK 8](https://www.oracle.com/technetwork/oracle-labs/program-languages/downloads/index.html) has to be installed. The environment variables JAVA\_HOME and JVMCI\_HOME have also to be set, so that JVMCI\_HOME points to a Java8+JVMCI and JAVA_HOME to the desired Java version. Possible instructions to do so could be (on Mac):
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-11.jdk/Contents/Home
+export JVMCI_HOME=/Library/Java/JavaVirtualMachines/labsjdk1.8.0_192-jvmci-0.53/Contents/Home
+```
 
 ## Getting the Code and Running Hello World
 

--- a/docs/basic-setup.md
+++ b/docs/basic-setup.md
@@ -4,15 +4,24 @@ A brief overview for a basic development setup for SOMns.
 
 ## Minimal Software Requirements
 
-SOMns works on Java 8+JVMCI, Java 9, 10 and 11, uses Ant as a build system, git as source control system, and Python for a launcher script.
+SOMns works on Java 8+JVMCI, Java 9, 10 and 11, uses Ant as a build system,
+git as source control system, and Python for a launcher script.
 
-SOMns relies on JVMCI, which is present by default in Java starting from Java 9. Hence, to use Java8, one needs to download a [lab JDK 8](https://www.oracle.com/technetwork/oracle-labs/program-languages/downloads/index.html) instead of the default JDK 8.
+For performance, SOMns relies on the Graal compiler using the JVMCI,
+which is present by default in Java starting from Java 9.
+To use Java 8, one needs to use the [Oracle Labs JDK 8](https://www.oracle.com/technetwork/oracle-labs/program-languages/downloads/index.html) instead of the default JDK 8.
 
-Although most of SOMns can be compiled under Java 9, 10 and 11, the Substrate VM dependency can be compiled so far only using Java 8+JVMCI.  To work around this problem, the build process includes two environment variables, JAVA\_HOME and JVMCI\_HOME. JVMCI_HOME must hold a Java 8+JVMCI home, while JAVA\_HOME can hold a more recent JDK home (JDK 11 for example).
+Although SOMns can be used with Java 9, 10, and 11, the Substrate VM dependency
+can be compiled so far only using JDK 8+JVMCI. To work around this problem,
+the build process includes two environment variables, `JAVA_HOME` and `JVMCI_HOME`.
+`JVMCI_HOME` must point to the JDK 8+JVMCI home directory,
+while `JAVA_HOME` can point to a standard JDK 8 or later.
 
-We test SOMns on Linux and macOS (fully under Java 8+JVMCI, and in Java 11 mixed with Java 8+JVMCI). Windows is not currently supported.
+We test SOMns on Linux and macOS (fully under JDK 8+JVMCI, and in Java 11 mixed
+with Java 8+JVMCI). Windows is not currently supported.
 
-On Ubuntu, the following instructions will install the necessary dependencies (in this case jdk 11):
+On Ubuntu, the following instructions will install the necessary dependencies,
+in this case JDK 11:
 
 ```bash
 sudo apt install openjdk-11-jdk git ant
@@ -30,7 +39,12 @@ brew install ant
 MacPorts or other Linux package manager should allow the installation of
 dependencies with similar instructions.
 
-In addition to the dependencies installed, a [lab JDK 8](https://www.oracle.com/technetwork/oracle-labs/program-languages/downloads/index.html) has to be installed. The environment variables JAVA\_HOME and JVMCI\_HOME have also to be set, so that JVMCI\_HOME points to a Java8+JVMCI and JAVA_HOME to the desired Java version. Possible instructions to do so could be (on Mac):
+In addition to the above dependencies, the [Oracle Labs JDK 8](https://www.oracle.com/technetwork/oracle-labs/program-languages/downloads/index.html)
+has to be installed.
+
+The environment variables `JAVA_HOME` and `JVMCI_HOME` have also to be set,
+so that `JVMCI_HOME` points to a JDK 8 + JVMCI and `JAVA_HOME` to the desired Java version.
+On a bash-compatible shell on macOS, the commands would be similar to:
 
 ```bash
 export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-11.jdk/Contents/Home


### PR DESCRIPTION
Update basic-setup to describe how to set-up the environment to ant compile the dev branch.

Java 8+JVMCI has basically to be installed and the environment variable JVMCI_HOME has to point to it for the substrate VM dependency to compile in addition to JAVA_HOME pointing to any Java version (typically Java 11).