### PR TITLE
Make sure the And/Or specializer doesn’t pass on subexpressions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.som linguist-language=Smalltalk
+*.ns linguist-language=Smalltalk

--- a/src/som/interpreter/nodes/specialized/AndMessageNode.java
+++ b/src/som/interpreter/nodes/specialized/AndMessageNode.java
@@ -60,10 +60,14 @@ public abstract class AndMessageNode extends BinaryComplexOperation {
       BinaryExpressionNode node;
       if (unwrapIfNecessary(argNodes[1]) instanceof BlockNode) {
         node = (BinaryExpressionNode) fact.createNode(
-            arguments[1], argNodes[0], argNodes[1]);
+            arguments[1],
+            eagerWrapper ? null : argNodes[0],
+            eagerWrapper ? null : argNodes[1]);
       } else {
         assert arguments == null || arguments[1] instanceof Boolean;
-        node = (BinaryExpressionNode) boolFact.createNode(argNodes[0], argNodes[1]);
+        node = (BinaryExpressionNode) boolFact.createNode(
+            eagerWrapper ? null : argNodes[0],
+            eagerWrapper ? null : argNodes[1]);
       }
       node.initialize(section, eagerWrapper);
       return node;


### PR DESCRIPTION
This prevents possible issues with nodes being multiple times in an AST.

The PR also declares all `.ns` files to be Smalltalk files for code highlighting on GitHub.