### PR TITLE
Report benchmark completion to ReBenchDB

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,7 @@ benchmark_savina_job:
   allow_failure: true
   script:
     - ant compile
-    - rebench --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-Savina
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-Savina
 
 benchmark_job:
   stage: benchmark
@@ -61,7 +61,7 @@ benchmark_job:
   allow_failure: true
   script:
     - ant compile
-    - rebench --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns
 
 benchmark_job_others:
   stage: benchmark
@@ -69,8 +69,9 @@ benchmark_job_others:
   allow_failure: true
   script:
     - ant compile
-    - rebench --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-concurrency-models
-    - rebench --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-interp
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-concurrency-models
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c codespeed.conf SOMns-interp
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --report-completion codespeed.conf
 
 benchmark_nightly_job:
   stage: benchmark

--- a/codespeed.conf
+++ b/codespeed.conf
@@ -7,7 +7,7 @@ reporting:
     # Benchmark results will be reported to ReBenchDB
     rebenchdb:
         # this url needs to point to the API endpoint
-        db_url: https://rebench.stefan-marr.de/rebenchdb/results
+        db_url: https://rebench.stefan-marr.de/rebenchdb
         repo_url: https://github.com/smarr/SOMns
         record_all: true # make sure everything is recorded
         project_name: SOMns


### PR DESCRIPTION
Enable reporting of results to ReBenchDB, which reports it to GitHub.