### PR TITLE
Fix bug in AsyncTestCase

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -381,6 +381,7 @@ kernel:           ${kernel}</echo>
             <jvmarg value="-ea" />
             <jvmarg value="-esa" />
             <jvmarg value="-Dpolyglot.engine.WarnInterpreterOnly=false" />
+            <jvmarg value="-Dorg.slf4j.simpleLogger.defaultLogLevel=off" />
             <arg line="${corelib.dir}/TestSuite/TestRunner.ns" />
         </java>
      </jacoco:coverage>

--- a/build.xml
+++ b/build.xml
@@ -136,7 +136,7 @@ kernel:           ${kernel}</echo>
     </target>
 
     <!-- libgraal-jdk also implicitly builds truffle-libs -->
-    <target name="truffle-libs" unless="skip.truffle" depends="jvmci-libs,truffle-submodule">
+    <target name="truffle-libs" unless="skip.truffle" depends="truffle-submodule,jvmci-libs">
         <exec executable="${mx.cmd}" dir="${compiler.dir}" failonerror="true">
             <env key="DYNAMIC_IMPORTS" value="/tools" />
             <env key="EXCLUDE_COMPONENTS" value="svmag,nju,nic,ni,nil,ins,dap,lsp,insight,insightheap,vvm" />
@@ -146,7 +146,7 @@ kernel:           ${kernel}</echo>
         </exec>
     </target>
 
-    <target name="libgraal-jdk" unless="skip.truffle" depends="jvmci-libs,truffle-submodule">
+    <target name="libgraal-jdk" unless="skip.truffle" depends="truffle-submodule,jvmci-libs">
         <exec executable="${mx.cmd}" dir="${vm.dir}" failonerror="true">
             <env key="JAVA_HOME" value="${jvmci.home}" />
             <!-- REM: This needs to match ./som -->

--- a/core-lib/TestSuite/ActorTests.ns
+++ b/core-lib/TestSuite/ActorTests.ns
@@ -145,6 +145,16 @@ class ActorTests usingPlatform: platform testFramework: minitest = Value (
       ^ assert: r resolvedWith: true.
     )
 
