### PR TITLE
Send Symbols together with external data to debugger UI

### DIFF
--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -564,12 +564,13 @@ public class TracingBackend {
       while (cont || !fullBuffers.isEmpty() || !externalData.isEmpty()) {
         writeExternalData(externalDataStream);
 
+        writeSymbols(symbolStream);
+
         BufferAndLimit b = tryToObtainBuffer();
         if (b == null) {
           continue;
         }
 
-        writeSymbols(symbolStream);
         if (front != null) {
           front.sendTracingData(b.getReadingFromStartBuffer());
         }


### PR DESCRIPTION
Pull request that moves the call to the method `writeSymbols` after `writeExternalData` in the `TracingBackend` class when processing the trace data.  This way symbols can be sent earlier and avoid races when sending the tracing information.