### PR TITLE
Adapt to new ReBench version, and reduce compilation threshold

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,7 @@ benchmark_savina_job:
   allow_failure: true
   script:
     - ant compile
-    - rebench --without-nice --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-Savina
+    - rebench --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-Savina
 
 benchmark_savina_csp_job:
   stage: benchmark
@@ -61,7 +61,7 @@ benchmark_savina_csp_job:
   allow_failure: true
   script:
     - ant compile
-    - rebench --without-nice --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-SavinaCSP
+    - rebench --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-SavinaCSP
 
 benchmark_job:
   stage: benchmark
@@ -69,7 +69,7 @@ benchmark_job:
   allow_failure: true
   script:
     - ant compile
-    - rebench --without-nice --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns
+    - rebench --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns
 
 benchmark_interp_job:
   stage: benchmark
@@ -77,7 +77,7 @@ benchmark_interp_job:
   allow_failure: true
   script:
     - ant compile
-    - rebench --without-nice --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-interp
+    - rebench --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-interp
 
 benchmark_nightly_job:
   stage: benchmark
@@ -87,8 +87,8 @@ benchmark_nightly_job:
     - triggers
   script:
     - ant compile
-    - rebench --without-nice --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf nightly
-    - rebench --without-nice --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-Savina-tracing
+    - rebench --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf nightly
+    - rebench --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-Savina-tracing
 
 build_virtualbox:
   stage: virtualbox-image

--- a/codespeed.conf
+++ b/codespeed.conf
@@ -90,7 +90,7 @@ benchmark_suites:
                 extra_args: "130 0 60"
                 codespeed_name: "peak.RichardsNS"
             - DeltaBlue:
-                extra_args: "250 0 1000"
+                extra_args: "250 0 13000"
                 codespeed_name: "peak.DeltaBlue"
                 warmup: 150
             - DeltaBlueNS:
@@ -124,10 +124,10 @@ benchmark_suites:
                 extra_args: "150 0 4"
                 codespeed_name: "peak.LeeSTM"
             - Vacation:
-                extra_args: "150 0 7"
+                extra_args: "150 0 14"
                 codespeed_name: "peak.Vacation"
             - VacationSTM:
-                extra_args: "150 0 7"
+                extra_args: "150 0 11"
                 codespeed_name: "peak.VacationSTM"
             - Splay:
                 extra_args: "150 0 1"
@@ -290,7 +290,7 @@ benchmark_suites:
                 extra_args: "55 0 2000"
                 codespeed_name: "peak.Dispatch"
             - Loop:
-                extra_args: "55 0 3000"
+                extra_args: "55 0 500000"
                 codespeed_name: "peak.Loop"
             - Recurse:
                 extra_args: "70 0 2000"

--- a/codespeed.conf
+++ b/codespeed.conf
@@ -84,13 +84,13 @@ benchmark_suites:
                 extra_args: "130 0 5"
                 codespeed_name: "peak.Havlak"
             - Richards:
-                extra_args: "130 0 60"
+                extra_args: "130 0 30"
                 codespeed_name: "peak.Richards"
             - RichardsNS:
-                extra_args: "130 0 60"
+                extra_args: "130 0 200"
                 codespeed_name: "peak.RichardsNS"
             - DeltaBlue:
-                extra_args: "250 0 13000"
+                extra_args: "250 0 10000"
                 codespeed_name: "peak.DeltaBlue"
                 warmup: 150
             - DeltaBlueNS:
@@ -114,7 +114,7 @@ benchmark_suites:
                 codespeed_name: "peak.GraphSearch"
                 warmup: 100
             - PageRank:
-                extra_args: "120 0 500"
+                extra_args: "120 0 1000"
                 codespeed_name: "peak.PageRank"
                 warmup: 20
             - Lee:
@@ -124,10 +124,10 @@ benchmark_suites:
                 extra_args: "150 0 4"
                 codespeed_name: "peak.LeeSTM"
             - Vacation:
-                extra_args: "150 0 14"
+                extra_args: "150 0 12"
                 codespeed_name: "peak.Vacation"
             - VacationSTM:
-                extra_args: "150 0 11"
+                extra_args: "150 0 10"
                 codespeed_name: "peak.VacationSTM"
             - Splay:
                 extra_args: "150 0 1"
@@ -189,7 +189,7 @@ benchmark_suites:
                 codespeed_name: "peak.Queens"
                 warmup: 70
             - Storage:
