### PR TITLE
Fix performance issue in ArrayLiteralNode and optimize access of context objects

### DIFF
--- a/src/som/interpreter/Method.java
+++ b/src/som/interpreter/Method.java
@@ -82,7 +82,7 @@ public final class Method extends Invokable {
 
   @Override
   public String toString() {
-    return "Method " + getName() + "\t@" + Integer.toHexString(hashCode());
+    return getName() + "\t@" + Integer.toHexString(hashCode());
   }
 
   @Override

--- a/src/som/interpreter/Primitive.java
+++ b/src/som/interpreter/Primitive.java
@@ -59,7 +59,7 @@ public final class Primitive extends Invokable {
     if (n != expressionOrSequence) {
       nodeType += " (wrapped)"; // indicate that it is wrapped
     }
-    return "Primitive " + nodeType + "@" + Integer.toHexString(hashCode());
+    return nodeType + "\t@" + Integer.toHexString(hashCode());
   }
 
   @Override

--- a/src/som/interpreter/nodes/literals/ArrayLiteralNode.java
+++ b/src/som/interpreter/nodes/literals/ArrayLiteralNode.java
@@ -1,5 +1,6 @@
 package som.interpreter.nodes.literals;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.Tag;
 import com.oracle.truffle.api.source.SourceSection;
@@ -95,7 +96,9 @@ public abstract class ArrayLiteralNode extends LiteralNode {
     public final Object executeGeneric(final VirtualFrame frame) {
       Object storage = executeSpecialized(frame);
       SMutableArray result = new SMutableArray(storage, Classes.arrayClass);
+
       if (!expectedType(result)) {
+        CompilerDirectives.transferToInterpreterAndInvalidate();
         replace(new Objects(expressions).initialize(sourceSection));
       }
       return result;

--- a/src/som/vmobjects/SObjectWithContext.java
+++ b/src/som/vmobjects/SObjectWithContext.java
@@ -1,6 +1,7 @@
 package som.vmobjects;
 
 import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.profiles.ValueProfile;
 
 import som.interpreter.SArguments;
 
@@ -29,8 +30,8 @@ public interface SObjectWithContext {
    * Return the object enclosing the current object,
    * which is the receiver of this object.
    */
-  default SObjectWithContext getOuterSelf() {
-    return (SObjectWithContext) SArguments.rcvr(getContext());
+  default SObjectWithContext getOuterSelf(final ValueProfile rcvrType) {
+    return (SObjectWithContext) rcvrType.profile(SArguments.rcvr(getContext()));
   }
 
 }


### PR DESCRIPTION
The specialization logic was included into the compilation, which causes code bloat.

The context objects could be well optimized in some cases where outer context access would cause a virtual method call, because the type was not known at compilation.

@sophie-kaleba: the two optimizations might be interesting for you, just as other examples.

This PR also remove the "Method"/"Primitive" strings from the names of the corresponding objects. Should be obvious enough in compilation logs.