### PR TITLE
Put Long#parseLong() behind boundary

### DIFF
--- a/src/som/primitives/IntegerPrims.java
+++ b/src/som/primitives/IntegerPrims.java
@@ -76,11 +76,13 @@ public abstract class IntegerPrims {
     }
 
     @Specialization
+    @TruffleBoundary
     public final Object doSClass(final String argument) {
       return Long.parseLong(argument);
     }
 
     @Specialization
+    @TruffleBoundary
     public final Object doSClass(final SSymbol argument) {
       return Long.parseLong(argument.getString());
     }


### PR DESCRIPTION
`Long#parseLong()` doesn't look like something for PE, so this puts it behind a `@TruffleBoundary`. Not tested, not benchmarked... take it or leave it. 😉 