### PR TITLE
Do not cache final layout assumptions

### DIFF
--- a/src/som/interpreter/objectstorage/InitializerFieldWrite.java
+++ b/src/som/interpreter/objectstorage/InitializerFieldWrite.java
@@ -89,7 +89,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"isLatestLayout"},
+      assumptions = {"cachedLayout.getAssumption()"},
       guards = {
           "accessor != null",
           "cachedLayout == rcvr.getObjectLayout()",
@@ -98,14 +98,13 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   public final long longValueSet(final SImmutableObject rcvr, final long value,
       @Cached("createProfile()") final IntValueProfile primMarkProfile,
       @Cached("rcvr.getObjectLayout()") final ObjectLayout cachedLayout,
-      @Cached("cachedLayout.getAssumption()") final Assumption isLatestLayout,
       @Cached("getLongAccessor(cachedLayout)") final AbstractPrimitiveAccessor accessor) {
     accessor.write(rcvr, value);
     return value;
   }
 
   @Specialization(
-      assumptions = {"isLatestLayout"},
+      assumptions = {"cachedLayout.getAssumption()"},
       guards = {
           "accessor != null",
           "cachedLayout == rcvr.getObjectLayout()",
@@ -114,14 +113,13 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   public final long longValueSet(final SMutableObject rcvr, final long value,
       @Cached("createProfile()") final IntValueProfile primMarkProfile,
       @Cached("rcvr.getObjectLayout()") final ObjectLayout cachedLayout,
-      @Cached("cachedLayout.getAssumption()") final Assumption isLatestLayout,
       @Cached("getLongAccessor(cachedLayout)") final AbstractPrimitiveAccessor accessor) {
     accessor.write(rcvr, value);
     return value;
   }
 
   @Specialization(
-      assumptions = {"isLatestLayout"},
+      assumptions = {"cachedLayout.getAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()"},
       replaces = "longValueSet",
@@ -129,7 +127,6 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   public final long longValueSetOrUnset(final SImmutableObject rcvr, final long value,
       @Cached("createProfile()") final IntValueProfile primMarkProfile,
       @Cached("rcvr.getObjectLayout()") final ObjectLayout cachedLayout,
-      @Cached("cachedLayout.getAssumption()") final Assumption isLatestLayout,
       @Cached("getLongAccessor(cachedLayout)") final AbstractPrimitiveAccessor accessor) {
     accessor.write(rcvr, value);
     accessor.markPrimAsSet(rcvr, primMarkProfile);
@@ -137,7 +134,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"isLatestLayout"},
+      assumptions = {"cachedLayout.getAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()"},
       replaces = "longValueSet",
@@ -145,7 +142,6 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   public final long longValueSetOrUnset(final SMutableObject rcvr, final long value,
       @Cached("createProfile()") final IntValueProfile primMarkProfile,
       @Cached("rcvr.getObjectLayout()") final ObjectLayout cachedLayout,
-      @Cached("cachedLayout.getAssumption()") final Assumption isLatestLayout,
       @Cached("getLongAccessor(cachedLayout)") final AbstractPrimitiveAccessor accessor) {
     accessor.write(rcvr, value);
     accessor.markPrimAsSet(rcvr, primMarkProfile);
@@ -153,7 +149,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"isLatestLayout"},
+      assumptions = {"cachedLayout.getAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()",
           "accessor.isPrimitiveSet(rcvr, primMarkProfile)"},
@@ -161,14 +157,13 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   public final double doubleValueSet(final SMutableObject rcvr, final double value,
       @Cached("createProfile()") final IntValueProfile primMarkProfile,
       @Cached("rcvr.getObjectLayout()") final ObjectLayout cachedLayout,
-      @Cached("cachedLayout.getAssumption()") final Assumption isLatestLayout,
       @Cached("getDoubleAccessor(cachedLayout)") final AbstractPrimitiveAccessor accessor) {
     accessor.write(rcvr, value);
     return value;
   }
 
   @Specialization(
-      assumptions = {"isLatestLayout"},
+      assumptions = {"cachedLayout.getAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()",
           "accessor.isPrimitiveSet(rcvr, primMarkProfile)"},
@@ -176,14 +171,13 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   public final double doubleValueSet(final SImmutableObject rcvr, final double value,
       @Cached("createProfile()") final IntValueProfile primMarkProfile,
       @Cached("rcvr.getObjectLayout()") final ObjectLayout cachedLayout,
-      @Cached("cachedLayout.getAssumption()") final Assumption isLatestLayout,
       @Cached("getDoubleAccessor(cachedLayout)") final AbstractPrimitiveAccessor accessor) {
     accessor.write(rcvr, value);
     return value;
   }
 
   @Specialization(
-      assumptions = {"isLatestLayout"},
+      assumptions = {"cachedLayout.getAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()"},
       replaces = "doubleValueSet",
@@ -191,7 +185,6 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   public final double doubleValueSetOrUnset(final SMutableObject rcvr, final double value,
       @Cached("createProfile()") final IntValueProfile primMarkProfile,
       @Cached("rcvr.getObjectLayout()") final ObjectLayout cachedLayout,
-      @Cached("cachedLayout.getAssumption()") final Assumption isLatestLayout,
       @Cached("getDoubleAccessor(cachedLayout)") final AbstractPrimitiveAccessor accessor) {
     accessor.write(rcvr, value);
     accessor.markPrimAsSet(rcvr, primMarkProfile);
@@ -199,7 +192,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"isLatestLayout"},
+      assumptions = {"cachedLayout.getAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()"},
       replaces = "doubleValueSet",
@@ -207,7 +200,6 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   public final double doubleValueSetOrUnset(final SImmutableObject rcvr, final double value,
       @Cached("createProfile()") final IntValueProfile primMarkProfile,
       @Cached("rcvr.getObjectLayout()") final ObjectLayout cachedLayout,
-      @Cached("cachedLayout.getAssumption()") final Assumption isLatestLayout,
       @Cached("getDoubleAccessor(cachedLayout)") final AbstractPrimitiveAccessor accessor) {
     accessor.write(rcvr, value);
     accessor.markPrimAsSet(rcvr, primMarkProfile);
@@ -215,39 +207,36 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"isLatestLayout"},
+      assumptions = {"cachedLayout.getAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()"},
       limit = "LIMIT")
   public final Object objectValue(final SImmutableObject rcvr, final Object value,
       @Cached("rcvr.getObjectLayout()") final ObjectLayout cachedLayout,
-      @Cached("cachedLayout.getAssumption()") final Assumption isLatestLayout,
       @Cached("getObjectAccessor(cachedLayout)") final AbstractObjectAccessor accessor) {
     accessor.write(rcvr, value);
     return value;
   }
 
   @Specialization(
-      assumptions = {"isLatestLayout"},
+      assumptions = {"cachedLayout.getAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()"},
       limit = "LIMIT")
   public final Object objectValue(final SMutableObject rcvr, final Object value,
       @Cached("rcvr.getObjectLayout()") final ObjectLayout cachedLayout,
-      @Cached("cachedLayout.getAssumption()") final Assumption isLatestLayout,
       @Cached("getObjectAccessor(cachedLayout)") final AbstractObjectAccessor accessor) {
     accessor.write(rcvr, value);
     return value;
   }
 
   @Specialization(
-      assumptions = {"isLatestLayout"},
+      assumptions = {"cachedLayout.getAssumption()"},
       guards = {"location != null",
           "cachedLayout == rcvr.getObjectLayout()"},
       limit = "LIMIT")
   public final Object unwritten(final SObject rcvr, final Object value,
       @Cached("rcvr.getObjectLayout()") final ObjectLayout cachedLayout,
-      @Cached("cachedLayout.getAssumption()") final Assumption isLatestLayout,
       @Cached("getUnwritten(cachedLayout)") final StorageLocation location) {
     CompilerDirectives.transferToInterpreter();
     ObjectTransitionSafepoint.INSTANCE.writeUninitializedSlot(rcvr, slot, value);

--- a/src/som/interpreter/objectstorage/InitializerFieldWrite.java
+++ b/src/som/interpreter/objectstorage/InitializerFieldWrite.java
@@ -1,6 +1,5 @@
 package som.interpreter.objectstorage;
 
-import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
@@ -89,7 +88,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"cachedLayout.getAssumption()"},
+      assumptions = {"cachedLayout.getIsLatestLayoutForClassAssumption()"},
       guards = {
           "accessor != null",
           "cachedLayout == rcvr.getObjectLayout()",
@@ -104,7 +103,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"cachedLayout.getAssumption()"},
+      assumptions = {"cachedLayout.getIsLatestLayoutForClassAssumption()"},
       guards = {
           "accessor != null",
           "cachedLayout == rcvr.getObjectLayout()",
@@ -119,7 +118,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"cachedLayout.getAssumption()"},
+      assumptions = {"cachedLayout.getIsLatestLayoutForClassAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()"},
       replaces = "longValueSet",
@@ -134,7 +133,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"cachedLayout.getAssumption()"},
+      assumptions = {"cachedLayout.getIsLatestLayoutForClassAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()"},
       replaces = "longValueSet",
@@ -149,7 +148,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"cachedLayout.getAssumption()"},
+      assumptions = {"cachedLayout.getIsLatestLayoutForClassAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()",
           "accessor.isPrimitiveSet(rcvr, primMarkProfile)"},
@@ -163,7 +162,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"cachedLayout.getAssumption()"},
+      assumptions = {"cachedLayout.getIsLatestLayoutForClassAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()",
           "accessor.isPrimitiveSet(rcvr, primMarkProfile)"},
@@ -177,7 +176,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"cachedLayout.getAssumption()"},
+      assumptions = {"cachedLayout.getIsLatestLayoutForClassAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()"},
       replaces = "doubleValueSet",
@@ -192,7 +191,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"cachedLayout.getAssumption()"},
+      assumptions = {"cachedLayout.getIsLatestLayoutForClassAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()"},
       replaces = "doubleValueSet",
