### PR TITLE
Remove unnecessary dynamicMetricsEnabled flag

### DIFF
--- a/som
+++ b/som
@@ -309,7 +309,6 @@ if args.java_coverage:
 if args.web_debugger:
     SOM_ARGS += ['--web-debug']
 if args.dynamic_metrics:
-    SOM_ARGS += ['--dynamic-metrics']
     flags += ['-Dsom.dynamicMetrics=true']
 if args.si_candidates:
     SOM_ARGS += ['--si-candidates']

--- a/src/som/VM.java
+++ b/src/som/VM.java
@@ -403,20 +403,17 @@ public final class VM {
       }
     }
 
-    if (options.dynamicMetricsEnabled) {
-      assert VmSettings.DYNAMIC_METRICS;
+    if (VmSettings.DYNAMIC_METRICS) {
       structuralProbe = DynamicMetrics.find(engine);
       assert structuralProbe != null : "Initialization of DynamicMetrics tool incomplete";
     }
 
     if (options.siCandidateIdentifierEnabled) {
-      assert !options.dynamicMetricsEnabled : "Currently, DynamicMetrics and CandidateIdentifer are not compatible";
       structuralProbe = CandidateIdentifier.find(env);
       assert structuralProbe != null : "Initialization of CandidateIdentifer tool incomplete";
     }
 
     if (VmSettings.TRACK_SNAPSHOT_ENTITIES) {
-      assert !options.dynamicMetricsEnabled : "Currently, DynamicMetrics and Snapshots are not compatible";
       assert !options.siCandidateIdentifierEnabled : "Currently, CandidateIdentifer and Snapshots are not compatible";
       structuralProbe = SnapshotBackend.getProbe();
     }

--- a/src/som/primitives/BlockPrims.java
+++ b/src/som/primitives/BlockPrims.java
@@ -44,6 +44,7 @@ public abstract class BlockPrims {
 
     if (VmSettings.DYNAMIC_METRICS) {
       callNode = new InstrumentableBlockApplyNode(callNode, node.getSourceSection());
+      // trigger instrumentation by Truffle
       new DummyParent(lang, callNode).notifyInserted();
       assert callNode.getParent() instanceof WrapperNode;
       callNode = (DirectCallNode) callNode.getParent();

--- a/src/som/vm/VmOptions.java
+++ b/src/som/vm/VmOptions.java
@@ -24,7 +24,6 @@ public class VmOptions {
 
   @CompilationFinal public boolean webDebuggerEnabled;
   @CompilationFinal public boolean profilingEnabled;
-  @CompilationFinal public boolean dynamicMetricsEnabled;
   @CompilationFinal public boolean siCandidateIdentifierEnabled;
   @CompilationFinal public boolean coverageEnabled;
   @CompilationFinal public String  coverageFile;
@@ -39,7 +38,7 @@ public class VmOptions {
     showUsage = args.length == 0;
     if (!VmSettings.INSTRUMENTATION &&
         (webDebuggerEnabled || profilingEnabled ||
-            dynamicMetricsEnabled || coverageEnabled || siCandidateIdentifierEnabled)) {
+            coverageEnabled || siCandidateIdentifierEnabled)) {
       throw new IllegalStateException(
           "Instrumentation is not enabled, but one of the tools is used. " +
               "Please set -D" + VmSettings.INSTRUMENTATION_PROP + "=true");
@@ -71,9 +70,6 @@ public class VmOptions {
           currentArg += 1;
         } else if (arguments[currentArg].equals("--profile")) {
           profilingEnabled = true;
-          currentArg += 1;
-        } else if (arguments[currentArg].equals("--dynamic-metrics")) {
-          dynamicMetricsEnabled = true;
           currentArg += 1;
         } else if (arguments[currentArg].equals("--si-candidates")) {
           siCandidateIdentifierEnabled = true;
@@ -114,7 +110,6 @@ public class VmOptions {
     Output.println("  --web-debug            Start web debugger");
     Output.println("");
     Output.println("  --profile              Enable the TruffleProfiler");
-    Output.println("  --dynamic-metrics      Enable the DynamicMetrics tool");
     Output.println("  --si-candidates        Enable the Super-instruction candidate tool");
     Output.println(
         "  --coveralls REPO_TOKEN Enable the Coverage tool and reporting to Coveralls.io");


### PR DESCRIPTION
This flag is redundant with the -Dsom.dynamicMetrics=true property and only cases confusion.

@sophie-kaleba thanks for finding this, could you please review the changes?