### PR TITLE
Fix som launcher to use same setting as build.xml for finding libgraal

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -178,6 +178,7 @@
         <travis target="libgraal-jdk" start="Build LibGraal-enabled JDK" />
         <exec executable="${mx.cmd}" dir="${vm.dir}" failonerror="true">
             <env key="JAVA_HOME" value="${jvmci.home}" />
+            <!-- REM: This needs to match ./som -->
             <env key="DYNAMIC_IMPORTS" value="/substratevm,/tools,/truffle,/sdk,/compiler" />
             <env key="FORCE_BASH_LAUNCHERS" value="true" />
             <env key="DISABLE_LIBPOLYGLOT" value="true" />

--- a/som
+++ b/som
@@ -207,7 +207,17 @@ if not args.interpreter and not java_bin.startswith(BASE_DIR + '/libs/jvmci') an
 if args.use_libgraal:
   from subprocess import check_output, STDOUT, CalledProcessError
   try:
-    libgraal_jdk_home = check_output([BASE_DIR + '/libs/mx/mx', '--primary-suite-path', BASE_DIR + '/libs/truffle/vm', '--env', 'libgraal', 'graalvm-home'], stderr=STDOUT, env = {'JAVA_HOME': java_bin.replace('/bin/java', '')})
+    libgraal_jdk_home = check_output(
+      [BASE_DIR + '/libs/mx/mx', '--primary-suite-path', BASE_DIR + '/libs/truffle/vm', 'graalvm-home'],
+      stderr=STDOUT,
+      env = {
+        'JAVA_HOME':            java_bin.replace('/bin/java', ''),
+        # REM: This needs to match build.xml:libgraal-jdk
+        'DYNAMIC_IMPORTS':      '/substratevm,/tools,/truffle,/sdk,/compiler',
+        'FORCE_BASH_LAUNCHERS': 'true',
+        'DISABLE_LIBPOLYGLOT':  'true',
+        'EXCLUDE_COMPONENTS':   'svmag,nju,nic,ni,nil'
+      })
     java_bin = libgraal_jdk_home.strip() + '/bin/java'
   except CalledProcessError as e:
     print "Failed to determine location of libgraal"


### PR DESCRIPTION
Previously, `som` would not find the libgraal JDK because the one built did not have the same settings as the one searched for.

Any changes to these settings need to make sure that build.xml and som match up.