### PR TITLE
Remove unused dependency and update Eclipse in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
           - os: ubuntu-20.04
             java: 11
             job: lint
-    
-    
+
+
     runs-on: ubuntu-20.04 # ubuntu-latest
     steps:
       - name: Checkout
@@ -36,7 +36,7 @@ jobs:
         run: |
           export JAVA_HOME=$JAVA_HOME_${{ matrix.java }}_X64
           ant -e jar unit-tests
-      
+
       - name: SOMns Test Suite
         if: matrix.job != 'lint'
         run: |
@@ -92,22 +92,22 @@ jobs:
         if: matrix.job == 'lint'
         run: |
           ant -e checkstyle
-  
+
       - name: Download Eclipse
         if: matrix.job == 'lint'
         run: |
            export ECLIPSE_TAR=eclipse.tar.gz
-           export ECLIPSE_URL=https://ftp.halifax.rwth-aachen.de/eclipse/eclipse/downloads/drops4/R-4.17-202009021800/eclipse-SDK-4.17-linux-gtk-x86_64.tar.gz
+           export ECLIPSE_URL=https://ftp.snt.utwente.nl/pub/software/eclipse/eclipse/downloads/drops4/R-4.19-202103031800/eclipse-SDK-4.19-linux-gtk-x86_64.tar.gz
            curl ${ECLIPSE_URL} -o ${ECLIPSE_TAR}
            tar -C ${GITHUB_WORKSPACE}/.. -xzf ${ECLIPSE_TAR}
-      
+
       - name: Check Eclipse Format
         if: matrix.job == 'lint'
         run: |
           export ECLIPSE_EXE=${GITHUB_WORKSPACE}/../eclipse/eclipse
           export JAVA_HOME=$JAVA_HOME_11_X64
           ant -e eclipseformat-check
-  
+
       - name: Lint Kompos
         if: matrix.job == 'lint'
         run: |

--- a/build.xml
+++ b/build.xml
@@ -100,7 +100,6 @@
         <pathelement location="${sdk.build}/polyglot-tck.jar" />
         <pathelement location="${lib.dir}/somns-deps-dev.jar" />
 
-        <pathelement location="${truffle.build}/truffle-debug.jar" />
         <pathelement location="${truffle.build}/truffle-dsl-processor.jar" />
         <pathelement location="${truffle.build}/truffle-tck.jar" />
     </path>

--- a/som
+++ b/som
@@ -232,7 +232,6 @@ if args.use_libgraal:
 
 CLASSPATH = (BASE_DIR + '/build/classes:'
            + BASE_DIR + '/libs/black-diamonds/build/classes:'
-           + TRUFFLE_DIR + '/truffle/mxbuild/dists/jdk1.8/truffle-debug.jar:'
            + BASE_DIR + '/libs/somns-deps.jar:'
            + BASE_DIR + '/libs/affinity.jar:'
            + BASE_DIR + '/libs/slf4j-api.jar:'


### PR DESCRIPTION
The truffle-debug.jar disappeared as it seems.
And the Eclipse version used in CI is not available on the mirror anymore. Updated it to the one used in TruffleSOM.