### PR TITLE
Swap tracing buffers for blocked threads

### DIFF
--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -404,7 +404,9 @@ public class TracingBackend {
       this.snapshotVersion = snapshotVersion;
     }
 
-    protected TraceWorkerThread() {}
+    protected TraceWorkerThread() {
+      super("TraceWorkerThread");
+    }
 
     private BufferAndLimit tryToObtainBuffer() {
       BufferAndLimit buffer;

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 
 import javax.management.Notification;
 import javax.management.NotificationEmitter;
@@ -274,6 +275,10 @@ public class TracingBackend {
         } else if (t.swapTracingBufferIfThreadSuspendedInDebugger()) {
           runningThreads -= 1;
           result[i] = null;
+        } else if (isBlockedInJava(t)) {
+          runningThreads -= 1;
+          result[i] = null;
+          t.getBuffer().swapStorage();
         }
       }
     }
@@ -288,6 +293,11 @@ public class TracingBackend {
         throw new RuntimeException(e);
       }
     }
+  }
+
+  private static boolean isBlockedInJava(final Thread t) {
+    Object blocker = LockSupport.getBlocker(t);
+    return blocker != null;
   }
 
   public static final long[] getStatistics() {

--- a/tools/kompos/.vscode/tasks.json
+++ b/tools/kompos/.vscode/tasks.json
@@ -1,29 +1,48 @@
 {
-  "version": "0.1.0",
-  "command": "npm",
-  "isShellCommand": true,
-  "showOutput": "always",
+  "version": "2.0.0",
   "echoCommand": true,
-  "suppressTaskName": true,
   "options": {
     "cwd": "${workspaceRoot}"
   },
   "tasks": [
     {
-      "taskName": "continuous compilation",
+      "type": "process",
+      "group": "build",
+      "label": "continuous compilation",
+      "command": "npm",
       "isBackground": true,
       "args": ["run", "watch"],
-      "problemMatcher": "$tsc-watch"
+      "problemMatcher": "$tsc-watch",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      }
     },
     {
-      "taskName": "test",
+      "type": "process",
+      "label": "test",
+      "group": "test",
+      "command": "npm",
       "isBackground": false,
-      "args": []
+      "args": ["test"],
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "clear": true
+      }
     },
     {
-      "taskName": "format",
+      "type": "process",
+      "command": "npm",
+      "label": "format",
+      "group": "build",
       "isBackground": false,
-      "args": ["run", "format"]
+      "args": ["run", "format"],
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      }
     }
   ]
 }


### PR DESCRIPTION
The forced swapping of buffers deadlocks when it encounters threads that are blocked in Java synchronization mechanisms.

This should be handled explicitly, by marking the threads, I think.

However, for the moment, we can actually check whether the thread is parked, i.e., blocked.
Unclear whether this includes all threads though.

@daumayr what do you think of this change?