-                extra_args: "75 0 1000"
+                extra_args: "75 0 700"
                 codespeed_name: "peak.Storage"
                 warmup: 25
             - Sieve:
@@ -293,7 +293,7 @@ benchmark_suites:
                 extra_args: "55 0 500000"
                 codespeed_name: "peak.Loop"
             - Recurse:
-                extra_args: "70 0 2000"
+                extra_args: "70 0 1000"
                 codespeed_name: "peak.Recurse"
                 warmup: 20
             - Sum:
@@ -317,25 +317,25 @@ benchmark_suites:
         benchmarks:
             # Microbenchmarks
             - PingPong:
-                extra_args: 40000
+                extra_args: 20000
                 codespeed_name: "M.PingPong"
             - Counting:
-                extra_args: 300000  # was 1000000
+                extra_args: 100000  # was 1000000
                 codespeed_name: "M.Counting"
             - ForkJoinThroughput:
-                extra_args: "3000:60" # "10000:60"
+                extra_args: "1000:60" # "10000:60"
                 codespeed_name: "M.ForkJoinThroughput"
             - ForkJoinActorCreation:
-                extra_args: 20000
+                extra_args: 10000
                 codespeed_name: "M.ForkJoinActorCreation"
             - ThreadRing:
                 extra_args: "100:50000"
                 codespeed_name: "M.ThreadRing"
             - Chameneos:
-                extra_args: "100:20000"  # "100:200000"
+                extra_args: "100:10000"  # "100:200000"
                 codespeed_name: "M.Chameneos"
             - BigContention:
-                extra_args: "500:120"
+                extra_args: "100:120"
                 codespeed_name: "M.BigContention"
 
             # Concurrency
@@ -343,25 +343,25 @@ benchmark_suites:
                 extra_args: "20:600:20" # "20:10000:50"
                 codespeed_name: "C.Dictionary"
             - ConcurrentSortedLinkedList:
-                extra_args: "10:500:10:1" # "20:8000:10:1"
+                extra_args: "10:300:10:1" # "20:8000:10:1"
                 codespeed_name: "C.SortedLinkedList"
             - ProducerConsumerBoundedBuffer:
                 extra_args: "40:5:5:10" # "50:40:40:1000"
                 codespeed_name: "C.ProdConBoundedBuffer"
             - Philosophers:
-                extra_args: "20:2000"
+                extra_args: "20:1000"
                 codespeed_name: "C.Philosophers"
             - SleepingBarber:
-                extra_args: "800:500:500:200"
+                extra_args: "800:400:400:200"
                 codespeed_name: "C.SleepingBarber"
             - CigaretteSmokers:
                 extra_args: "1000:200"
                 codespeed_name: "C.CigaretteSmokers"
             - LogisticsMapSeries:
-                extra_args: "10000:10:346"
+                extra_args: "2000:10:346"
                 codespeed_name: "C.LogisticsMapSeries"
             - BankTransaction:
-                extra_args: "1000:10000"
+                extra_args: "1000:1000"
                 codespeed_name: "C.BankTransaction"
 
             # Parallelism
@@ -369,10 +369,10 @@ benchmark_suites:
                 extra_args: "10000:65536:74755"  # "100000:1152921504606846976:74755"
                 codespeed_name: "P.RadixSort"
             - UnbalancedCobwebbedTree:
-                extra_args: "10000:10:0:1"
+                extra_args: "5000:10:0:1"
                 codespeed_name: "P.UnbalancedCobwebbedTree"
             - TrapezoidalApproximation:
-                extra_args: "100:100000:1:5" # "100:10000000:1:5"
+                extra_args: "100:10000:1:5" # "100:10000000:1:5"
                 codespeed_name: "P.TrapezoidalApproximation"
             - AStarSearch:
                 extra_args: "100:10"
@@ -407,7 +407,7 @@ benchmark_suites:
                 extra_args: "100:100000"  # "100:200000"
                 codespeed_name: "M.Chameneos"
             - BigContention:
-                extra_args: "2000:120"
+                extra_args: "800:120"
                 codespeed_name: "M.BigContention"
 
             # Concurrency
@@ -415,42 +415,42 @@ benchmark_suites:
                 extra_args: "20:1000:20" # "20:10000:50"
                 codespeed_name: "C.Dictionary"
             - ConcurrentSortedLinkedList:
-                extra_args: "10:1500:10:1" # "20:8000:10:1"
+                extra_args: "10:1000:10:1" # "20:8000:10:1"
                 codespeed_name: "C.SortedLinkedList"
             - ProducerConsumerBoundedBuffer:
