### PR TITLE
Pin threads to a cores

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -23,5 +23,6 @@
 	<classpathentry kind="src" path="/com.oracle.truffle.tools.profiler"/>
 	<classpathentry kind="src" path="/org.graalvm.polyglot.tck"/>
 	<classpathentry kind="src" path="/com.oracle.svm.core"/>
+	<classpathentry kind="lib" path="libs/affinity.jar"/>
 	<classpathentry kind="output" path="build/classes"/>
 </classpath>

--- a/build.xml
+++ b/build.xml
@@ -79,6 +79,12 @@
         <pathelement location="${classes.dir}" />
         <pathelement location="${bd.dir}/build/classes" />
         <pathelement location="${lib.dir}/somns-deps.jar" />
+        <pathelement location="${lib.dir}/affinity.jar" />
+
+        <pathelement location="${lib.dir}/slf4j-api.jar" />
+        <pathelement location="${lib.dir}/slf4j-simple.jar" />
+        <pathelement location="${lib.dir}/jna-platform.jar" />
+        <pathelement location="${lib.dir}/jna.jar" />
 
         <pathelement location="${svm.build}/svm-core.jar" />
         <pathelement location="${tools.build}/truffle-profiler.jar" />
@@ -92,7 +98,6 @@
         <pathelement location="${sdk.build}/word-api.jar" />
         <pathelement location="${sdk.build}/polyglot-tck.jar" />
         <pathelement location="${lib.dir}/somns-deps-dev.jar" />
-
 
         <pathelement location="${truffle.build}/truffle-debug.jar" />
         <pathelement location="${truffle.build}/truffle-dsl-processor.jar" />
@@ -214,6 +219,24 @@
         <get src="${lib.url}/somns-deps-dev-${somns-deps.version}.jar"
             usetimestamp="true"
             dest="${lib.dir}/somns-deps-dev.jar" />
+        <get src="https://repo1.maven.org/maven2/net/openhft/affinity/3.2.3/affinity-3.2.3.jar"
+            usetimestamp="true"
+            dest="${lib.dir}/affinity.jar" />
+        <get src="https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar"
+            usetimestamp="true"
+            dest="${lib.dir}/slf4j-api.jar" />
+        <get src="https://repo1.maven.org/maven2/org/slf4j/slf4j-nop/1.7.30/slf4j-nop-1.7.30.jar"
+            usetimestamp="true"
+            dest="${lib.dir}/slf4j-nop.jar" />
+        <get src="https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.30/slf4j-simple-1.7.30.jar"
+            usetimestamp="true"
+            dest="${lib.dir}/slf4j-simple.jar" />
+        <get src="https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/5.5.0/jna-platform-5.5.0.jar"
+            usetimestamp="true"
+            dest="${lib.dir}/jna-platform.jar" />
+        <get src="https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.5.0/jna-5.5.0.jar"
+            usetimestamp="true"
+            dest="${lib.dir}/jna.jar" />
         <travis target="som-libs" />
     </target>
 
@@ -292,7 +315,7 @@
 
     <target name="jacoco-lib" description="Get JaCoCo dependency">
         <travis target="jacoco-lib" start="Get JaCoCo" />
-        <get src="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/${jacoco.version}/jacoco-${jacoco.version}.zip"
+        <get src="https://repo1.maven.org/maven2/org/jacoco/jacoco/${jacoco.version}/jacoco-${jacoco.version}.zip"
             usetimestamp="true"
             dest="${lib.dir}/jacoco-${jacoco.version}.zip" />
         <unzip src="${lib.dir}/jacoco-${jacoco.version}.zip" dest="${lib.dir}/jacoco"/>

