### PR TITLE
Fix overflow bug in DividePrim

### DIFF
--- a/core-lib/TestSuite/IntegerTests.ns
+++ b/core-lib/TestSuite/IntegerTests.ns
@@ -195,6 +195,11 @@ class IntegerTests usingPlatform: platform testFramework: minitest = (
 
       self assert:  3 equals: 7 / 2.0.
       self assert:  2 equals: 7 / 3.5.
+
+      self assert: 9223372036854775808 equals: (* Java.MIN_VALUE *)   -9223372036854775808 / -1.
+
+      (* To trigger issue, we need to compute the value, because it is otherwise parsed as a big integer *)
+      self assert: 9223372036854775808 equals: (* Java.MIN_VALUE *) ((-922337203685477580 * 10) - 8) / -1.
     )
 
     public testDouble = (

--- a/src/som/primitives/arithmetic/DividePrim.java
+++ b/src/som/primitives/arithmetic/DividePrim.java
@@ -12,9 +12,17 @@ import bd.primitives.Primitive;
 @GenerateNodeFactory
 @Primitive(primitive = "int:divideBy:", selector = "/")
 public abstract class DividePrim extends ArithmeticPrim {
-  @Specialization
+  private static final BigInteger OVERFLOW_RESULT =
+      BigInteger.valueOf(Long.MIN_VALUE).divide(BigInteger.valueOf(-1));
+
+  @Specialization(guards = "!isOverflowDivision(left, right)")
   public final long doLong(final long left, final long right) {
     return left / right;
+  }
+
+  @Specialization(guards = "isOverflowDivision(left, right)")
+  public final Object doLongWithOverflow(final long left, final long right) {
+    return OVERFLOW_RESULT;
   }
 
   @Specialization
@@ -39,5 +47,9 @@ public abstract class DividePrim extends ArithmeticPrim {
   @Specialization
   public final Object doLong(final long left, final double right) {
     return (long) (left / right);
+  }
+
+  protected static final boolean isOverflowDivision(final long left, final long right) {
+    return left == Long.MIN_VALUE && right == -1;
   }
 }


### PR DESCRIPTION
`Long.MIN_VALUE / -1` is the only division that overflows.
Since the result is well-known, it can be precomputed.

"In cases where the size is int or long and overflow errors need to be detected, the methods addExact, subtractExact, multiplyExact, and toIntExact throw an ArithmeticException when the results overflow. For other arithmetic operations such as divide, absolute value, increment, decrement, and negation overflow occurs only with a specific minimum or maximum value and should be checked against the minimum or maximum as appropriate."
See https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html