### PR TITLE
More user-friendly errors and minor updates

### DIFF
--- a/.checkstyle_checks.xml
+++ b/.checkstyle_checks.xml
@@ -33,9 +33,6 @@
       <property name="format" value="^[A-Z][_a-zA-Z0-9]*$"/>
     </module>
     <module name="RedundantImport"/>
-    <module name="LineLength">
-      <property name="max" value="550"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -176,4 +173,7 @@
     <property name="message" value="illegal Windows line ending"/>
   </module>
   <module name="Translation"/>
+  <module name="LineLength">
+    <property name="max" value="550"/>
+  </module>
 </module>

--- a/.classpath
+++ b/.classpath
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry combineaccessrules="false" kind="src" path="/com.oracle.truffle.api.jdk8"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="tests/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>

--- a/.factorypath
+++ b/.factorypath
@@ -1,7 +1,3 @@
 <factorypath>
-    <factorypathentry kind="WKSPJAR" id="/TRUFFLE_API/truffle-api.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="WKSPJAR" id="/TRUFFLE_DSL_PROCESSOR/truffle-dsl-processor.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="WKSPJAR" id="/TRUFFLE_DSL_PROCESSOR_INTERNAL/truffle-dsl-processor-internal.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="WKSPJAR" id="/TRUFFLE_DSL_PROCESSOR_INTEROP_INTERNAL/truffle-dsl-processor-interop-internal.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="WKSPJAR" id="/GRAAL_SDK/graal-sdk.jar" enabled="true" runInBatchMode="false"/>
 </factorypath>

--- a/build.xml
+++ b/build.xml
@@ -56,7 +56,7 @@
     <property name="svm.build"   location="${svm.dir}/mxbuild/dists/jdk1.8" />
     <property name="truffle.build" location="${truffle.dir}/mxbuild/dists/jdk1.8" />
     <property name="somns-deps.version" value="0.3.6" />
-    <property name="checkstyle.version" value="8.11" />
+    <property name="checkstyle.version" value="8.28" />
     <property name="jacoco.version"     value="0.8.5" />
     <property name="jvmci.home"  location="${lib.dir}/jvmci${home.ext}" />
 

--- a/core-lib/TestSuite/extension/.factorypath
+++ b/core-lib/TestSuite/extension/.factorypath
@@ -1,6 +1,3 @@
 <factorypath>
-    <factorypathentry kind="WKSPJAR" id="/TRUFFLE_API/truffle-api.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="WKSPJAR" id="/TRUFFLE_DSL_PROCESSOR/truffle-dsl-processor.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="WKSPJAR" id="/TRUFFLE_DSL_PROCESSOR_INTERNAL/truffle-dsl-processor-internal.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="WKSPJAR" id="/TRUFFLE_DSL_PROCESSOR_INTEROP_INTERNAL/truffle-dsl-processor-interop-internal.jar" enabled="true" runInBatchMode="false"/>
 </factorypath>

--- a/src/som/interpreter/SomLanguage.java
+++ b/src/som/interpreter/SomLanguage.java
@@ -262,7 +262,9 @@ public final class SomLanguage extends TruffleLanguage<VM> {
 
     @Override
     public Object execute(final VirtualFrame frame) {
-      vm.shutdown();
+      if (vm != null) {
+        vm.shutdown();
+      }
       return true;
     }
   }

--- a/src/som/vm/VmOptions.java
+++ b/src/som/vm/VmOptions.java
@@ -1,5 +1,6 @@
 package som.vm;
 
+import java.io.File;
 import java.util.Arrays;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
@@ -93,6 +94,20 @@ public class VmOptions {
   }
 
   public boolean isConfigUsable() {
+    boolean noPlatformFile = !(new File(platformFile)).exists();
+    if (noPlatformFile) {
+      Output.errorPrintln("The platformFile " + platformFile
+          + " was not found. Please check the --platform setting.");
+    }
+    boolean noKernelFile = !(new File(kernelFile)).exists();
+    if (noKernelFile) {
+      Output.errorPrintln("The kernelFile " + kernelFile
+          + " was not found. Please check the --kernel setting.");
+    }
+    if (noPlatformFile || noKernelFile) {
+      return false;
+    }
+
     if (!showUsage) {
       return true;
     }


### PR DESCRIPTION
This fixes a NPE when SOMns is started without suitable configuration, and gives errors when platform/kernel are not found. This should address #338.

The PR also updates checkstyle, and fixes dependencies in the Eclipse project for latest Eclipse 2019-12 and the Truffle we are using.

@sophie-kaleba could you give this a spin?