@@ -207,7 +206,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"cachedLayout.getAssumption()"},
+      assumptions = {"cachedLayout.getIsLatestLayoutForClassAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()"},
       limit = "LIMIT")
@@ -219,7 +218,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"cachedLayout.getAssumption()"},
+      assumptions = {"cachedLayout.getIsLatestLayoutForClassAssumption()"},
       guards = {"accessor != null",
           "cachedLayout == rcvr.getObjectLayout()"},
       limit = "LIMIT")
@@ -231,7 +230,7 @@ public abstract class InitializerFieldWrite extends ExprWithTagsNode {
   }
 
   @Specialization(
-      assumptions = {"cachedLayout.getAssumption()"},
+      assumptions = {"cachedLayout.getIsLatestLayoutForClassAssumption()"},
       guards = {"location != null",
           "cachedLayout == rcvr.getObjectLayout()"},
       limit = "LIMIT")

--- a/src/som/interpreter/objectstorage/ObjectLayout.java
+++ b/src/som/interpreter/objectstorage/ObjectLayout.java
@@ -95,7 +95,7 @@ public final class ObjectLayout {
     latestLayoutForClass.check();
   }
 
-  Assumption getAssumption() {
+  Assumption getIsLatestLayoutForClassAssumption() {
     return latestLayoutForClass;
   }
 


### PR DESCRIPTION
There's no need to cache a final value, so this should reduce cache sizes a bit.

The only downside is that the better name (`isLatestLayout`) is dropped, maybe `getAssumption()` should be renamed at some point (e.g. `getIsLatestLayoutAssumption()`)?