### PR TITLE
Remember object slot being allocated, and use onSpinWait to resolve old todo

### DIFF
--- a/src/som/vmobjects/SClass.java
+++ b/src/som/vmobjects/SClass.java
@@ -133,7 +133,7 @@ public final class SClass extends SObjectWithClass {
     // Class loading can take considerable time and might be problematic here.
     // But seems better than running into a stack overflow in other places.
     while (!layout.isValid()) {
-      // TODO(JDK9): add call to Thread.onSpinWait() once moving to JDK9 support
+      Thread.onSpinWait();
       layout = instanceClassGroup.getInstanceLayout();
     }
 


### PR DESCRIPTION
When waiting for a valid object layout in `getLayoutForInstancesToUpdateObject()`, we probably want to use `onSpinWait()`, which was introduced in JDK 9.

And after ensuring that the slot is available in `ClassSlotAccessNode`, we probably want to remember that, too.