+    public testAsyncTurnResultsInNearRefFail= (
+      | bobP r |
+      bobP:: (actors createActorFromValue: Bob) <-: meet: self.
+      r:: bobP whenResolved: [:bob |
+          (bob <-: answerNearRef)
+             whenResolved: [:bob2 | bob2 = bob ]].
+      ^ assert: r resolvedWith: false.
+    )
+
+
     public testAsyncTurnResultsInValue = (
       | bob |
       bob:: (actors createActorFromValue: Bob) <-: meet: self.

--- a/core-lib/TestSuite/ActorTests.ns
+++ b/core-lib/TestSuite/ActorTests.ns
@@ -15,12 +15,6 @@ class ActorTests usingPlatform: platform testFramework: minitest = Value (
     msg:: errorTestMessage.
   )()
 
-  private class NoExceptionReceivedException signal = Exception (
-          | public msg |
-          msg:: 'received value, expected exception'.
-          self signal.
-  )()
-
   class Bob meet: a = (
     | private alice = a. |
   ) (
@@ -29,8 +23,6 @@ class ActorTests usingPlatform: platform testFramework: minitest = Value (
     public answerValue    = ( ^ 42           )
     public raiseException = ( ^ Exception signal )
   )
-
-  class Peter = () ()
 
   class DeepChain = (
     |exception|
@@ -212,22 +204,6 @@ class ActorTests usingPlatform: platform testFramework: minitest = Value (
         pp resolve: nil
       ].
       ^ pp promise
-    )
-
-    public testAsyncAssertionFailed= (
-      | bobP peterP assertP resultP whenP |
-          peterP:: (actors createActorFromValue: Peter).
-          bobP:: (actors createActorFromValue: Bob) <-: meet: peterP.
-          resultP:: bobP whenResolved: [:bob |
-                 (bob <-: answerFarRef)
-                 whenResolved: [:peter | peter = bob ]
-                 ].
-
-         assertP:: assert: resultP resolvedWith: true.
-
-         whenP:: assertP whenResolved:[:v | NoExceptionReceivedException signal ]
-                     onError: [:e | assert: e messageText equals: 'Equality assertion failed; expected: true, was: false' ].
-         ^ whenP
     )
 
   ) : (
@@ -635,6 +611,11 @@ class ActorTests usingPlatform: platform testFramework: minitest = Value (
   public class PromiseErrored = AsyncTestContext (
   | private Exception = kernel Exception. aliceValue = 10. bobValue = 20.|
   )(
+     private class NoExceptionReceivedException signal = Exception (
+        | public msg |
+        msg:: 'received value, expected exception'.
+        self signal.
+    )()
 
     private class Alice new = (
     | exception |

--- a/core-lib/TestSuite/ActorTests.ns
+++ b/core-lib/TestSuite/ActorTests.ns
@@ -15,6 +15,12 @@ class ActorTests usingPlatform: platform testFramework: minitest = Value (
     msg:: errorTestMessage.
   )()
 
+  private class NoExceptionReceivedException signal = Exception (
+          | public msg |
+          msg:: 'received value, expected exception'.
+          self signal.
+  )()
+
   class Bob meet: a = (
     | private alice = a. |
   ) (
@@ -23,6 +29,8 @@ class ActorTests usingPlatform: platform testFramework: minitest = Value (
     public answerValue    = ( ^ 42           )
     public raiseException = ( ^ Exception signal )
   )
+
+  class Peter = () ()
 
   class DeepChain = (
     |exception|
@@ -145,16 +153,6 @@ class ActorTests usingPlatform: platform testFramework: minitest = Value (
       ^ assert: r resolvedWith: true.
     )
 
-    public testAsyncTurnResultsInNearRefFail= (
-      | bobP r |
-      bobP:: (actors createActorFromValue: Bob) <-: meet: self.
-      r:: bobP whenResolved: [:bob |
-          (bob <-: answerNearRef)
-             whenResolved: [:bob2 | bob2 = bob ]].
-      ^ assert: r resolvedWith: false.
-    )
-
-
     public testAsyncTurnResultsInValue = (
       | bob |
       bob:: (actors createActorFromValue: Bob) <-: meet: self.
@@ -214,6 +212,23 @@ class ActorTests usingPlatform: platform testFramework: minitest = Value (
         pp resolve: nil
       ].
       ^ pp promise
+    )
+
+    public testAssertionFailed= (
+      | bobP peterP assertPromise r |
+          peterP:: (actors createActorFromValue: Peter).
+          bobP:: (actors createActorFromValue: Bob) <-: meet: peterP.
+          r:: bobP whenResolved: [:bob |
+                 (bob <-: answerFarRef)
+                 whenResolved: [:peter | peter = bob ]
+                 ].
+
+         assertPromise:: assert: r resolvedWith: true.
+
+         assertPromise whenResolved:[:v | NoExceptionReceivedException signal ]
+                       onError: [:e | assert: e messageText equals: 'Equality assertion failed; expected: true, was: false' ].
+
+         ^ assertPromise
     )
 
   ) : (
@@ -621,11 +636,6 @@ class ActorTests usingPlatform: platform testFramework: minitest = Value (
   public class PromiseErrored = AsyncTestContext (
   | private Exception = kernel Exception. aliceValue = 10. bobValue = 20.|
   )(
-     private class NoExceptionReceivedException signal = Exception (
-        | public msg |
-        msg:: 'received value, expected exception'.
-        self signal.
-    )()
 
     private class Alice new = (
     | exception |

--- a/core-lib/TestSuite/ActorTests.ns
+++ b/core-lib/TestSuite/ActorTests.ns
@@ -214,21 +214,20 @@ class ActorTests usingPlatform: platform testFramework: minitest = Value (
       ^ pp promise
     )
 
-    public testAssertionFailed= (
-      | bobP peterP assertPromise r |
+    public testAsyncAssertionFailed= (
+      | bobP peterP assertP resultP whenP |
           peterP:: (actors createActorFromValue: Peter).
           bobP:: (actors createActorFromValue: Bob) <-: meet: peterP.
-          r:: bobP whenResolved: [:bob |
+          resultP:: bobP whenResolved: [:bob |
                  (bob <-: answerFarRef)
                  whenResolved: [:peter | peter = bob ]
                  ].
 
-         assertPromise:: assert: r resolvedWith: true.
+         assertP:: assert: resultP resolvedWith: true.
 
-         assertPromise whenResolved:[:v | NoExceptionReceivedException signal ]
-                       onError: [:e | assert: e messageText equals: 'Equality assertion failed; expected: true, was: false' ].
-
-         ^ assertPromise
+         whenP:: assertP whenResolved:[:v | NoExceptionReceivedException signal ]
+                     onError: [:e | assert: e messageText equals: 'Equality assertion failed; expected: true, was: false' ].
+         ^ whenP
     )
 
   ) : (

--- a/core-lib/TestSuite/FileTests.ns
+++ b/core-lib/TestSuite/FileTests.ns
@@ -1,14 +1,8 @@
 class FileTests usingPlatform: platform testFramework: minitest = Value (
 | private TestContext = minitest TestContext.
-  private AsyncTestContext = minitest AsyncTestContext.
-  private actors      = platform actors.
   private Exception   = platform kernel Exception.
-  private NotAValue   = platform kernel NotAValue.
   private ArgumentError = platform kernel ArgumentError.
-  private Vector      = platform kernel Vector.
-  private Array       = platform kernel Array.
   private ObjectMirror = platform mirrors ObjectMirror.
-  private errorTestMessage = 'test exception 1'.
 
   private FilePath    = platform files FilePath.
   private FilePattern = platform files FilePattern.

--- a/core-lib/TestSuite/Minitest.ns
+++ b/core-lib/TestSuite/Minitest.ns
@@ -441,12 +441,12 @@ OTHER DEALINGS IN THE SOFTWARE. *)
               exClass:: (ClassMirror reflecting: e) classObject.
               exClass == TestFailureException ifTrue: [
                 promisePair resolve: (testContextInstance
-                  ifNil:    [ TestFailure case: self description: ex messageText]
-                  ifNotNil: [:it | it createFailureResultFor: self description: ex messageText])
+                  ifNil:    [ TestFailure case: self description: e messageText ]
+                  ifNotNil: [:it | it createFailureResultFor: self description: e messageText ])
               ] ifFalse: [
                 promisePair resolve: (testContextInstance
-                  ifNil:    [ TestError case: self exception: ex ]
-                  ifNotNil: [:it | it createErrorResultFor: self exception: ex ])
+                  ifNil:    [ TestError case: self exception: e ]
+                  ifNotNil: [:it | it createErrorResultFor: self exception: e ])
               ]
             ]
         ] on: TestFailureException

--- a/core-lib/TestSuite/Minitest.ns
+++ b/core-lib/TestSuite/Minitest.ns
@@ -63,21 +63,19 @@ Asynchronous tests can be defined implementing a subclass of AsyncTestContext.
 Both synchronous and asynchronous tests can be included. Method names for synchronous tests
 should begin with 'test' and for asynchronous tests with 'testAsync'.
 
- class Math = () (
-     public factorial: n = (
-       n = 0 ifTrue: [ ^ 1 ].
-       ^ (self <-: factorial: n - 1) <-: * n
-     )
- )
-
-public class MathAsyncTest = AsyncTestContext () (
-
-    public testAsyncFactorial = (
-      | mathP |
-      mathP:: (actors createActorFromValue: Math) <-: new.
-
-      ^ assert: (mathP <-: factorial: 4) resolvedWith: 24.
+    class Math = () (
+        public factorial: n = (
+            n = 0 ifTrue: [ ^ 1 ].
+            ^ (self <-: factorial: n - 1) <-: * n
+        )
     )
+
+    public class MathAsyncTest = AsyncTestContext () (
+        public testAsyncFactorial = (
+            | mathP |
+            mathP:: (actors createActorFromValue: Math) <-: new.
+            ^ assert: (mathP <-: factorial: 4) resolvedWith: 24.
+        )
     ) : (
         TEST_CONTEXT = ()
     )
@@ -448,9 +446,8 @@ OTHER DEALINGS IN THE SOFTWARE. *)
   class AsyncTestCase env: testEnvironment selector: selector
     = TestCase env: testEnvironment selector: selector (
     (* Represents a particular test (a method with the selector that begins with
-                  'testAsync') in a text context. See AsyncTestContext. *)
-    )(
-
+       'testAsync') in a text context. See AsyncTestContext. *)
+  )(
     public isAsync = ( ^ true )
 
     public runUsing: tester = (
@@ -790,11 +787,9 @@ OTHER DEALINGS IN THE SOFTWARE. *)
   )
 
   public class AsyncTestContext = TestContext <: Value (
-  (* An object for defining and running individual asynchronous tests. Instances of this class
-     need to implement test methods which start with the 'testAsync' prefix. Although methods starting with
-     'test' can also be implemented, they will execute only assertions declared in TestContext.
-     See Minitest.ns#L416.
-  *)
+    (* An object for defining and running individual asynchronous tests.
+       Instances of this class need to implement test methods which start with
+       the 'testAsync' prefix. *)
   )(
     assert: promise resolvedWith: expectedResolution = (
       (* TODO: add timeout support *)

--- a/core-lib/TestSuite/Minitest.ns
+++ b/core-lib/TestSuite/Minitest.ns
@@ -59,6 +59,32 @@ test framework recognize this class as a test context and scan it for test
 methods. Eventually, when Newspeak supports it, class metadata will be used
 instead to mark classes as test contexts.
 
+Asynchronous tests can be defined implementing a subclass of AsyncTestContext.
+Both synchronous and asynchronous tests can be included. Method names for synchronous tests
+should begin with 'test' and for asynchronous tests with 'testAsync'.
+
+ class Math = () (
+     public factorial: n = (
+       n = 0 ifTrue: [ ^ 1 ].
+       ^ (self <-: factorial: n - 1) <-: * n
+     )
+ )
+
+public class MathAsyncTest = AsyncTestContext () (
+
+    public testAsyncFactorial = (
+      | mathP |
+      mathP:: (actors createActorFromValue: Math) <-: new.
+
+      ^ assert: (mathP <-: factorial: 4) resolvedWith: 24.
+    )
+    ) : (
+        TEST_CONTEXT = ()
+    )
+
+This asychronous test context defines one test method, which starts with 'testAsync' and returns a promise
+of the result corresponding to the evaluation of the assertion.
+
 This important point is worth reiterating. A class is a test context if and
 only if it contains a class-side method named TEST_CONTEXT. Inheriting from
 TestContext by itself does NOT make a class a test context, it only provides it
@@ -339,9 +365,10 @@ OTHER DEALINGS IN THE SOFTWARE. *)
 |)(
   class TestCase env: testEnvironment selector: selector = (
     (* Represents a particular test (a method with the selector that begins with
-       'test') in a text context. This class, unlike SUnit's class by the same
+       'test' or 'testAsync') in a text context. This class, unlike SUnit's class by the same
        name, is internal to the framework and is not intended to be subclassed
-       or instantiated by framework users. See TestContext.
+       or instantiated by framework users. See TestContext. For asynchronous tests
+       see AsyncTestCase and AsyncTestContext.
 
        An instance holds onto a test environment (which indirectly identifies
        the test context class) and a selector within the class. While a test
@@ -419,7 +446,11 @@ OTHER DEALINGS IN THE SOFTWARE. *)
   )
 
   class AsyncTestCase env: testEnvironment selector: selector
-    = TestCase env: testEnvironment selector: selector ()(
+    = TestCase env: testEnvironment selector: selector (
+    (* Represents a particular test (a method with the selector that begins with
+                  'testAsync') in a text context. See AsyncTestContext. *)
+    )(
+
     public isAsync = ( ^ true )
 
     public runUsing: tester = (
@@ -436,17 +467,17 @@ OTHER DEALINGS IN THE SOFTWARE. *)
               immediately garbage-collectable, which is an important property for large test suites. *)
               cleanUp.
               promisePair resolve: testSuccess ]
-            onError: [:e |
+            onError: [:ex |
               | exClass |
               exClass:: (ClassMirror reflecting: e) classObject.
               exClass == TestFailureException ifTrue: [
                 promisePair resolve: (testContextInstance
-                  ifNil:    [ TestFailure case: self description: e messageText ]
-                  ifNotNil: [:it | it createFailureResultFor: self description: e messageText ])
+                  ifNil:    [ TestFailure case: self description: ex messageText ]
+                  ifNotNil: [:it | it createFailureResultFor: self description: ex messageText ])
               ] ifFalse: [
                 promisePair resolve: (testContextInstance
-                  ifNil:    [ TestError case: self exception: e ]
-                  ifNotNil: [:it | it createErrorResultFor: self exception: e ])
+                  ifNil:    [ TestError case: self exception: ex ]
+                  ifNotNil: [:it | it createErrorResultFor: self exception: ex ])
               ]
             ]
         ] on: TestFailureException
@@ -758,7 +789,13 @@ OTHER DEALINGS IN THE SOFTWARE. *)
     )
   )
 
-  public class AsyncTestContext = TestContext <: Value ()(
+  public class AsyncTestContext = TestContext <: Value (
+  (* An object for defining and running individual asynchronous tests. Instances of this class
+     need to implement test methods which start with the 'testAsync' prefix. Although methods starting with
+     'test' can also be implemented, they will execute only assertions declared in TestContext.
+     See Minitest.ns#L416.
+  *)
+  )(
     assert: promise resolvedWith: expectedResolution = (
       (* TODO: add timeout support *)
       ^ promise

--- a/core-lib/TestSuite/Minitest.ns
+++ b/core-lib/TestSuite/Minitest.ns
@@ -466,7 +466,7 @@ OTHER DEALINGS IN THE SOFTWARE. *)
               promisePair resolve: testSuccess ]
             onError: [:ex |
               | exClass |
-              exClass:: (ClassMirror reflecting: e) classObject.
+              exClass:: (ClassMirror reflecting: ex) classObject.
               exClass == TestFailureException ifTrue: [
                 promisePair resolve: (testContextInstance
                   ifNil:    [ TestFailure case: self description: ex messageText ]

--- a/core-lib/TestSuite/Minitest.ns
+++ b/core-lib/TestSuite/Minitest.ns
@@ -786,7 +786,7 @@ OTHER DEALINGS IN THE SOFTWARE. *)
     )
   )
 
-  public class AsyncTestContext = TestContext <: Value (
+  public class AsyncTestContext = TestContext (
     (* An object for defining and running individual asynchronous tests.
        Instances of this class need to implement test methods which start with
        the 'testAsync' prefix. *)

--- a/core-lib/TestSuite/MinitestTests.ns
+++ b/core-lib/TestSuite/MinitestTests.ns
@@ -13,7 +13,7 @@ class MinitestTests usingPlatform: platform testFramework: minitest = Value (
   public class AssertionTests = AsyncTestContext (
     (* Describe the class in this comment. *)
   | guineaPig = GuineaPigTestModule testFramework: testFramework.
-    catalog = TestCatalog forModule: guineaPig. (* catalog is not a value... *)
+    catalog = TestCatalog forModule: guineaPig.
   |)(
     public class GuineaPigTestModule testFramework: testFramework = (
     | private TestContext = testFramework TestContext.

--- a/core-lib/TestSuite/MinitestTests.ns
+++ b/core-lib/TestSuite/MinitestTests.ns
@@ -1,4 +1,4 @@
-class MinitestTests usingPlatform: platform testFramework: minitest = (
+class MinitestTests usingPlatform: platform testFramework: minitest = Value (
   (* Tests of the Minitest framework (that is, meta-tests). *)
 |
   private Exception     = platform kernel Exception.
@@ -6,6 +6,8 @@ class MinitestTests usingPlatform: platform testFramework: minitest = (
   private TestContext   = minitest TestContext.
   private TestCatalog   = minitest TestCatalog.
   private Tester        = minitest Tester.
+  private AsyncTestContext   = minitest AsyncTestContext.
+  private actors   = platform actors.
 |
 ) (
   public class AssertionTests = TestContext (
@@ -297,6 +299,31 @@ class MinitestTests usingPlatform: platform testFramework: minitest = (
     )
   ) : (
     TEST_CONTEXT = ()
+  )
+
+  public class Math = () (
+     public factorial: n = (
+       n = 0 ifTrue: [ ^ 1 ].
+       ^ (self <-: factorial: n - 1) <-: * n
+      )
+  )
+
+  public class AsyncAssertionTest = AsyncTestContext (
+    (* Test class to test asynchronous assertions failing *)
+  ) (
+
+     public testAsyncAssertionFailed = (
+       | mathP whenP assertP |
+       mathP:: (actors createActorFromValue: Math) <-: new.
+
+       assertP:: assert: (mathP <-: factorial: 4) resolvedWith: 0.
+
+       whenP:: assertP whenResolved:[:v | NoExceptionReceivedException signal ]
+                       onError: [:e | assert: e messageText equals: 'Equality assertion failed; expected: 0, was: 24' ].
+       ^ whenP
+       )
+     ) : (
+        TEST_CONTEXT = ()
   )
 
   public class TestLifecycleTests = TestContext (

--- a/core-lib/TestSuite/MinitestTests.ns
+++ b/core-lib/TestSuite/MinitestTests.ns
@@ -10,14 +10,14 @@ class MinitestTests usingPlatform: platform testFramework: minitest = Value (
   private actors   = platform actors.
 |
 ) (
-  public class AssertionTests = TestContext (
+  public class AssertionTests = AsyncTestContext (
     (* Describe the class in this comment. *)
   | guineaPig = GuineaPigTestModule testFramework: testFramework.
     catalog = TestCatalog forModule: guineaPig.
     tester
   |
   ) (
-    public class GuineaPigTestModule testFramework: testFramework = (
+    public class GuineaPigTestModule testFramework: testFramework = Value (
       | private TestContext = testFramework TestContext. |
     ) (
       public class AssertEqualsTestContext = TestContext ()(
@@ -195,6 +195,30 @@ class MinitestTests usingPlatform: platform testFramework: minitest = Value (
         TEST_CONTEXT = ()
       )
 
+      public class AssertAsyncTestContext = AsyncTestContext (
+      (* Class for testing asynchronous assertions. *)
+      )(
+         public testAsyncAssertResolvedWithPass = (
+         | completionPP |
+
+         completionPP:: actors createPromisePair.
+         completionPP resolver resolve: 4.
+
+         ^ assert: completionPP promise resolvedWith: 4
+         )
+
+         public testAsyncAssertResolvedWithFail = (
+           | completionPP |
+
+           completionPP:: actors createPromisePair.
+           completionPP resolver resolve: 4.
+
+           ^ assert: completionPP promise resolvedWith: 5
+         )
+       ): (
+         TEST_CONTEXT = ()
+      )
+
       class GenericException = Exception (
         | public messageText |
       )()
@@ -297,33 +321,20 @@ class MinitestTests usingPlatform: platform testFramework: minitest = Value (
           assert: tester successes containsSelector: #testShouldntIsNotFailingTestForOtherException.
       ]
     )
+
+    public testAsyncAssertResolved = (
+      tester:: Tester testSuite: (catalog testSuiteNamed: 'AssertAsyncTestContext').
+      ^ tester runAll whenResolved: [:r |
+                         assert: tester errors size equals: 0.
+                         assert: tester failures size equals: 1.
+                         assert: tester failures containsSelector: #testAsyncAssertResolvedWithFail.
+                         assert: tester successes size equals: 1.
+                         assert: tester successes containsSelector: #testAsyncAssertResolvedWithPass.
+      ]
+    )
+
   ) : (
     TEST_CONTEXT = ()
-  )
-
-  public class Math = () (
-     public factorial: n = (
-       n = 0 ifTrue: [ ^ 1 ].
-       ^ (self <-: factorial: n - 1) <-: * n
-      )
-  )
-
-  public class AsyncAssertionTest = AsyncTestContext (
-    (* Test class to test asynchronous assertions failing *)
-  ) (
-
-     public testAsyncAssertionFailed = (
-       | mathP whenP assertP |
-       mathP:: (actors createActorFromValue: Math) <-: new.
-
-       assertP:: assert: (mathP <-: factorial: 4) resolvedWith: 0.
-
-       whenP:: assertP whenResolved:[:v | NoExceptionReceivedException signal ]
-                       onError: [:e | assert: e messageText equals: 'Equality assertion failed; expected: 0, was: 24' ].
-       ^ whenP
-       )
-     ) : (
-        TEST_CONTEXT = ()
   )
 
   public class TestLifecycleTests = TestContext (

--- a/core-lib/TestSuite/MinitestTests.ns
+++ b/core-lib/TestSuite/MinitestTests.ns
@@ -13,10 +13,8 @@ class MinitestTests usingPlatform: platform testFramework: minitest = Value (
   public class AssertionTests = AsyncTestContext (
     (* Describe the class in this comment. *)
   | guineaPig = GuineaPigTestModule testFramework: testFramework.
-    catalog = TestCatalog forModule: guineaPig.
-    tester
-  |
-  ) (
+    catalog = TestCatalog forModule: guineaPig. (* catalog is not a value... *)
+  |)(
     public class GuineaPigTestModule testFramework: testFramework = Value (
       | private TestContext = testFramework TestContext. |
     ) (
@@ -196,23 +194,17 @@ class MinitestTests usingPlatform: platform testFramework: minitest = Value (
       )
 
       public class AssertAsyncTestContext = AsyncTestContext (
-      (* Class for testing asynchronous assertions. *)
+        (* Class for testing asynchronous assertions. *)
       )(
          public testAsyncAssertResolvedWithPass = (
-         | completionPP |
-
-         completionPP:: actors createPromisePair.
-         completionPP resolver resolve: 4.
-
-         ^ assert: completionPP promise resolvedWith: 4
+           | completionPP = actors createPromisePair. |
+           completionPP resolver resolve: 4.
+           ^ assert: completionPP promise resolvedWith: 4
          )
 
          public testAsyncAssertResolvedWithFail = (
-           | completionPP |
-
-           completionPP:: actors createPromisePair.
+           | completionPP = actors createPromisePair. |
            completionPP resolver resolve: 4.
-
            ^ assert: completionPP promise resolvedWith: 5
          )
        ): (
@@ -238,6 +230,7 @@ class MinitestTests usingPlatform: platform testFramework: minitest = Value (
     )
 
     public testAsyncAssertEquals = (
+      | tester |
       tester:: Tester testSuite: (catalog testSuiteNamed: 'AssertEqualsTestContext').
       ^ tester runAll whenResolved: [:r |
           assert: tester errors size equals: 0.
@@ -252,6 +245,7 @@ class MinitestTests usingPlatform: platform testFramework: minitest = Value (
     )
 
     public testAsyncAsserts = (
+      | tester |
       tester:: Tester testSuite: (catalog testSuiteNamed: 'AssertTestContext').
       ^ tester runAll whenResolved: [:r |
           assert: tester errors size equals: 3.
@@ -273,6 +267,7 @@ class MinitestTests usingPlatform: platform testFramework: minitest = Value (
     )
 
     public testAsyncDenials = (
+      | tester |
       tester:: Tester testSuite: (catalog testSuiteNamed: 'DenyTestContext').
       ^ tester runAll whenResolved: [:r |
           assert: tester errors size equals: 2.
@@ -291,6 +286,7 @@ class MinitestTests usingPlatform: platform testFramework: minitest = Value (
     )
 
     public testAsyncResultCreation = (
+      | tester |
       tester:: Tester testSuite: (catalog testSuiteNamed: 'ResultCreationTestContext').
       ^ tester runAll whenResolved: [:r |
           assert: tester failures size equals: 1.
@@ -305,6 +301,7 @@ class MinitestTests usingPlatform: platform testFramework: minitest = Value (
     )
 
     public testAsyncShouldShouldnt = (
+      | tester |
       tester:: Tester testSuite: (catalog testSuiteNamed: 'ShouldShouldntTestContext').
       ^ tester runAll whenResolved: [:r |
           assert: tester errors size equals: 0.
@@ -323,16 +320,16 @@ class MinitestTests usingPlatform: platform testFramework: minitest = Value (
     )
 
     public testAsyncAssertResolved = (
+      | tester |
       tester:: Tester testSuite: (catalog testSuiteNamed: 'AssertAsyncTestContext').
       ^ tester runAll whenResolved: [:r |
-                         assert: tester errors size equals: 0.
-                         assert: tester failures size equals: 1.
-                         assert: tester failures containsSelector: #testAsyncAssertResolvedWithFail.
-                         assert: tester successes size equals: 1.
-                         assert: tester successes containsSelector: #testAsyncAssertResolvedWithPass.
+          assert: tester errors size equals: 0.
+          assert: tester failures size equals: 1.
+          assert: tester failures containsSelector: #testAsyncAssertResolvedWithFail.
+          assert: tester successes size equals: 1.
+          assert: tester successes containsSelector: #testAsyncAssertResolvedWithPass.
       ]
     )
-
   ) : (
     TEST_CONTEXT = ()
   )

--- a/core-lib/TestSuite/MinitestTests.ns
+++ b/core-lib/TestSuite/MinitestTests.ns
@@ -6,7 +6,7 @@ class MinitestTests usingPlatform: platform testFramework: minitest = Value (
   private TestContext   = minitest TestContext.
   private TestCatalog   = minitest TestCatalog.
   private Tester        = minitest Tester.
-  private AsyncTestContext   = minitest AsyncTestContext.
+  private AsyncTestContext = minitest AsyncTestContext.
   private actors   = platform actors.
 |
 ) (
@@ -15,9 +15,9 @@ class MinitestTests usingPlatform: platform testFramework: minitest = Value (
   | guineaPig = GuineaPigTestModule testFramework: testFramework.
     catalog = TestCatalog forModule: guineaPig. (* catalog is not a value... *)
   |)(
-    public class GuineaPigTestModule testFramework: testFramework = Value (
-      | private TestContext = testFramework TestContext. |
-    ) (
+    public class GuineaPigTestModule testFramework: testFramework = (
+    | private TestContext = testFramework TestContext.
+    |)(
       public class AssertEqualsTestContext = TestContext ()(
         public testAssertEqualsFail = (
           assert: 3 equals: 4

--- a/core-lib/TestSuite/StreamTests.ns
+++ b/core-lib/TestSuite/StreamTests.ns
@@ -1,9 +1,6 @@
 class StreamTests usingPlatform: platform testFramework: minitest = Value (
 | private TestContext = minitest TestContext.
-  private AsyncTestContext = minitest AsyncTestContext.
-  private actors      = platform actors.
   private Exception   = platform kernel Exception.
-  private NotAValue   = platform kernel NotAValue.
   private Vector      = platform kernel Vector.
   private Array       = platform kernel Array.
   private ObjectMirror = platform mirrors ObjectMirror.

--- a/src/som/compiler/MixinDefinition.java
+++ b/src/som/compiler/MixinDefinition.java
@@ -453,8 +453,18 @@ public final class MixinDefinition implements SomInteropObject {
     boolean declaredAsValue = superIsValue || mixinsIncludeValue || isValueClass;
 
     if (declaredAsValue && !allSlotsAreImmutable) {
+      String mutableSlots = "";
+      for (SlotDefinition sd : slots.getValues()) {
+        if (!sd.isImmutable()) {
+          if (!mutableSlots.equals("")) {
+            mutableSlots += ", ";
+          }
+          mutableSlots += sd.getName().getString();
+        }
+      }
+
       reportErrorAndExit(": The class ",
-          " is declared as value, but also declared mutable slots");
+          " is declared as value, but also declared mutable slots: " + mutableSlots);
     }
     if (declaredAsValue && !hasOnlyImmutableFields) {
       reportErrorAndExit(": The class ",

--- a/src/som/interpreter/nodes/IsValueCheckNode.java
+++ b/src/som/interpreter/nodes/IsValueCheckNode.java
@@ -17,6 +17,7 @@ import com.oracle.truffle.api.source.SourceSection;
 import som.VM;
 import som.compiler.MixinDefinition.SlotDefinition;
 import som.interpreter.TruffleCompiler;
+import som.interpreter.Types;
 import som.interpreter.nodes.IsValueCheckNodeFactory.ValueCheckNodeGen;
 import som.interpreter.nodes.nary.UnaryExpressionNode;
 import som.interpreter.objectstorage.ObjectLayout;
@@ -133,7 +134,7 @@ public abstract class IsValueCheckNode extends UnaryExpressionNode {
       if (allFieldsContainValues) {
         return rcvr;
       }
-      return notAValue.signal(rcvr);
+      return notAValue.signal(Types.getClassOf(rcvr));
     }
 
     protected static final class FieldTester extends Node {

--- a/src/som/interpreter/nodes/IsValueCheckNode.java
+++ b/src/som/interpreter/nodes/IsValueCheckNode.java
@@ -123,7 +123,7 @@ public abstract class IsValueCheckNode extends UnaryExpressionNode {
       if (cachedTester.allFieldsContainValues(rcvr)) {
         return rcvr;
       } else {
-        return notAValue.signal(rcvr);
+        return notAValue.signal(rcvr.getSOMClass());
       }
     }
 

--- a/src/som/primitives/actors/CreateActorPrim.java
+++ b/src/som/primitives/actors/CreateActorPrim.java
@@ -8,6 +8,7 @@ import com.oracle.truffle.api.instrumentation.Tag;
 
 import bd.primitives.Primitive;
 import som.VM;
+import som.interpreter.Types;
 import som.interpreter.actors.Actor;
 import som.interpreter.actors.SFarReference;
 import som.interpreter.nodes.ExceptionSignalingNode;
@@ -63,7 +64,11 @@ public abstract class CreateActorPrim extends BinarySystemOperation {
 
   @Fallback
   public final Object throwNotAValueException(final Object receiver, final Object argument) {
-    return notAValue.signal(argument);
+    if (argument instanceof SClass) {
+      return notAValue.signal(argument);
+    } else {
+      return notAValue.signal(Types.getClassOf(argument));
+    }
   }
 
   @Override

--- a/src/som/primitives/processes/ChannelPrimitives.java
+++ b/src/som/primitives/processes/ChannelPrimitives.java
@@ -16,6 +16,7 @@ import bd.primitives.Primitive;
 import som.VM;
 import som.compiler.AccessModifier;
 import som.compiler.MixinBuilder.MixinDefinitionId;
+import som.interpreter.Types;
 import som.interpreter.actors.SuspendExecutionNodeGen;
 import som.interpreter.nodes.ExceptionSignalingNode;
 import som.interpreter.nodes.nary.BinaryComplexOperation.BinarySystemOperation;
@@ -316,7 +317,8 @@ public abstract class ChannelPrimitives {
     public final Object write(final VirtualFrame frame, final SChannelOutput out,
         final Object val) {
       if (!isVal.executeBoolean(frame, val)) {
-        notAValue.signal(val);
+        CompilerDirectives.transferToInterpreter();
+        notAValue.signal(Types.getClassOf(val));
       }
       try {
         out.writeAndSuspendReader(val, afterRead.executeShouldHalt(), traceWrite);


### PR DESCRIPTION
Pull request to fix a bug in the `AsyncTestCase` class related to the failed assertions. The `onError` block of the `runUsing` method declares `e` as the variable for the exception but it was wrongly referenced as `ex`. Added a small test case that triggers a failed assertion in ActorTests.ns.