### PR TITLE
Make fsckprojects optional on Truffle and JVMCI being present

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -135,7 +135,7 @@
     <target name="clobber" description="Do clean, and also clean truffle build" depends="clean,clean-truffle">
         <travis target="clobber" start="clobber" />
         
-        <exec executable="${mx.cmd}" dir="${svm.dir}" failonerror="true">
+        <exec executable="${mx.cmd}" dir="${svm.dir}" failonerror="true" if:true="${truffle.and.jvmci.present}">
             <arg value="--dynamicimports"/>
             <arg value="../truffle,../tools,../compiler,../sdk"/>
             <arg value="fsckprojects"/>


### PR DESCRIPTION
`ant clobber` fails when there is no JVMCI available.
So, let's check that it is there before executing `mx`.