### PR TITLE
Renew Safepoint assumption only when invalid

### DIFF
--- a/src/som/interpreter/objectstorage/ObjectTransitionSafepoint.java
+++ b/src/som/interpreter/objectstorage/ObjectTransitionSafepoint.java
@@ -150,7 +150,9 @@ public final class ObjectTransitionSafepoint {
   }
 
   void renewAssumption() {
-    noSafePoint = create();
+    if (!noSafePoint.isValid()) {
+      noSafePoint = create();
+    }
   }
 
   private void waitForSafepointStart() {

--- a/tests/java/som/interpreter/objectstorage/SafepointPhaserTest.java
+++ b/tests/java/som/interpreter/objectstorage/SafepointPhaserTest.java
@@ -93,4 +93,19 @@ public class SafepointPhaserTest {
       ObjectTransitionSafepoint.INSTANCE.unregister();
     }, 60);
   }
+
+  @Test
+  public void testSafepointRegisterStorm() throws InterruptedException {
+    ObjectTransitionSafepoint.reset();
+    ParallelHelper.executeNTimesInParallel(() -> {
+      for (int i = 0; i < 100_000; i += 1) {
+        ObjectTransitionSafepoint.INSTANCE.register();
+
+        ObjectTransitionSafepoint.INSTANCE.transitionObject(
+            new SMutableObject(instanceClass, factory, layout));
+
+        ObjectTransitionSafepoint.INSTANCE.unregister();
+      }
+    }, 60);
+  }
 }

--- a/tests/java/som/tests/BasicInterpreterTests.java
+++ b/tests/java/som/tests/BasicInterpreterTests.java
@@ -275,9 +275,10 @@ public class BasicInterpreterTests {
         Boolean.class) : "INIT is exected to return true after initializing the Context";
 
     try {
-      ParallelHelper.executeNTimesInParallel(() -> {
+      ParallelHelper.executeNTimesInParallel((final int id) -> {
         Value actualResult = context.eval(Launcher.START);
         assertEqualsSOMValue(expectedResult, actualResult.as(Object.class));
+        return null;
       });
     } finally {
       context.close();

--- a/tests/java/som/tests/ParallelHelper.java
+++ b/tests/java/som/tests/ParallelHelper.java
@@ -9,16 +9,18 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.IntFunction;
 
 
 public final class ParallelHelper {
 
-  public static void executeNTimesInParallel(final Runnable task) throws InterruptedException {
+  public static void executeNTimesInParallel(final IntFunction<Void> task)
+      throws InterruptedException {
     executeNTimesInParallel(task, 10);
   }
 
-  public static void executeNTimesInParallel(final Runnable task, final int timeoutInSeconds)
-      throws InterruptedException {
+  public static void executeNTimesInParallel(final IntFunction<Void> task,
+      final int timeoutInSeconds) throws InterruptedException {
     int numThreads = getNumberOfThreads();
 
     ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
@@ -30,12 +32,13 @@ public final class ParallelHelper {
       CountDownLatch threadsDone = new CountDownLatch(numThreads);
 
       for (int i = 0; i < numThreads; i++) {
+        int id = i;
         threadPool.submit(() -> {
           try {
             threadsInitialized.countDown();
             threadsInitialized.await();
 
-            task.run();
+            task.apply(id);
           } catch (Throwable t) {
             exceptions.add(t);
           }


### PR DESCRIPTION
The assumption should not be replaced without invalidating it, or to put it differently:
If it is replaced before invalidation, the notice of invalidation may be lost. Thus, code depending on it is never invalidated.

- also added two more tests