### PR TITLE
Fix kompos tracing

### DIFF
--- a/som
+++ b/som
@@ -101,6 +101,8 @@ tools.add_argument('--coverage', help='determine SOMns code coverage and store i
                    dest='coverage', default=None)
 tools.add_argument('--java-coverage', help='determine Java code coverage and store in given file',
                    dest='java_coverage', default=None)
+tools.add_argument('-kt', '--kompos-tracing', help='enable tracing of actor operations',
+                   dest='kompos_tracing', action='store_true', default=False)
 
 parser.add_argument('-o', '--only', help='only compile give methods, comma separated list',
                     dest='only_compile', default=None)
@@ -316,6 +318,8 @@ if args.vmdebug:
 
 if args.actor_tracing:
     flags += ['-Dsom.actorTracing=true']
+if args.kompos_tracing:
+    flags += ['-Dsom.komposTracing=true']
 if args.small_ids:
     flags += ['-Dsom.smallIds=true']
 if args.trace_file:

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -30,7 +30,6 @@ import tools.concurrency.TracingActors.ReplayActor;
 import tools.concurrency.TracingActors.TracingActor;
 import tools.debugger.WebDebugger;
 import tools.debugger.entities.ActivityType;
-import tools.debugger.entities.DynamicScopeType;
 import tools.replay.actors.ActorExecutionTrace;
 import tools.replay.nodes.TraceActorContextNode;
 import tools.snapshot.SnapshotBuffer;
@@ -301,15 +300,9 @@ public class Actor implements Activity {
       }
 
       try {
-        if (VmSettings.KOMPOS_TRACING) {
-          KomposTrace.scopeStart(DynamicScopeType.TURN, msg.getMessageId(),
-              msg.getTargetSourceSection());
-        }
         msg.execute();
       } finally {
-        if (VmSettings.KOMPOS_TRACING) {
-          KomposTrace.scopeEnd(DynamicScopeType.TURN);
-        }
+
       }
     }
 

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -299,11 +299,7 @@ public class Actor implements Activity {
         TracingActor.handleBreakpointsAndStepping(msg, dbg, actor);
       }
 