--- a/som
+++ b/som
@@ -227,7 +227,7 @@ TWEAK_INLINING = ['-Dgraal.TruffleCompilationThreshold=191',
 
 GRAAL_JVMCI_FLAGS = ['-XX:+UnlockExperimentalVMOptions', '-XX:+EnableJVMCI', '-XX:-UseJVMCICompiler']
 
-JAVA_ARGS = ['-server']
+JAVA_ARGS = ['-server', '-XX:+UseThreadPriorities']
 
 if JAVA_MAJOR_VERSION == 8:
   JAVA_ARGS += ['-d64']

--- a/som
+++ b/som
@@ -114,6 +114,8 @@ parser.add_argument('-A', '--no-assert', help='execute with assertions disabled'
                     dest='assert_', action='store_false', default=True)
 parser.add_argument('-B', '--no-background', help='disable background compilation',
                     dest='background_compilation', action='store_false', default=True)
+parser.add_argument('-P', '--no-pinning', help='disable pinning of threads to cores',
+                    dest='use_pinning', action='store_false', default=True)
 parser.add_argument('-C', '--no-compilation', help='disable Truffle compilation',
                     dest='no_compilation', action='store_true', default=False)
 parser.add_argument('-G', '--interpreter', help='run without Graal',
@@ -203,7 +205,12 @@ if not args.interpreter and not java_bin.startswith(BASE_DIR + '/libs/jvmci') an
 CLASSPATH = (BASE_DIR + '/build/classes:'
            + BASE_DIR + '/libs/black-diamonds/build/classes:'
            + TRUFFLE_DIR + '/truffle/mxbuild/dists/jdk1.8/truffle-debug.jar:'
-           + BASE_DIR + '/libs/somns-deps.jar')
+           + BASE_DIR + '/libs/somns-deps.jar:'
+           + BASE_DIR + '/libs/affinity.jar:'
+           + BASE_DIR + '/libs/slf4j-api.jar:'
+           + BASE_DIR + '/libs/slf4j-simple.jar:'
+           + BASE_DIR + '/libs/jna-platform.jar:'
+           + BASE_DIR + '/libs/jna.jar')
 
 BOOT_CLASSPATH = ('-Xbootclasspath/a:'
              + TRUFFLE_DIR + '/sdk/mxbuild/dists/jdk1.8/graal-sdk.jar:'
@@ -404,6 +411,22 @@ if args.java_args:
 
 flags += ['-Dsom.tools=' + BASE_DIR + '/tools']
 flags += ['-Dsom.baseDir=' + BASE_DIR]
+
+if args.use_pinning:
+  ## check whether there are any known restrictions to core usage
+  ## that needs to be considered for pinning
+  core_set = os.environ.get('REBENCH_DENOISE_CORE_SET', None)
+  if core_set:
+    ## calculate the mask for cores, as hexadecimal representation
+    core_set = core_set.split("-")
+    core_set[0] = int(core_set[0])
+    core_set[1] = int(core_set[1])
+    bit_mask = 0
+    for c in range(core_set[0], core_set[1] + 1):
+      bit_mask += 1 << c
+    flags += ['-Daffinity.reserved=' + hex(bit_mask).lstrip("0x")]
+else:
+  flags += ['-Dsom.usePinning=false']
 
 all_args = JAVA_ARGS + ['-classpath', CLASSPATH] + [BOOT_CLASSPATH] + flags + SOM_ARGS + args.args
 

--- a/src/som/vm/VmSettings.java
+++ b/src/som/vm/VmSettings.java
@@ -42,6 +42,8 @@ public class VmSettings implements Settings {
 
   public static final String BASE_DIRECTORY;
 
+  public static final boolean USE_PINNING;
+
   static {
     String prop = System.getProperty("som.threads");
     if (prop == null) {
@@ -85,6 +87,8 @@ public class VmSettings implements Settings {
     RECYCLE_BUFFERS = getBool("som.bufferRecycling", true);
 
     BASE_DIRECTORY = System.getProperty("som.baseDir", System.getProperty("user.dir"));
+
+    USE_PINNING = getBool("som.usePinning", true);
   }
 
   private static boolean getBool(final String prop, final boolean defaultVal) {

--- a/src/tools/concurrency/TracingActivityThread.java
+++ b/src/tools/concurrency/TracingActivityThread.java
@@ -5,6 +5,9 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.oracle.truffle.api.TruffleOptions;
+
+import net.openhft.affinity.AffinityLock;
 import som.VM;
 import som.interpreter.SomLanguage;
 import som.interpreter.actors.Actor.ActorProcessingThread;
@@ -23,6 +26,8 @@ public abstract class TracingActivityThread extends ForkJoinWorkerThread {
 
   public static final AtomicInteger threadIdGen =
       (VmSettings.ACTOR_TRACING || VmSettings.KOMPOS_TRACING) ? new AtomicInteger(1) : null;
+
+  private Object /* AffinityLock */ affinity;
 
   protected final long threadId;
   protected long       nextEntityId;
@@ -180,6 +185,11 @@ public abstract class TracingActivityThread extends ForkJoinWorkerThread {
     if (VmSettings.ACTOR_TRACING || VmSettings.KOMPOS_TRACING) {
       TracingBackend.registerThread(this);
     }
+
+    if (!TruffleOptions.AOT && VmSettings.USE_PINNING) {
+      affinity = AffinityLock.acquireLock();
+    }
+
     vm.enterContext();
   }
 
@@ -192,6 +202,10 @@ public abstract class TracingActivityThread extends ForkJoinWorkerThread {
     }
     if (VmSettings.SNAPSHOTS_ENABLED) {
       SnapshotBackend.registerSnapshotBuffer(snapshotBuffer);
+    }
+
+    if (!TruffleOptions.AOT && VmSettings.USE_PINNING) {
+      ((AffinityLock) affinity).release();
     }
 
     vm.leaveContext();

--- a/src/tools/concurrency/TracingActivityThread.java
+++ b/src/tools/concurrency/TracingActivityThread.java
@@ -106,6 +106,7 @@ public abstract class TracingActivityThread extends ForkJoinWorkerThread {
     }
 
     setName(getClass().getSimpleName() + "-" + threadId);
+    setPriority(MAX_PRIORITY);
   }
 
   public abstract Activity getActivity();

--- a/src/tools/concurrency/TracingActivityThread.java
+++ b/src/tools/concurrency/TracingActivityThread.java
@@ -21,10 +21,12 @@ import tools.snapshot.SnapshotBuffer;
 public abstract class TracingActivityThread extends ForkJoinWorkerThread {
   private final VM vm;
 
-  public static AtomicInteger threadIdGen = new AtomicInteger(1);
-  protected final long        threadId;
-  protected long              nextEntityId;
-  protected byte              snapshotId;
+  public static final AtomicInteger threadIdGen =
+      (VmSettings.ACTOR_TRACING || VmSettings.KOMPOS_TRACING) ? new AtomicInteger(1) : null;
+
+  protected final long threadId;
+  protected long       nextEntityId;
+  protected byte       snapshotId;
 
   public static final int EXTERNAL_BUFFER_SIZE = 500;
 


### PR DESCRIPTION
This is hopefully a good idea in general.
We have fork/join pools sized so that each thread corresponds to a physical core, and we don't necessarily need them to wander around.
However, for instance actors are scheduled still on the fork/join pool and not bound to a thread.
So, they may still wander about.
Though, the benchmarks are not necessarily faster, just more predictable.


@daumayr this may have an impact for you in the future, and we may need to see whether this causes any regressions.
@sophie-kaleba I would recommend that we add this to the other SOMs as well, especially grSOM and TruffleSOM.

This makes quite a bit of difference in the amount of noise that benchmarks measure, I think.
Still need to do a proper analysis and write up, but I think it should make benchmarking more reliable.

### Note

This doesn't support the native image variant at the moment. For native-image support, it's likely easier to use the underlying system API directly.