### PR TITLE
Fix termination in Launcher and of Fork/Join Pools

### DIFF
--- a/src/som/Launcher.java
+++ b/src/som/Launcher.java
@@ -44,7 +44,7 @@ public final class Launcher {
       exitCode = result.as(Integer.class);
     } finally {
       context.eval(SHUTDOWN);
-      context.close(true);
+      context.close();
       finalizeExecution(exitCode);
     }
 

--- a/src/som/VM.java
+++ b/src/som/VM.java
@@ -251,7 +251,7 @@ public final class VM {
         new ForkJoinPool[] {actorPool, processesPool, forkJoinPool, threadPool};
 
     for (ForkJoinPool pool : pools) {
-      pool.shutdown();
+      pool.shutdownNow();
       try {
         pool.awaitTermination(10, TimeUnit.SECONDS);
       } catch (InterruptedException e) {


### PR DESCRIPTION
We now force the shutdown of fork/join pools and cancel running tasks.
This should be fine, because the explicit shutdown request was triggered at this point.

The launcher should rely on our own shutdown mechanism, and not trigger Truffle's one.
Truffle's shutdown is costly, because it instruments all methods first.

The following program was hanging:

```Smalltalk
class Foo usingPlatform: platform = Value (
| private Thread = platform threading Thread.
  private Array  = platform kernel Array.
|)(
  public main: args = (
    | philosophers |
    philosophers:: Array new: 3.

    philosophers doIndexes: [:i |
      | t |
      t:: Thread spawn: [:j | j println ] with: { i. }.
      philosophers at: i put: t.
    ].

    philosophers do: [:ph |
      ph join.
      'joined' println ].

    ^ 0
  )
)
```