### PR TITLE
Changes to get actor mailbox information

### DIFF
--- a/src/som/interpreter/actors/EventualSendNode.java
+++ b/src/som/interpreter/actors/EventualSendNode.java
@@ -212,7 +212,7 @@ public class EventualSendNode extends ExprWithTagsNode {
 
       if (VmSettings.KOMPOS_TRACING) {
         KomposTrace.sendOperation(SendOp.ACTOR_MSG, msg.getMessageId(),
-            target.getId());
+            target.getId(), msg.getSelector(), msg.getTarget().getId(), msg.getTargetSourceSection());
       }
 
       target.send(msg, actorPool);
@@ -227,9 +227,15 @@ public class EventualSendNode extends ExprWithTagsNode {
           messageReceiverBreakpoint.executeShouldHalt(),
           promiseResolverBreakpoint.executeShouldHalt());
 
+      Actor target = null;
+      if (isFarRefRcvr(args)) {
+        SFarReference farReference = (SFarReference) args[0];
+        target = farReference.getActor();
+      }
+
       if (VmSettings.KOMPOS_TRACING) {
         KomposTrace.sendOperation(SendOp.PROMISE_MSG, msg.getMessageId(),
-            rcvr.getPromiseId());
+            rcvr.getPromiseId(), msg.getSelector(), target != null ? target.getId() : -1, msg.getTargetSourceSection());
       }
 
       registerNode.register(rcvr, msg, rcvr.getOwner());
@@ -286,7 +292,7 @@ public class EventualSendNode extends ExprWithTagsNode {
 
       if (VmSettings.KOMPOS_TRACING) {
         KomposTrace.sendOperation(SendOp.ACTOR_MSG, msg.getMessageId(),
-            current.getId());
+            current.getId(), msg.getSelector(), msg.getTarget().getId(), msg.getTargetSourceSection());
       }
 
       current.send(msg, actorPool);
@@ -322,7 +328,7 @@ public class EventualSendNode extends ExprWithTagsNode {
 
       if (VmSettings.KOMPOS_TRACING) {
         KomposTrace.sendOperation(SendOp.ACTOR_MSG, msg.getMessageId(),
-            current.getId());
+            current.getId(), msg.getSelector(), msg.getTarget().getId(), msg.getTargetSourceSection());
       }
 
       current.send(msg, actorPool);

--- a/src/som/primitives/actors/PromisePrims.java
+++ b/src/som/primitives/actors/PromisePrims.java
@@ -175,7 +175,7 @@ public final class PromisePrims {
 
       if (VmSettings.KOMPOS_TRACING) {
         KomposTrace.sendOperation(SendOp.PROMISE_MSG, pcm.getMessageId(),
-            rcvr.getPromiseId());
+            rcvr.getPromiseId(), pcm.getSelector(), rcvr.getOwner().getId(), pcm.getTargetSourceSection());
       }
       registerNode.register(rcvr, pcm, current);
 
@@ -242,7 +242,7 @@ public final class PromisePrims {
 
       if (VmSettings.KOMPOS_TRACING) {
         KomposTrace.sendOperation(SendOp.PROMISE_MSG, msg.getMessageId(),
-            rcvr.getPromiseId());
+            rcvr.getPromiseId(), msg.getSelector(), rcvr.getOwner().getId(), msg.getTargetSourceSection());
       }
       registerNode.register(rcvr, msg, current);
 
@@ -321,9 +321,9 @@ public final class PromisePrims {
 
       if (VmSettings.KOMPOS_TRACING) {
         KomposTrace.sendOperation(SendOp.PROMISE_MSG, onResolved.getMessageId(),
-            rcvr.getPromiseId());
+            rcvr.getPromiseId(), onResolved.getSelector(), onResolved.getTarget().getId(), onResolved.getTargetSourceSection());
         KomposTrace.sendOperation(SendOp.PROMISE_MSG, onError.getMessageId(),
-            rcvr.getPromiseId());
+            rcvr.getPromiseId(), onError.getSelector(), onError.getTarget().getId(), onResolved.getTargetSourceSection());
       }
 
       synchronized (rcvr) {

--- a/src/tools/concurrency/TracingChannel.java
+++ b/src/tools/concurrency/TracingChannel.java
@@ -55,7 +55,7 @@ public final class TracingChannel extends SChannel {
         super.write(value, traceWrite);
       } finally {
         KomposTrace.sendOperation(
-            SendOp.CHANNEL_SEND, current.messageId, current.channelId);
+            SendOp.CHANNEL_SEND, current.messageId, current.channelId, null, 0, null);
       }
     }
   }

--- a/src/tools/debugger/entities/SendOp.java
+++ b/src/tools/debugger/entities/SendOp.java
@@ -1,5 +1,7 @@
 package tools.debugger.entities;
 
+import tools.TraceData;
+
 public enum SendOp {
   ACTOR_MSG(Marker.ACTOR_MSG_SEND, EntityType.ACT_MSG, EntityType.ACTOR),
   PROMISE_MSG(Marker.PROMISE_MSG_SEND, EntityType.ACT_MSG, EntityType.PROMISE),
@@ -9,6 +11,9 @@ public enum SendOp {
   private final byte       id;
   private final EntityType entity;
   private final EntityType target;
+
+  private static final int SYMBOL_ID_SIZE = 2;
+  private static final int RECEIVER_ACTOR_ID_SIZE = 8;
 
   SendOp(final byte id, final EntityType entity, final EntityType target) {
     this.id = id;
@@ -29,6 +34,6 @@ public enum SendOp {
   }
 
   public int getSize() {
-    return 17;
+    return 17 + RECEIVER_ACTOR_ID_SIZE + SYMBOL_ID_SIZE + TraceData.SOURCE_SECTION_SIZE;
   }
 }


### PR DESCRIPTION
- add three entries in the trace for the send operation entity. Add a symbol id to record the selector of the message. Add a targetActorId to record the receiver actor of the message. Add a source section corresponding to the origin of the send operation. Update the corresponding usages of this method.
- the targetActorId is needed because in the case of a PROMISE_MSG the target of the send operation is a promise, but we need the information of the target actor of the original message.
- the source section is already recorded for the dynamic scopes, however, dynamic scopes are created when the message is processed. To show the origin of a message sent in the mailbox, the source section is needed at the point where a message is sent but not yet processed.