### PR TITLE
Fix problems with blocks in variable declaration expressions 

### DIFF
--- a/core-lib/TestSuite/RegressionTests.ns
+++ b/core-lib/TestSuite/RegressionTests.ns
@@ -26,7 +26,7 @@ class RegressionTests usingPlatform: platform testFramework: minitest = (
     class B = ()( public foo = ( ^ 2 ) ) : ( public bar = ( ^ 2 ))
 
     make: cls = ( ^ cls new )
-    
+
     bar: cls = ( ^ cls bar )
 
     public testMake = (
@@ -34,11 +34,27 @@ class RegressionTests usingPlatform: platform testFramework: minitest = (
       self assert: (make: B) foo equals: 2.
       self assert: (make: A) foo equals: 1.
     )
-    
+
     public testClassMethod = (
       self assert: (bar: A) equals: 1.
       self assert: (bar: B) equals: 2.
       self assert: (bar: A) equals: 1.
+    )
+  ) : ( TEST_CONTEXT = () )
+
+  public class VariableAccessInLocalDefinition = TestContext ()(
+    public testSelfInBlock = (
+      | var = [ self ] value. |
+      self assert: var is: self.
+    )
+
+    public returnSelfFromBlock = (
+      | var = [ ^ self ] value. |
+      ^ #error
+    )
+
+    public testReturnSelfFromBlock = (
+      self assert: returnSelfFromBlock is: self
     )
   ) : ( TEST_CONTEXT = () )
 )

--- a/src/som/interpreter/LexicalScope.java
+++ b/src/som/interpreter/LexicalScope.java
@@ -15,6 +15,7 @@ import bd.inlining.Scope;
 import som.compiler.MixinBuilder.MixinDefinitionId;
 import som.compiler.MixinDefinition;
 import som.compiler.Variable;
+import som.compiler.Variable.Internal;
 import som.interpreter.nodes.dispatch.Dispatchable;
 import som.vmobjects.SSymbol;
 
@@ -193,8 +194,18 @@ public abstract class LexicalScope {
 
     public void setVariables(final Variable[] variables) {
       assert variables != null : "variables are expected to be != null once set";
-      assert this.variables == null;
-      this.variables = variables;
+      assert this.variables == null
+          || (this.variables.length == 1 && this.variables[0] instanceof Internal);
+      if (this.variables == null) {
+        this.variables = variables;
+      } else {
+        Variable internal = this.variables[0];
+        this.variables = new Variable[variables.length + 1];
+        for (int i = 0; i < variables.length; i += 1) {
+          this.variables[i] = variables[i];
+        }
+        this.variables[variables.length] = internal;
+      }
     }
 
     /**
@@ -207,6 +218,11 @@ public abstract class LexicalScope {
     }
 
     public void addVariable(final Variable var) {
+      if (variables == null) {
+        variables = new Variable[] {var};
+        return;
+      }
+
       int length = variables.length;
       variables = Arrays.copyOf(variables, length + 1);
       variables[length] = var;


### PR DESCRIPTION
This fixes an issue with using blocks in variable declarations:

```
public testSelfInBlock = (
      | var = [ self ] value. |
      self assert: var is: self.
)
```

Before the PR, the block caused an exception, caused by how we manage variables on the MethodScope objects.

We expect them to be set exactly once, when the variable declaration parsing is completed.

However, if we have a block, the block needs a marker for us to know whether it's on the stack, which is an `Internal` variable added to the variable array.
The array may have been set (if we have a block in the method after the variable declarations), or it may not have been set yet (if we have a block in the variable declarations).
This fixes the error when we haven't set the variables yet.


@daumayr @sophie-kaleba could one of you review this and approve the PR, or suggest improvements, perhaps missing tests?