-                extra_args: "40:10:10:60" # "50:40:40:1000"
+                extra_args: "40:5:5:10" # "50:40:40:1000"
                 codespeed_name: "C.ProdConBoundedBuffer"
             - Philosophers:
                 extra_args: "20:5000"
                 codespeed_name: "C.Philosophers"
             - SleepingBarber:
-                extra_args: "2500:1000:1000:1000"
+                extra_args: "1000:1000:1000:500"
                 codespeed_name: "C.SleepingBarber"
             - CigaretteSmokers:
                 extra_args: "10000:200"
                 codespeed_name: "C.CigaretteSmokers"
             - LogisticsMapSeries:
-                extra_args: "25000:10:346"
+                extra_args: "10000:10:346"
                 codespeed_name: "C.LogisticsMapSeries"
             - BankTransaction:
-                extra_args: "1000:100000"
+                extra_args: "1000:50000"
                 codespeed_name: "C.BankTransaction"
 
             # Parallelism
             - RadixSort:
-                extra_args: "50000:65536:74755"  # "100000:1152921504606846976:74755"
+                extra_args: "10000:65536:74755"  # "100000:1152921504606846976:74755"
                 codespeed_name: "P.RadixSort"
             - UnbalancedCobwebbedTree:
-                extra_args: "100000:10:500:100"
+                extra_args: "30000:10:500:100"
                 codespeed_name: "P.UnbalancedCobwebbedTree"
             - TrapezoidalApproximation:
-                extra_args: "100:1000000:1:5" # "100:10000000:1:5"
+                extra_args: "100:100000:1:5" # "100:10000000:1:5"
                 codespeed_name: "P.TrapezoidalApproximation"
             - AStarSearch:
                 extra_args: "100:20"
                 codespeed_name: "P.AStarSearch"
             - NQueens:
-                extra_args: "20:10:4"
+                extra_args: "20:9:4"
                 codespeed_name: "P.NQueens"
 
     validation:
@@ -487,16 +487,16 @@ benchmark_suites:
             ## Excluding Fib, NQueens, QuickSort
             ## we have similar versions already
             - CilkSort:
-                extra_args: "130 0 20"
+                extra_args: "130 0 50"
                 codespeed_name: "peak.CilkSort"
             - Integrate:
                 extra_args: "130 0 100"
                 codespeed_name: "peak.Integrate"
             - Jacobi:
-                extra_args: "130 0 200"
+                extra_args: "130 0 400"
                 codespeed_name: "peak.Jacobi"
             - LUDecomposition:
-                extra_args: "130 0 128"
+                extra_args: "130 0 256"
                 codespeed_name: "peak.LUDecomposition"
 
     fj-startup:
@@ -563,15 +563,15 @@ benchmark_suites:
         benchmarks:
             - PingPong:
                 #numMessages numThreads, numThreads is unused
-                extra_args: "4000 2"
+                extra_args: "10000 2"
                 codespeed_name: "CSP.PingPong"
             - ForkJoinThroughput:
                 #numMessages numThreads
-                extra_args: "4000 4"
+                extra_args: "8000 4"
                 codespeed_name: "CSP.ForkJoinThroughput"
             - Philosophers:
                 #numrounds numThreads, uses numThreads - 1 Philosophers
-                extra_args: "500 4"
+                extra_args: "200 4"
                 codespeed_name: "CSP.Philosophers"
 
     savina-csp-interp:
@@ -583,15 +583,15 @@ benchmark_suites:
         benchmarks:
             - PingPong:
                 #numMessages numThreads, numThreads is unused
-                extra_args: "4000 2"
+                extra_args: "8000 2"
                 codespeed_name: "CSP.PingPong"
             - ForkJoinThroughput:
                 #numMessages numThreads
-                extra_args: "4000 4"
+                extra_args: "8000 4"
                 codespeed_name: "CSP.ForkJoinThroughput"
             - Philosophers:
                 #numrounds numThreads, uses numThreads - 1 Philosophers
-                extra_args: "500 4"
+                extra_args: "700 4"
                 codespeed_name: "CSP.Philosophers"
 
 # VMs have a name and are specified by a path and the binary to be executed

