### PR TITLE
Fix Travis Error codes and Codespeed URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,9 @@ before_install:
      STR=`echo "$@"`
      printf "travis_fold:start:$ID\n$STR\n"
      eval "$@"
+     RESULT_EVAL=$?
      printf "travis_fold:end:$ID\n"
+     return $RESULT_EVAL
    }
 
 

--- a/codespeed.conf
+++ b/codespeed.conf
@@ -7,7 +7,7 @@ reporting:
     # results can also be reported to a codespeed instance
     # see: https://github.com/tobami/codespeed
     codespeed:
-        url: http://somns-speed.stefan-marr.de/result/add/json/
+        url: https://somns-speed.stefan-marr.de/result/add/json/
 
 runs:
   min_iteration_time: 5


### PR DESCRIPTION
- error codes on Travis CI were not preserved by output folding
- somns-speed moved to a HTTPS URL