### PR TITLE
Use ReBenchDB for performance tracking

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,7 @@ benchmark_savina_job:
   allow_failure: true
   script:
     - ant compile
-    - export EXP=`if [[ "$CI_BUILD_REF_NAME" = "master" ]]; then echo "SOMns-Savina"; else echo "SOMns-Savina-exp"; fi`; rebench --without-nice -c --commit-id="$CI_BUILD_REF" --environment="`hostname` `cat /etc/issue | cut -d ' ' -f 1`" --project=SOMns-Savina --branch=master codespeed.conf $EXP
+    - rebench --without-nice --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-Savina
 
 benchmark_savina_csp_job:
   stage: benchmark
@@ -61,7 +61,7 @@ benchmark_savina_csp_job:
   allow_failure: true
   script:
     - ant compile
-    - export EXP=`if [[ "$CI_BUILD_REF_NAME" = "master" ]]; then echo "SOMns-SavinaCSP"; else echo "SOMns-SavinaCSP-exp"; fi`; rebench --without-nice -c --commit-id="$CI_BUILD_REF" --environment="`hostname` `cat /etc/issue | cut -d ' ' -f 1`" --project=SOMns-SavinaCSP --branch=master codespeed.conf $EXP
+    - rebench --without-nice --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-SavinaCSP
 
 benchmark_job:
   stage: benchmark
@@ -69,7 +69,7 @@ benchmark_job:
   allow_failure: true
   script:
     - ant compile
-    - export EXP=`if [[ "$CI_BUILD_REF_NAME" = "master" ]]; then echo "SOMns"; else echo "SOMns-exp"; fi`; rebench --without-nice -c --commit-id="$CI_BUILD_REF" --environment="`hostname` `cat /etc/issue | cut -d ' ' -f 1`" --project=SOMns --branch=master codespeed.conf $EXP
+    - rebench --without-nice --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns
 
 benchmark_interp_job:
   stage: benchmark
@@ -77,7 +77,7 @@ benchmark_interp_job:
   allow_failure: true
   script:
     - ant compile
-    - export EXP=`if [[ "$CI_BUILD_REF_NAME" = "master" ]]; then echo "SOMns-interp"; else echo "SOMns-interp-exp"; fi`; rebench --without-nice -c --commit-id="$CI_BUILD_REF" --environment="`hostname` `cat /etc/issue | cut -d ' ' -f 1`" --project=SOMns --branch=master codespeed.conf $EXP
+    - rebench --without-nice --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-interp
 
 benchmark_nightly_job:
   stage: benchmark
@@ -87,8 +87,8 @@ benchmark_nightly_job:
     - triggers
   script:
     - ant compile
-    - rebench --without-nice -c --commit-id="$CI_BUILD_REF" --environment="`hostname` `cat /etc/issue | cut -d ' ' -f 1`" --project=SOMns --branch=master codespeed.conf nightly
-    - rebench --without-nice -c --commit-id="$CI_BUILD_REF" --environment="`hostname` `cat /etc/issue | cut -d ' ' -f 1`" --project=SOMns --branch=master codespeed.conf SOMns-Savina-tracing
+    - rebench --without-nice --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf nightly
+    - rebench --without-nice --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-Savina-tracing
 
 build_virtualbox:
   stage: virtualbox-image

--- a/codespeed.conf
+++ b/codespeed.conf
@@ -4,10 +4,13 @@ default_data_file: 'codespeed.data'
 default_experiment: SOMns
 
 reporting:
-    # results can also be reported to a codespeed instance
-    # see: https://github.com/tobami/codespeed
-    codespeed:
-        url: https://somns-speed.stefan-marr.de/result/add/json/
+    # Benchmark results will be reported to ReBenchDB
+    rebenchdb:
+        # this url needs to point to the API endpoint
+        db_url: https://rebench.stefan-marr.de/rebenchdb/results
+        repo_url: https://github.com/smarr/SOMns
+        record_all: true # make sure everything is recorded
+        project_name: SOMns
 
 runs:
   min_iteration_time: 5
@@ -610,21 +613,6 @@ executors:
     SOMns-graal-tn:
         path: .
         executable: som
-    SOMns-interp-exp:
-        path: .
-        executable: som
-        args: "-G -t1 "
-    SOMns-graal-exp:
-        path: .
-        executable: som
-        args: "-t1 "
-    SOMns-graal-tn-exp:
-        path: .
-        executable: som
-    SOMns-interp-tn-exp:
-        path: .
-        executable: som
-        args: "-G "
 
     # with actor tracing
     SOMns-interp-at:
@@ -715,21 +703,6 @@ experiments:
                 suites:
                   - savina-csp
 
-    SOMns-exp:
-        description: All benchmarks on SOMns with Graal
-        suites:
-            - micro-startup
-            - micro-steady
-            - macro-startup
-            - macro-steady
-            - sort-startup
-            - sort-steady
-            - som-startup
-            - som-steady
-            - fj-startup
-            - fj-steady
-        executions:
-            - SOMns-graal-exp
     SOMns-interp:
         description: All benchmarks on SOMns without Graal
         suites:
@@ -739,34 +712,6 @@ experiments:
             - som-startup
         executions:
             - SOMns-interp
-    SOMns-interp-exp:
-        description: All benchmarks on SOMns without Graal
-        suites:
-            - micro-startup
-            - macro-startup
-            - sort-startup
-            - som-startup
-        executions:
-            - SOMns-interp
-    SOMns-Savina-exp:
-        description: Run the Savina Actor benchmarks
-        executions:
-            - SOMns-interp-exp:
-                suites:
-                  - savina-interp
-            - SOMns-graal-exp:
-                suites:
-                  - savina-jit
-
-    SOMns-SavinaCSP-exp:
-        description: Run the Savina Actor benchmarks
-        executions:
-            - SOMns-interp-tn-exp:
-                suites:
-                  - savina-csp-interp
-            - SOMns-graal-tn-exp:
-                suites:
-                  - savina-csp
 
     SOMns-Savina-tracing:
         description: Run the Savina Actor benchmarks with tracing enabled


### PR DESCRIPTION
This PR enables the use of ReBenchDB as our main means of tracking performance over time and comparing the performance of different versions/experiments.

- remove Codespeed settings, won't report to it any longer
- remove -exp settings, where were only needed for Codespeed
- use branch name as GitLab knows it