--- a/core-lib/Benchmarks/Vacation.ns
+++ b/core-lib/Benchmarks/Vacation.ns
@@ -28,15 +28,17 @@ class Vacation usingPlatform: platform andHarness: harness = (
       manager:: initializeManager: problemSize.
       clients:: initializeClients: manager for: numThreads and: problemSize.
 
-      i:: 0.
-      threads:: Array new: numThreads withAll: [
-        i:: i + 1.
-        Thread spawn: [:i |
-          (clients at: i) run
-        ] with: { i }
-      ].
+      numThreads = 1
+        ifTrue: [ (clients at: 1) run ]
+        ifFalse: [
+          i:: 0.
+          threads:: Array new: numThreads withAll: [
+            i:: i + 1.
+            Thread spawn: [:i |
+              (clients at: i) run
+            ] with: { i } ].
 
-      threads do: [:t | t join ].
+          threads do: [:t | t join ] ].
 
       ^ checkTables: manager problemSize: problemSize
     )

--- a/core-lib/Benchmarks/VacationSTM.ns
+++ b/core-lib/Benchmarks/VacationSTM.ns
@@ -28,15 +28,17 @@ class VacationSTM usingPlatform: platform andHarness: harness = (
       manager:: initializeManager: problemSize.
       clients:: initializeClients: manager for: numThreads and: problemSize.
 
-      i:: 0.
-      threads:: Array new: numThreads withAll: [
-        i:: i + 1.
-        Thread spawn: [:i |
-          (clients at: i) run
-        ] with: { i }
-      ].
+      numThreads = 1
+        ifTrue: [ (clients at: 1) run ]
+        ifFalse: [
+          i:: 0.
+          threads:: Array new: numThreads withAll: [
+            i:: i + 1.
+            Thread spawn: [:i |
+              (clients at: i) run
+            ] with: { i } ].
 
-      threads do: [:t | t join ].
+          threads do: [:t | t join ] ].
 
       ^ checkTables: manager problemSize: problemSize
     )

--- a/som
+++ b/som
@@ -249,7 +249,7 @@ else:
   flags += GRAAL_JVMCI_FLAGS
   if args.embedded_graal:
     flags += GRAAL_EMBEDDED_FLAGS
-  flags += ['-Dgraal.TruffleCompilationThreshold=25']
+  flags += ['-Dgraal.TruffleCompilationThreshold=25', '-Dgraal.TruffleOSRCompilationThreshold=1000']
 
 if args.som_dnu:
     flags += ['-Dsom.printStackTraceOnDNU=true']

--- a/som
+++ b/som
@@ -118,6 +118,8 @@ parser.add_argument('-C', '--no-compilation', help='disable Truffle compilation'
                     dest='no_compilation', action='store_true', default=False)
 parser.add_argument('-G', '--interpreter', help='run without Graal',
                     dest='interpreter', action='store_true', default=False)
+parser.add_argument('-E', '--no-early-compilation', help='start compilation using default trigger values. SOMns triggers it earlier to make benchmarking faster',
+                    dest='early_compilation', action='store_false', default=True)
 parser.add_argument('-EG', '--no-embedded-graal', help='run without the embedded Graal',
                     dest='embedded_graal', action='store_false', default=True)
 parser.add_argument('-X', '--java-interpreter', help='run without Graal, and only the Java interpreter',
@@ -249,7 +251,8 @@ else:
   flags += GRAAL_JVMCI_FLAGS
   if args.embedded_graal:
     flags += GRAAL_EMBEDDED_FLAGS
-  flags += ['-Dgraal.TruffleCompilationThreshold=25', '-Dgraal.TruffleOSRCompilationThreshold=1000']
+  if args.early_compilation:
+    flags += ['-Dgraal.TruffleCompilationThreshold=25', '-Dgraal.TruffleOSRCompilationThreshold=1000']
 
 if args.som_dnu:
     flags += ['-Dsom.printStackTraceOnDNU=true']

--- a/som
+++ b/som
@@ -249,6 +249,7 @@ else:
   flags += GRAAL_JVMCI_FLAGS
   if args.embedded_graal:
     flags += GRAAL_EMBEDDED_FLAGS
+  flags += ['-Dgraal.TruffleCompilationThreshold=25']
 
 if args.som_dnu:
     flags += ['-Dsom.printStackTraceOnDNU=true']


### PR DESCRIPTION
Reduce the compilation threshold from 1000 to 25 method activations to trigger compilation earlier.
This hopefully reduces the interference caused from the compiler.

- add a flag to use the standard value
- resize benchmarks to account for the reduced speed on with the new version of ReBench that reduces other interference

@daumayr @sophie-kaleba just for your information.
The relevant change to ReBench is https://github.com/smarr/ReBench/pull/143