### PR TITLE
Fix Nondeterministic Corner Case in Receiver-Side Replay

### DIFF
--- a/src/som/interpreter/actors/ReceivedRootNode.java
+++ b/src/som/interpreter/actors/ReceivedRootNode.java
@@ -13,7 +13,6 @@ import som.interpreter.SArguments;
 import som.interpreter.SomLanguage;
 import som.interpreter.actors.EventualMessage.PromiseMessage;
 import som.interpreter.actors.SPromise.SResolver;
-import som.interpreter.actors.SPromise.STracingPromise;
 import som.vm.VmSettings;
 import tools.concurrency.KomposTrace;
 import tools.concurrency.TracingActors.TracingActor;
@@ -93,9 +92,7 @@ public abstract class ReceivedRootNode extends RootNode {
 
     if (VmSettings.RECEIVER_SIDE_TRACING) {
       if (msg instanceof PromiseMessage) {
-        PromiseMessage pmsg = (PromiseMessage) msg;
-        STracingPromise tprom = (STracingPromise) pmsg.getPromise();
-        promiseMessageTracer.record(tprom.getResolvingActor());
+        promiseMessageTracer.record(msg.messageId);
       }
       messageTracer.record(((TracingActor) msg.getSender()).getId());
     }

--- a/src/som/interpreter/actors/RegisterOnPromiseNode.java
+++ b/src/som/interpreter/actors/RegisterOnPromiseNode.java
@@ -11,6 +11,7 @@ import som.interpreter.actors.EventualMessage.PromiseMessage;
 import som.interpreter.actors.SPromise.SReplayPromise;
 import som.interpreter.actors.SPromise.STracingPromise;
 import som.vm.VmSettings;
+import tools.concurrency.TracingActors.TracingActor;
 import tools.dym.DynamicMetrics;
 import tools.replay.ReplayRecord;
 import tools.replay.TraceRecord;
@@ -72,6 +73,8 @@ public abstract class RegisterOnPromiseNode {
             ((SReplayPromise) promise).registerOnResolvedReplay(msg);
             return;
           }
+        } else if (VmSettings.RECEIVER_SIDE_TRACING || VmSettings.RECEIVER_SIDE_REPLAY) {
+          msg.messageId = ((TracingActor) current).getNextPromiseMsgNumber();
         }
 
         if (!promise.isResolvedUnsync()) {
@@ -154,6 +157,8 @@ public abstract class RegisterOnPromiseNode {
             ((SReplayPromise) promise).registerOnErrorReplay(msg);
             return;
           }
+        } else if (VmSettings.RECEIVER_SIDE_TRACING || VmSettings.RECEIVER_SIDE_REPLAY) {
+          msg.messageId = ((TracingActor) current).getNextPromiseMsgNumber();
         }
 
         if (!promise.isErroredUnsync()) {

--- a/src/tools/concurrency/TracingActors.java
+++ b/src/tools/concurrency/TracingActors.java
@@ -16,7 +16,6 @@ import som.VM;
 import som.interpreter.actors.Actor;
 import som.interpreter.actors.EventualMessage;
 import som.interpreter.actors.EventualMessage.PromiseMessage;
-import som.interpreter.actors.SPromise.STracingPromise;
 import som.vm.VmSettings;
 import tools.debugger.WebDebugger;
 import tools.replay.PassiveEntityWithEvents;
@@ -34,6 +33,7 @@ public class TracingActors {
     protected SnapshotRecord snapshotRecord;
     private int              traceBufferId;
     protected int            version;
+    private long             nextPMsgNumber;
 
     /**
      * Flag that indicates if a step-to-next-turn action has been made in the previous message.
@@ -141,6 +141,15 @@ public class TracingActors {
      */
     public DeserializationBuffer getDeserializationBuffer() {
       return null;
+    }
+
+    /**
+     * Only to be used by the thread executing this actor
+     *
+     * @return
+     */
+    public long getNextPromiseMsgNumber() {
+      return nextPMsgNumber++;
     }
   }
 
@@ -306,7 +315,7 @@ public class TracingActors {
 
       // handle promise messages
       if (msg instanceof PromiseMessage
-          && (((STracingPromise) ((PromiseMessage) msg).getPromise()).getResolvingActor() != expected.getResolver())) {
+          && msg.getMessageId() != expected.getMessageId()) {
         return false;
       }
 
@@ -517,7 +526,7 @@ public class TracingActors {
         return sender;
       }
 
-      public long getResolver() {
+      public long getMessageId() {
         return resolver;
       }
 


### PR DESCRIPTION
This pull request fixes a corner case in which the receiver-side rr is not able to capture and reproduce message orderings accurately.

The problem can occur when the following conditions are met:
- a message send (M1) to a resolved promise (P1) and a promise resolution (P2) race with each other
- the resolver of P1 is performing the resolution of P2
- the actor sending M1 also sent a message M2 that is stored in P2

Under the old replay, both messages would have the same sender/receiver promise message tuple in the trace. Hence we do not capture wether M1 or M2 is processed first.

The new solution sequentially numbers all promise messages sent by an actor, and records that number in place of the id of the resolver. replay executions automatically generate the same message numbers. In combination with the sender, this allows us to uniquely identify the promise messages and accurately reorder them.

Promise resolver tracking was removed from tracing promises. 
The messageId field from Kompos tracing was reused to store message numbers.

TODO: add a testcase, do thorough testing