### PR TITLE
Blocking primitives cannot participate in safepoints

### DIFF
--- a/src/som/primitives/ActivityJoin.java
+++ b/src/som/primitives/ActivityJoin.java
@@ -10,6 +10,7 @@ import com.oracle.truffle.api.source.SourceSection;
 import bd.primitives.Primitive;
 import som.interpreter.actors.SuspendExecutionNodeGen;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
+import som.interpreter.objectstorage.ObjectTransitionSafepoint;
 import som.primitives.threading.TaskThreads.SomTaskOrThread;
 import som.vm.VmSettings;
 import tools.concurrency.KomposTrace;
@@ -38,7 +39,12 @@ public class ActivityJoin {
 
     @TruffleBoundary
     private static Object doJoin(final SomTaskOrThread task) {
-      return task.join();
+      try {
+        ObjectTransitionSafepoint.INSTANCE.unregister();
+        return task.join();
+      } finally {
+        ObjectTransitionSafepoint.INSTANCE.register();
+      }
     }
 
     @Specialization

--- a/src/som/primitives/threading/DelayPrimitives.java
+++ b/src/som/primitives/threading/DelayPrimitives.java
@@ -6,6 +6,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 
 import bd.primitives.Primitive;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
+import som.interpreter.objectstorage.ObjectTransitionSafepoint;
 import som.vm.constants.Nil;
 import som.vmobjects.SObjectWithClass.SObjectWithoutFields;
 
@@ -18,10 +19,12 @@ public final class DelayPrimitives {
     @TruffleBoundary
     public final SObjectWithoutFields doLong(final long milliseconds) {
       try {
+        ObjectTransitionSafepoint.INSTANCE.unregister();
         Thread.sleep(milliseconds);
       } catch (InterruptedException e) {
         /* Not relevant for the moment */
       }
+      ObjectTransitionSafepoint.INSTANCE.register();
       return Nil.nilObject;
     }
   }

--- a/src/som/primitives/threading/MutexPrimitives.java
+++ b/src/som/primitives/threading/MutexPrimitives.java
@@ -13,6 +13,7 @@ import som.interpreter.nodes.dispatch.BlockDispatchNode;
 import som.interpreter.nodes.dispatch.BlockDispatchNodeGen;
 import som.interpreter.nodes.nary.BinaryExpressionNode;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
+import som.interpreter.objectstorage.ObjectTransitionSafepoint;
 import som.vmobjects.SBlock;
 import som.vmobjects.SClass;
 import tools.concurrency.Tags.AcquireLock;
@@ -27,7 +28,12 @@ public final class MutexPrimitives {
     @TruffleBoundary
     @Specialization
     public static final ReentrantLock lock(final ReentrantLock lock) {
-      lock.lock();
+      try {
+        ObjectTransitionSafepoint.INSTANCE.unregister();
+        lock.lock();
+      } finally {
+        ObjectTransitionSafepoint.INSTANCE.register();
+      }
       return lock;
     }
 


### PR DESCRIPTION
Adapt all known blocking primitives to unregister before, and reregister after a safepoint.

@daumayr could you have a look and see whether this fixes your issues?

We don't have benchmarks evaluating this change, so, I think, correctness is key, and if performance becomes an issue, we need to find more specific strategies, or optimizations for special cases.