### PR TITLE
Specify path to VM settings to black-diamonds

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -546,6 +546,7 @@
         <arg line="native-image" />
         <arg line="--macro:truffle --no-fallback --initialize-at-build-time -H:+ReportExceptionStackTraces" />
         <arg line="-H:-ThrowUnsafeOffsetErrors" />
+        <arg line="-Dbd.settings=som.vm.VmSettings" />
         
         <!-- <arg line="-H:+PrintRuntimeCompileMethods" /> -->
         <!-- <arg line="-H:+PrintMethodHistogram" /> 


### PR DESCRIPTION
Otherwise VM settings passed on the command line are ignored when building a native image