### PR TITLE
Make Safepoint usage more robust and increase test time outs

### DIFF
--- a/src/som/interpreter/objectstorage/ObjectTransitionSafepoint.java
+++ b/src/som/interpreter/objectstorage/ObjectTransitionSafepoint.java
@@ -95,11 +95,13 @@ public final class ObjectTransitionSafepoint {
   public void transitionObject(final SObject obj) {
     waitForSafepointStart();
 
-    // Safepoint phase, used to update the object
-    // object is required to handle updates from multiple threads correctly
-    obj.updateLayoutToMatchClass();
-
-    phaser.finishSafepointAndAwaitCompletion();
+    try {
+      // Safepoint phase, used to update the object
+      // object is required to handle updates from multiple threads correctly
+      obj.updateLayoutToMatchClass();
+    } finally {
+      phaser.finishSafepointAndAwaitCompletion();
+    }
   }
 
   /**
@@ -113,11 +115,13 @@ public final class ObjectTransitionSafepoint {
       final Object value) {
     waitForSafepointStart();
 
-    // Safepoint phase, used to update the object
-    // object is required to handle updates from multiple threads correctly
-    obj.writeUninitializedSlot(slot, value);
-
-    phaser.finishSafepointAndAwaitCompletion();
+    try {
+      // Safepoint phase, used to update the object
+      // object is required to handle updates from multiple threads correctly
+      obj.writeUninitializedSlot(slot, value);
+    } finally {
+      phaser.finishSafepointAndAwaitCompletion();
+    }
   }
 
   /**
@@ -131,22 +135,26 @@ public final class ObjectTransitionSafepoint {
       final Object value) {
     waitForSafepointStart();
 
-    // Safepoint phase, used to update the object
-    // object is required to handle updates from multiple threads correctly
-    obj.writeAndGeneralizeSlot(slot, value);
-
-    phaser.finishSafepointAndAwaitCompletion();
+    try {
+      // Safepoint phase, used to update the object
+      // object is required to handle updates from multiple threads correctly
+      obj.writeAndGeneralizeSlot(slot, value);
+    } finally {
+      phaser.finishSafepointAndAwaitCompletion();
+    }
   }
 
   public void ensureSlotAllocatedToAvoidDeadlock(final SObject obj,
       final SlotDefinition slot) {
     waitForSafepointStart();
 
-    // Safepoint phase, used to update the object
-    // object is required to handle updates from multiple threads correctly
-    obj.ensureSlotAllocatedToAvoidDeadlock(slot);
-
-    phaser.finishSafepointAndAwaitCompletion();
+    try {
+      // Safepoint phase, used to update the object
+      // object is required to handle updates from multiple threads correctly
+      obj.ensureSlotAllocatedToAvoidDeadlock(slot);
+    } finally {
+      phaser.finishSafepointAndAwaitCompletion();
+    }
   }
 
   void renewAssumption() {

--- a/src/som/interpreter/objectstorage/SafepointPhaser.java
+++ b/src/som/interpreter/objectstorage/SafepointPhaser.java
@@ -261,7 +261,7 @@ public final class SafepointPhaser {
 
   void finishSafepointAndAwaitCompletion() {
     int phase = arriveAndAwaitAdvance();
-    assert (phase & 1) == 0 : "Expect phase to be evem on completion of safepoint, but was "
+    assert (phase & 1) == 0 : "Expect phase to be even on completion of safepoint, but was "
         + phase;
   }
 

--- a/tests/java/som/tests/ParallelHelper.java
+++ b/tests/java/som/tests/ParallelHelper.java
@@ -53,7 +53,7 @@ public final class ParallelHelper {
       }
 
       assertTrue("Failed parallel test with: " + exceptions, exceptions.isEmpty());
-      assertTrue(allArrivedWithinTime);
+      assertTrue("Some threads timed out on threadsDone", allArrivedWithinTime);
     } finally {
       threadPool.shutdownNow();
     }

--- a/tests/java/som/tests/ParallelHelper.java
+++ b/tests/java/som/tests/ParallelHelper.java
@@ -24,10 +24,9 @@ public final class ParallelHelper {
     int numThreads = getNumberOfThreads();
 
     ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
+    List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<Throwable>());
 
     try {
-      List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<Throwable>());
-
       CountDownLatch threadsInitialized = new CountDownLatch(numThreads);
       CountDownLatch threadsDone = new CountDownLatch(numThreads);
 
@@ -41,8 +40,9 @@ public final class ParallelHelper {
             task.apply(id);
           } catch (Throwable t) {
             exceptions.add(t);
+          } finally {
+            threadsDone.countDown();
           }
-          threadsDone.countDown();
         });
       }
       boolean allArrivedWithinTime = threadsDone.await(timeoutInSeconds, TimeUnit.SECONDS);


### PR DESCRIPTION
We need to make sure that exceptions do not break our safepoint invariants.
Thus, I moved the `unregister` in tests, and the second `await` operation into `finally` blocks.

Same idea also applies to the `ParallelHelper` implementation to make it more robust.

@daumayr please have a quick look.

Thanks