-      try {
-        msg.execute();
-      } finally {
-
-      }
+      msg.execute();
     }
 
     private boolean getCurrentMessagesOrCompleteExecution() {

--- a/src/som/vm/VmSettings.java
+++ b/src/som/vm/VmSettings.java
@@ -55,8 +55,8 @@ public class VmSettings implements Settings {
         System.getProperty("som.traceFile", System.getProperty("user.dir") + "/traces/trace");
     MEMORY_TRACING = getBool("som.memoryTracing", false);
     REPLAY = getBool("som.replay", false);
-    KOMPOS_TRACING = TRUFFLE_DEBUGGER_ENABLED; // REPLAY;
-    DISABLE_TRACE_FILE = getBool("som.disableTraceFile", false) || REPLAY;
+    KOMPOS_TRACING = getBool("som.komposTracing", false) || TRUFFLE_DEBUGGER_ENABLED; // REPLAY;
+    DISABLE_TRACE_FILE = getBool("som.disableTraceFile", false) || (REPLAY && !KOMPOS_TRACING);
     TRACE_SMALL_IDS = getBool("som.smallIds", false);
 
     ACTOR_TRACING = getBool("som.actorTracing", false);

--- a/src/tools/TraceData.java
+++ b/src/tools/TraceData.java
@@ -8,7 +8,8 @@ import som.vm.VmSettings;
  */
 public class TraceData {
 
-  public static final int SOURCE_SECTION_SIZE = VmSettings.TRUFFLE_DEBUGGER_ENABLED ? 8 : 0;
+  public static final int SOURCE_SECTION_SIZE =
+      (VmSettings.TRUFFLE_DEBUGGER_ENABLED || VmSettings.KOMPOS_TRACING) ? 8 : 0;
 
   public static final long ENTITY_ID_BITS = 30;
   public static final long THREAD_ID_BITS = 10;

--- a/src/tools/TraceData.java
+++ b/src/tools/TraceData.java
@@ -9,7 +9,7 @@ import som.vm.VmSettings;
 public class TraceData {
 
   public static final int SOURCE_SECTION_SIZE =
-      (VmSettings.TRUFFLE_DEBUGGER_ENABLED || VmSettings.KOMPOS_TRACING) ? 8 : 0;
+      VmSettings.KOMPOS_TRACING ? 8 : 0;
 
   public static final long ENTITY_ID_BITS = 30;
   public static final long THREAD_ID_BITS = 10;

--- a/src/tools/concurrency/KomposTrace.java
+++ b/src/tools/concurrency/KomposTrace.java
@@ -1,5 +1,8 @@
 package tools.concurrency;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.source.SourceSection;
+
 import bd.source.SourceCoordinate;
 import som.interpreter.actors.Actor;
 import som.interpreter.nodes.dispatch.Dispatchable;
@@ -9,8 +12,6 @@ import som.vm.Symbols;
 import som.vm.VmSettings;
 import som.vmobjects.SInvokable;
 import som.vmobjects.SSymbol;
-import src.com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import src.com.oracle.truffle.api.source.SourceSection;
 import tools.debugger.PrimitiveCallOrigin;
 import tools.debugger.entities.ActivityType;
 import tools.debugger.entities.DynamicScopeType;
@@ -171,7 +172,6 @@ public class KomposTrace {
       super.swapStorage();
       this.lastActivity = null;
       recordCurrentActivity(current);
-
       return true;
     }
 

--- a/src/tools/concurrency/KomposTrace.java
+++ b/src/tools/concurrency/KomposTrace.java
@@ -1,8 +1,5 @@
 package tools.concurrency;
 
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.source.SourceSection;
-
 import bd.source.SourceCoordinate;
 import som.interpreter.actors.Actor;
 import som.interpreter.actors.Actor.ActorProcessingThread;
@@ -14,6 +11,8 @@ import som.vm.Symbols;
 import som.vm.VmSettings;
 import som.vmobjects.SInvokable;
 import som.vmobjects.SSymbol;
+import src.com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import src.com.oracle.truffle.api.source.SourceSection;
 import tools.debugger.PrimitiveCallOrigin;
 import tools.debugger.entities.ActivityType;
 import tools.debugger.entities.DynamicScopeType;
@@ -283,7 +282,7 @@ public class KomposTrace {
       putLong(activityId);
       putShort(symbolId);
 
-      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED || VmSettings.KOMPOS_TRACING) {
+      if (VmSettings.KOMPOS_TRACING) {
         writeSourceSection(sourceSection);
       }
       assert position == start + requiredSpace;
@@ -307,7 +306,7 @@ public class KomposTrace {
       put(eventMarker);
       putLong(id);
 
-      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED || VmSettings.KOMPOS_TRACING) {
+      if (VmSettings.KOMPOS_TRACING) {
         writeSourceSection(section);
       }
       assert position == start + eventSize;

--- a/src/tools/concurrency/KomposTrace.java
+++ b/src/tools/concurrency/KomposTrace.java
@@ -2,8 +2,6 @@ package tools.concurrency;
 
 import bd.source.SourceCoordinate;
 import som.interpreter.actors.Actor;
-import som.interpreter.actors.Actor.ActorProcessingThread;
-import som.interpreter.actors.EventualMessage;
 import som.interpreter.nodes.dispatch.Dispatchable;
 import som.vm.Activity;
 import som.vm.ObjectSystem;
@@ -170,20 +168,9 @@ public class KomposTrace {
               Implementation.IMPL_CURRENT_ACTIVITY.getSize())) {
         return false;
       }
-
       super.swapStorage();
       this.lastActivity = null;
       recordCurrentActivity(current);
-
-      if (Thread.currentThread() instanceof ActorProcessingThread) {
-        EventualMessage msg = EventualMessage.getCurrentExecutingMessage();
-        ActorProcessingThread apt =
-            (ActorProcessingThread) ActorProcessingThread.currentThread();
-
-        if (apt.getCurrentActor() != null && msg != null) {
-          scopeStart(DynamicScopeType.TURN, msg.getMessageId(), msg.getTargetSourceSection());
-        }
-      }
 
       return true;
     }

--- a/src/tools/concurrency/KomposTrace.java
+++ b/src/tools/concurrency/KomposTrace.java
@@ -283,7 +283,7 @@ public class KomposTrace {
       putLong(activityId);
       putShort(symbolId);
 
-      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
+      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED || VmSettings.KOMPOS_TRACING) {
         writeSourceSection(sourceSection);
       }
       assert position == start + requiredSpace;
@@ -307,7 +307,7 @@ public class KomposTrace {
       put(eventMarker);
       putLong(id);
 
-      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
+      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED || VmSettings.KOMPOS_TRACING) {
         writeSourceSection(section);
       }
       assert position == start + eventSize;

--- a/src/tools/concurrency/TraceBuffer.java
+++ b/src/tools/concurrency/TraceBuffer.java
@@ -15,7 +15,7 @@ public abstract class TraceBuffer {
 
   public static TraceBuffer create(final long threadId) {
     assert VmSettings.ACTOR_TRACING || VmSettings.KOMPOS_TRACING;
-    if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
+    if (VmSettings.KOMPOS_TRACING) {
       return new KomposTrace.KomposTraceBuffer(threadId);
     } else {
       return new ActorTraceBuffer();

--- a/src/tools/concurrency/TracingActors.java
+++ b/src/tools/concurrency/TracingActors.java
@@ -406,7 +406,7 @@ public class TracingActors {
 
         for (EventualMessage msg : todo) {
           currentThread.currentMessage = msg;
-          handleBreakpointsAndStepping(firstMessage, dbg, a);
+          handleBreakpointsAndStepping(msg, dbg, a);
           msg.execute();
         }
 

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -583,9 +583,19 @@ public class TracingBackend {
       String name =
           VmSettings.TRACE_FILE + (VmSettings.SNAPSHOTS_ENABLED ? "." + snapshotVersion : "");
 
-      File f = new File(name + ".trace");
-      File sf = new File(name + ".sym");
-      File edf = new File(name + ".dat");
+      File f;
+      File sf;
+      File edf;
+      if (VmSettings.KOMPOS_TRACING) {
+        f = new File(name + ".ktrace");
+        sf = new File(name + ".ksym");
+        edf = new File(name + ".kdat");
+      } else {
+        f = new File(name + ".trace");
+        sf = new File(name + ".sym");
+        edf = new File(name + ".dat");
+      }
+
       f.getParentFile().mkdirs();
 
       try {

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -26,6 +26,8 @@ import javax.management.NotificationEmitter;
 import javax.management.NotificationListener;
 import javax.management.openmbean.CompositeData;
 
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.sun.management.GarbageCollectionNotificationInfo;
 
 import som.Output;
@@ -36,8 +38,6 @@ import som.vm.constants.Nil;
 import som.vmobjects.SArray;
 import som.vmobjects.SArray.SImmutableArray;
 import som.vmobjects.SSymbol;
-import src.com.oracle.truffle.api.CompilerDirectives;
-import src.com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import tools.debugger.FrontendConnector;
 import tools.replay.StringWrapper;
 import tools.replay.TwoDArrayWrapper;

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -26,8 +26,6 @@ import javax.management.NotificationEmitter;
 import javax.management.NotificationListener;
 import javax.management.openmbean.CompositeData;
 
-import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.sun.management.GarbageCollectionNotificationInfo;
 
 import som.Output;
@@ -38,6 +36,8 @@ import som.vm.constants.Nil;
 import som.vmobjects.SArray;
 import som.vmobjects.SArray.SImmutableArray;
 import som.vmobjects.SSymbol;
+import src.com.oracle.truffle.api.CompilerDirectives;
+import src.com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import tools.debugger.FrontendConnector;
 import tools.replay.StringWrapper;
 import tools.replay.TwoDArrayWrapper;
@@ -241,7 +241,7 @@ public class TracingBackend {
 
   public static final void forceSwapBuffers() {
     assert VmSettings.ACTOR_TRACING
-        || (VmSettings.TRUFFLE_DEBUGGER_ENABLED && VmSettings.KOMPOS_TRACING);
+        || (VmSettings.TRUFFLE_DEBUGGER_ENABLED);
     TracingActivityThread[] result;
     synchronized (tracingThreads) {
       result = tracingThreads.toArray(new TracingActivityThread[0]);

--- a/src/tools/debugger/FrontendConnector.java
+++ b/src/tools/debugger/FrontendConnector.java
@@ -16,14 +16,16 @@ import org.java_websocket.WebSocket;
 
 import com.google.gson.Gson;
 import com.oracle.truffle.api.instrumentation.Instrumenter;
+import com.oracle.truffle.api.instrumentation.Tag;
+import com.oracle.truffle.api.nodes.RootNode;
+import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.api.source.SourceSection;
 import com.sun.net.httpserver.HttpServer;
 
 import bd.source.SourceCoordinate;
 import bd.source.TaggedSourceCoordinate;
 import som.vm.VmSettings;
 import som.vmobjects.SSymbol;
-import src.com.oracle.truffle.api.nodes.RootNode;
-import src.com.oracle.truffle.api.source.SourceSection;
 import tools.Tagging;
 import tools.TraceData;
 import tools.concurrency.TracingBackend;

--- a/src/tools/debugger/FrontendConnector.java
+++ b/src/tools/debugger/FrontendConnector.java
@@ -16,16 +16,14 @@ import org.java_websocket.WebSocket;
 
 import com.google.gson.Gson;
 import com.oracle.truffle.api.instrumentation.Instrumenter;
-import com.oracle.truffle.api.instrumentation.Tag;
-import com.oracle.truffle.api.nodes.RootNode;
-import com.oracle.truffle.api.source.Source;
-import com.oracle.truffle.api.source.SourceSection;
 import com.sun.net.httpserver.HttpServer;
 
 import bd.source.SourceCoordinate;
 import bd.source.TaggedSourceCoordinate;
 import som.vm.VmSettings;
 import som.vmobjects.SSymbol;
+import src.com.oracle.truffle.api.nodes.RootNode;
+import src.com.oracle.truffle.api.source.SourceSection;
 import tools.Tagging;
 import tools.TraceData;
 import tools.concurrency.TracingBackend;
@@ -259,7 +257,7 @@ public class FrontendConnector {
   }
 
   public void awaitClient() {
-    assert VmSettings.KOMPOS_TRACING && VmSettings.TRUFFLE_DEBUGGER_ENABLED;
+    assert VmSettings.TRUFFLE_DEBUGGER_ENABLED;
     assert clientConnected != null;
     assert messageSocket == null && traceSocket == null;
     assert traceHandler.getConnection() != null;

--- a/src/tools/debugger/entities/ActivityType.java
+++ b/src/tools/debugger/entities/ActivityType.java
@@ -1,6 +1,5 @@
 package tools.debugger.entities;
 
-import som.vm.VmSettings;
 import tools.TraceData;
 
 
@@ -54,7 +53,7 @@ public enum ActivityType {
   }
 
   public int getCreationSize() {
-    return VmSettings.TRUFFLE_DEBUGGER_ENABLED ? (11 + TraceData.SOURCE_SECTION_SIZE) : 11;
+    return 11 + TraceData.SOURCE_SECTION_SIZE;
   }
 
   public int getCompletionSize() {


### PR DESCRIPTION
This PR fixes the following bugs in the kompos tracing:

- duplicated Turn start/end events for actors.
- scope loss when swapping buffer. During parsing events from the replacement buffer are assigned to any open scope.
- breakpoint handing in replay used wrong message object.
- avoid constantly swapping buffers because of incorrect boolean condition

The PR also enables kompos tracing without webdebugger, and during replay executions.